### PR TITLE
more flexible params for channels_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Model Context Protocol (MCP) server for Slack Workspaces. This integration suppo
   - Required inputs:
     - `channel_types` (string): Comma-separated channel types. Allowed values: 'mpim', 'im', 'public_channel', 'private_channel'. Example: 'public_channel,private_channel,im'.
     - `sort` (string): Type of sorting. Allowed values: 'popularity' - sort by number of members/participants in each channel.
-    - `limit` (string, default: 100): Limit of channels to fetch.
+    - `limit` (number, default: 100): Limit of channels to fetch.
     - `cursor` (string): Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request.
   - Returns: List of channels
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Model Context Protocol (MCP) server for Slack Workspaces. This integration suppo
   - Required inputs:
     - `channel_types` (string): Comma-separated channel types. Allowed values: 'mpim', 'im', 'public_channel', 'private_channel'. Example: 'public_channel,private_channel,im'.
     - `sort` (string): Type of sorting. Allowed values: 'popularity' - sort by number of members/participants in each channel.
+    - `limit` (string, default: 100): Limit of channels to fetch.
+    - `cursor` (string): Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request.
   - Returns: List of channels
 
 ## Setup Guide

--- a/pkg/handler/channels.go
+++ b/pkg/handler/channels.go
@@ -22,7 +22,7 @@ type Channel struct {
 	Topic       string `json:"topic"`
 	Purpose     string `json:"purpose"`
 	MemberCount int    `json:"memberCount"`
-	Cursor   	string `json:"cursor"`
+	Cursor      string `json:"cursor"`
 }
 
 type ChannelsHandler struct {
@@ -76,10 +76,10 @@ func (ch *ChannelsHandler) ChannelsHandler(ctx context.Context, request mcp.Call
 		Types:           channelTypes,
 		Limit:           limit,
 		ExcludeArchived: true,
-		Cursor:			 cursor,
+		Cursor:          cursor,
 	}
 	var (
-		total int
+		total   int
 		nextcur string
 	)
 	for {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,6 +49,13 @@ func NewMCPServer(provider *provider.ApiProvider) *MCPServer {
 		mcp.WithString("sort",
 			mcp.Description("Type of sorting. Allowed values: 'popularity' - sort by number of members/participants in each channel."),
 		),
+		mcp.WithNumber("limit",
+			mcp.DefaultNumber(100),
+			mcp.Description("The maximum number of items to return. Must be an integer under 1000."),
+		),
+		mcp.WithString("cursor",
+			mcp.Description("Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request."),
+		),
 	), channelsHandler.ChannelsHandler)
 
 	return &MCPServer{


### PR DESCRIPTION
In real real-world setup, the channel list can be large and exceed the model context size limitation. Need to be able to break it down into batches.