### PR TITLE
Increase users fetch limit up to allowed maximum

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
         context: .
         target: dev
         dockerfile: Dockerfile
-    # command: /dlv debug /app/mcp/mcp-server.go --headless --listen=:40000 --api-version=2 --log -- --transport sse
+    # command: /dlv debug /app/cmd/slack-mcp-server/main.go --headless --listen=:40000 --api-version=2 --log -- --transport sse
     restart: unless-stopped
     networks:
       - app-tier

--- a/docker-compose.toolkit.yml
+++ b/docker-compose.toolkit.yml
@@ -5,7 +5,7 @@ services:
         target: production
         dockerfile: Dockerfile
     # Uncomment to have delve debug on port 40000
-    # command: /dlv debug /app/mcp/mcp-server.go --headless --listen=:40000 --api-version=2 --log -- --transport sse
+    # command: /dlv debug /app/cmd/slack-mcp-server/main.go --headless --listen=:40000 --api-version=2 --log -- --transport sse
     restart: unless-stopped
     networks:
       - app-tier

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -89,7 +89,11 @@ func (ap *ApiProvider) bootstrapDependencies(ctx context.Context) error {
 		}
 	}
 
-	users, err := ap.client.GetUsersContext(ctx)
+	optionLimit := slack.GetUsersOptionLimit(1000)
+
+	users, err := ap.client.GetUsersContext(ctx,
+		optionLimit,
+	)
 	if err != nil {
 		log.Printf("Failed to fetch users: %v", err)
 		return err


### PR DESCRIPTION
It turned out that on Workspaces like kubernetes the default fetch limit of `200` takes too long for provider to boot the users cache. As a first temporary measure the limit has been increased up to allowed maximum of `1000` per batch.

```
mcp-server-1  | 2025/04/26 16:44:33 SSE server listening on 0.0.0.0:3001
mcp-server-1  | 2025/04/26 16:44:33 Booting provider...
mcp-server-1  | 2025/04/26 16:44:33 Authenticated as: &{https://kubernetes.slack.com/ Kubernetes XXXXX T09NY5SBT UXXXXXXXXXXX  }
mcp-server-1  | 2025/04/26 16:54:26 Wrote 213801 users to cache ".users_cache.json"
mcp-server-1  | 2025/04/26 16:54:26 Provider booted successfully.
```

Now it took 10 minutes for provider to fetch all users from this community. 