### PR TITLE
feat: add SLACK_MCP_XOXP_TOKEN user OAuth authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ Token value is printed right after the executed command (it starts with
  - Press Ctrl+C or Cmd+C to copy it's value to clipboard.
  - Save it for later.
 
+#### Alternative: Using `SLACK_MCP_XOXP_TOKEN` (User OAuth)
+
+Instead of using browser-based tokens (XOXC/XOXD), you can use a User OAuth token:
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app
+2. Under "OAuth & Permissions", add the following scopes:
+   - `channels:history` - View messages in public channels
+   - `channels:read` - View basic information about public channels
+   - `groups:history` - View messages in private channels
+   - `groups:read` - View basic information about private channels
+   - `im:history` - View messages in direct messages
+   - `im:read` - View basic information about direct messages
+   - `mpim:history` - View messages in group direct messages
+   - `mpim:read` - View basic information about group direct messages
+   - `users:read` - View people in a workspace
+3. Install the app to your workspace
+4. Copy the "User OAuth Token" (starts with `xoxp-`)
+
+> **Note**: You only need **either** XOXP token **or** both XOXC/XOXD tokens. XOXP user tokens are recommended for production use as they're more secure and don't require browser session extraction.
+
 ### 2. Installation
 
 Choose one of these installation methods:
@@ -85,6 +105,28 @@ You can configure the MCP server using command line arguments and environment va
 If you have npm installed, this is the fastest way to get started with `slack-mcp-server` on Claude Desktop.
 
 Open your `claude_desktop_config.json` and add the mcp server to the list of `mcpServers`:
+
+**Option 1: Using XOXP Token (Recommended)**
+``` json
+{
+  "mcpServers": {
+    "slack": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "slack-mcp-server@latest",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "SLACK_MCP_XOXP_TOKEN": "xoxp-..."
+      }
+    }
+  }
+}
+```
+
+**Option 2: Using XOXC/XOXD Tokens**
 ``` json
 {
   "mcpServers": {
@@ -108,6 +150,32 @@ Open your `claude_desktop_config.json` and add the mcp server to the list of `mc
 <details>
 <summary>Or, stdio transport with docker.</summary>
 
+**Option 1: Using XOXP Token (Recommended)**
+```json
+{
+  "mcpServers": {
+    "slack": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "SLACK_MCP_XOXP_TOKEN",
+        "ghcr.io/korotovsky/slack-mcp-server",
+        "mcp-server",
+        "--transport",
+        "stdio"
+      ],
+      "env": {
+        "SLACK_MCP_XOXP_TOKEN": "xoxp-..."
+      }
+    }
+  }
+}
+```
+
+**Option 2: Using XOXC/XOXD Tokens**
 ```json
 {
   "mcpServers": {

--- a/cmd/slack-mcp-server/main.go
+++ b/cmd/slack-mcp-server/main.go
@@ -60,7 +60,7 @@ func newUsersWatcher(p *provider.ApiProvider) func() {
 	return func() {
 		log.Println("Caching users collection...")
 
-		if os.Getenv("SLACK_MCP_XOXC_TOKEN") == "demo" && os.Getenv("SLACK_MCP_XOXD_TOKEN") == "demo" {
+		if os.Getenv("SLACK_MCP_XOXP_TOKEN") == "demo" || (os.Getenv("SLACK_MCP_XOXC_TOKEN") == "demo" && os.Getenv("SLACK_MCP_XOXD_TOKEN") == "demo") {
 			log.Println("Demo credentials are set, skip.")
 			return
 		}
@@ -78,7 +78,7 @@ func newChannelsWatcher(p *provider.ApiProvider) func() {
 	return func() {
 		log.Println("Caching channels collection...")
 
-		if os.Getenv("SLACK_MCP_XOXC_TOKEN") == "demo" && os.Getenv("SLACK_MCP_XOXD_TOKEN") == "demo" {
+		if os.Getenv("SLACK_MCP_XOXP_TOKEN") == "demo" || (os.Getenv("SLACK_MCP_XOXC_TOKEN") == "demo" && os.Getenv("SLACK_MCP_XOXD_TOKEN") == "demo") {
 			log.Println("Demo credentials are set, skip.")
 			return
 		}


### PR DESCRIPTION
## Summary
- Add support for User OAuth tokens (xoxp-) as an alternative authentication method
- Maintain full backward compatibility with existing XOXC/XOXD session-based authentication  
- XOXP tokens take priority when both authentication methods are available
- Update demo mode detection to support both authentication methods

## Changes Made
- **pkg/provider/api.go**: Added `newWithXOXP()` and `newWithXOXC()` functions with fallback logic
- **cmd/slack-mcp-server/main.go**: Updated demo mode detection for both token types
- **README.md**: Added comprehensive User OAuth setup documentation and configuration examples
- **CLAUDE.md**: Updated environment variables documentation

## Benefits
- More secure authentication option that doesn't require browser session extraction
- Follows OAuth best practices with proper user tokens
- Zero breaking changes for existing users
- Clear migration path from session-based to OAuth authentication

## Test Plan
- [x] Code compiles successfully
- [x] Maintains backward compatibility with XOXC/XOXD tokens
- [x] XOXP token authentication works with standard OAuth flow
- [x] Demo mode works with both authentication methods
- [x] Documentation is comprehensive and accurate