### PR TITLE
Improved date parsing, adding tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,6 +1,8 @@
 name: Unit Tests
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,27 @@
+name: Unit Tests
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Download dependencies
+        run: make deps
+
+      - name: Run unit tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 .DEFAULT_GOAL := help
 
 TAG ?=
+GO=go
 PACKAGE = $(shell go list -m)
 GIT_COMMIT_HASH = $(shell git rev-parse HEAD)
 GIT_VERSION = $(shell git describe --tags --always --dirty)
@@ -48,7 +49,6 @@ clean: ## Clean up all build artifacts
 build: clean tidy format ## Build the project
 	go build $(COMMON_BUILD_ARGS) -o ./build/$(BINARY_NAME) ./cmd/slack-mcp-server
 
-
 .PHONY: build-all-platforms
 build-all-platforms: clean tidy format ## Build the project for all platforms
 	$(foreach os,$(OSES),$(foreach arch,$(ARCHS), \
@@ -92,17 +92,21 @@ npm-publish: npm-copy-binaries ## Publish the npm packages
 	jq '.optionalDependencies |= with_entries(.value = "$(NPM_VERSION)")' ./npm/slack-mcp-server/package.json > tmp.json && mv tmp.json ./npm/slack-mcp-server/package.json; \
 	cd npm/slack-mcp-server && npm publish
 
+.PHONY: deps
+deps: ## Download dependencies
+	$(GO) mod download
+
 .PHONY: test
 test: ## Run the tests
-	go test -count=1 -v ./...
+	$(GO) test -count=1 -v ./...
 
 .PHONY: format
 format: ## Format the code
-	go fmt ./...
+	$(GO) fmt ./...
 
 .PHONY: tidy
 tidy: ## Tidy up the go modules
-	go mod tidy
+	$(GO) mod tidy
 
 .PHONY: release
 release: ## Create release tag. Usage: make tag TAG=v1.2.3

--- a/cmd/slack-mcp-server/main.go
+++ b/cmd/slack-mcp-server/main.go
@@ -54,7 +54,7 @@ func main() {
 		}
 
 		sseServer := s.ServeSSE(":" + port)
-		log.Printf("SSE server listening on " + host + ":" + port)
+		log.Printf("SSE server listening on %s:%s", host, port)
 		if err := sseServer.Start(host + ":" + port); err != nil {
 			log.Fatalf("Server error: %v", err)
 		}

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -717,7 +717,6 @@ func parseFlexibleDate(dateStr string) (time.Time, string, error) {
 		}
 	}
 
-	// Try relative dates
 	lowerDateStr := strings.ToLower(dateStr)
 	now := time.Now().UTC()
 

--- a/pkg/handler/conversations_test.go
+++ b/pkg/handler/conversations_test.go
@@ -1,0 +1,332 @@
+package handler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseFlexibleDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantDate string
+		wantErr  bool
+	}{
+		// Standard formats (existing)
+		{
+			name:     "YYYY-MM-DD",
+			input:    "2025-07-15",
+			wantDate: "2025-07-15",
+			wantErr:  false,
+		},
+		{
+			name:     "YYYY/MM/DD",
+			input:    "2025/07/15",
+			wantDate: "2025-07-15",
+			wantErr:  false,
+		},
+
+		// New flexible month-year formats
+		{
+			name:     "Month Year - July 2025",
+			input:    "July 2025",
+			wantDate: "2025-07-01",
+			wantErr:  false,
+		},
+		{
+			name:     "Year Month - 2025 July",
+			input:    "2025 July",
+			wantDate: "2025-07-01",
+			wantErr:  false,
+		},
+		{
+			name:     "Abbreviated Month Year - Jul 2025",
+			input:    "Jul 2025",
+			wantDate: "2025-07-01",
+			wantErr:  false,
+		},
+		{
+			name:     "Year Abbreviated Month - 2025 Jul",
+			input:    "2025 Jul",
+			wantDate: "2025-07-01",
+			wantErr:  false,
+		},
+		{
+			name:     "Case insensitive - july 2025",
+			input:    "july 2025",
+			wantDate: "2025-07-01",
+			wantErr:  false,
+		},
+		{
+			name:     "Case insensitive - JULY 2025",
+			input:    "JULY 2025",
+			wantDate: "2025-07-01",
+			wantErr:  false,
+		},
+
+		// Day-Month-Year formats
+		{
+			name:     "1-July-2025",
+			input:    "1-July-2025",
+			wantDate: "2025-07-01",
+			wantErr:  false,
+		},
+		{
+			name:     "July-25-2025",
+			input:    "July-25-2025",
+			wantDate: "2025-07-25",
+			wantErr:  false,
+		},
+		{
+			name:     "July 10 2025",
+			input:    "July 10 2025",
+			wantDate: "2025-07-10",
+			wantErr:  false,
+		},
+		{
+			name:     "10 July 2025",
+			input:    "10 July 2025",
+			wantDate: "2025-07-10",
+			wantErr:  false,
+		},
+		{
+			name:     "31-December-2025",
+			input:    "31-December-2025",
+			wantDate: "2025-12-31",
+			wantErr:  false,
+		},
+		{
+			name:     "2025 July 10",
+			input:    "2025 July 10",
+			wantDate: "2025-07-10",
+			wantErr:  false,
+		},
+
+		// Various month names
+		{
+			name:     "January full name",
+			input:    "January 2025",
+			wantDate: "2025-01-01",
+			wantErr:  false,
+		},
+		{
+			name:     "February abbreviated",
+			input:    "Feb 2025",
+			wantDate: "2025-02-01",
+			wantErr:  false,
+		},
+		{
+			name:     "September with Sept abbreviation",
+			input:    "Sept 2025",
+			wantDate: "2025-09-01",
+			wantErr:  false,
+		},
+
+		// Relative dates
+		{
+			name:     "today",
+			input:    "today",
+			wantDate: time.Now().UTC().Format("2006-01-02"),
+			wantErr:  false,
+		},
+		{
+			name:     "yesterday",
+			input:    "yesterday",
+			wantDate: time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02"),
+			wantErr:  false,
+		},
+		{
+			name:     "Today with capital T",
+			input:    "Today",
+			wantDate: time.Now().UTC().Format("2006-01-02"),
+			wantErr:  false,
+		},
+		{
+			name:     "Yesterday with capital Y",
+			input:    "Yesterday",
+			wantDate: time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02"),
+			wantErr:  false,
+		},
+		{
+			name:     "TODAY all caps",
+			input:    "TODAY",
+			wantDate: time.Now().UTC().Format("2006-01-02"),
+			wantErr:  false,
+		},
+		{
+			name:     "YESTERDAY all caps",
+			input:    "YESTERDAY",
+			wantDate: time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02"),
+			wantErr:  false,
+		},
+		{
+			name:     "tomorrow",
+			input:    "tomorrow",
+			wantDate: time.Now().UTC().AddDate(0, 0, 1).Format("2006-01-02"),
+			wantErr:  false,
+		},
+		{
+			name:     "5 days ago",
+			input:    "5 days ago",
+			wantDate: time.Now().UTC().AddDate(0, 0, -5).Format("2006-01-02"),
+			wantErr:  false,
+		},
+		{
+			name:     "1 day ago",
+			input:    "1 day ago",
+			wantDate: time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02"),
+			wantErr:  false,
+		},
+
+		// Edge cases
+		{
+			name:     "Whitespace trimming",
+			input:    "  July 2025  ",
+			wantDate: "2025-07-01",
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid month name",
+			input:    "Jully 2025",
+			wantDate: "",
+			wantErr:  true,
+		},
+		{
+			name:     "Invalid date format",
+			input:    "2025-13-01",
+			wantDate: "",
+			wantErr:  true,
+		},
+		{
+			name:     "Invalid day for month",
+			input:    "31-February-2025",
+			wantDate: "",
+			wantErr:  true,
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			wantDate: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, gotDate, err := parseFlexibleDate(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseFlexibleDate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && gotDate != tt.wantDate {
+				t.Errorf("parseFlexibleDate() gotDate = %v, want %v", gotDate, tt.wantDate)
+			}
+		})
+	}
+}
+
+func TestBuildDateFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		before  string
+		after   string
+		on      string
+		during  string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "On with flexible format July 2025",
+			before:  "",
+			after:   "",
+			on:      "July 2025",
+			during:  "",
+			want:    map[string]string{"on": "2025-07-01"},
+			wantErr: false,
+		},
+		{
+			name:    "Before and After with flexible formats",
+			before:  "December 2025",
+			after:   "January 2025",
+			on:      "",
+			during:  "",
+			want:    map[string]string{"before": "2025-12-01", "after": "2025-01-01"},
+			wantErr: false,
+		},
+		{
+			name:    "During with day format",
+			before:  "",
+			after:   "",
+			on:      "",
+			during:  "15-July-2025",
+			want:    map[string]string{"during": "2025-07-15"},
+			wantErr: false,
+		},
+		{
+			name:    "Error: on with other filters",
+			before:  "2025-12-01",
+			after:   "",
+			on:      "July 2025",
+			during:  "",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Error: during with before",
+			before:  "2025-12-01",
+			after:   "",
+			on:      "",
+			during:  "July 2025",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Error: after date is after before date",
+			before:  "January 2025",
+			after:   "December 2025",
+			on:      "",
+			during:  "",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Valid: complex date formats",
+			before:  "31-December-2025",
+			after:   "1-January-2025",
+			on:      "",
+			during:  "",
+			want:    map[string]string{"before": "2025-12-31", "after": "2025-01-01"},
+			wantErr: false,
+		},
+		{
+			name:    "Error: invalid date format",
+			before:  "",
+			after:   "",
+			on:      "Jully 2025",
+			during:  "",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildDateFilters(tt.before, tt.after, tt.on, tt.during)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildDateFilters() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if len(got) != len(tt.want) {
+					t.Errorf("buildDateFilters() got map length = %v, want %v", len(got), len(tt.want))
+					return
+				}
+				for k, v := range tt.want {
+					if got[k] != v {
+						t.Errorf("buildDateFilters() got[%s] = %v, want %v", k, got[k], v)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -260,7 +260,7 @@ func (ap *ApiProvider) RefreshChannels(ctx context.Context) error {
 	if data, err := ioutil.ReadFile(ap.channelsCache); err == nil {
 		var cachedChannels []Channel
 		if err := json.Unmarshal(data, &cachedChannels); err != nil {
-			log.Printf("Failed to unmarshal %s: %v; will refetch", cachedChannels, err)
+			log.Printf("Failed to unmarshal %+v: %v; will refetch", cachedChannels, err)
 		} else {
 			for _, c := range cachedChannels {
 				ap.channels[c.ID] = c


### PR DESCRIPTION
Ref #49 

Standard Date Formats

- 2006-01-02 (YYYY-MM-DD)
- 2006/01/02 (YYYY/MM/DD)
- 01-02-2006 (MM-DD-YYYY)
- 01/02/2006 (MM/DD/YYYY)
- 02-01-2006 (DD-MM-YYYY)
- 02/01/2006 (DD/MM/YYYY)
- Jan 2, 2006
- January 2, 2006
- 2 Jan 2006
- 2 January 2006

Month-Year Formats (NEW)

- July 2025 → 2025-07-01
- 2025 July → 2025-07-01
- Jul 2025 → 2025-07-01
- 2025 Jul → 2025-07-01
- Any month name (full or abbreviated) + year
- Case-insensitive: july 2025, JULY 2025

Day-Month-Year Formats (NEW)

- 1-July-2025 → 2025-07-01
- July-25-2025 → 2025-07-25
- July 10 2025 → 2025-07-10
- 10 July 2025 → 2025-07-10
- 2025 July 10 → 2025-07-10
- 31-December-2025 → 2025-12-31

Supports both hyphens (-) and spaces as separators
Case-insensitive month names

Relative Dates

- today → current date
- yesterday → current date - 1 day
- tomorrow → current date + 1 day
- 5 days ago → current date - 5 days
- 1 day ago → current date - 1 day
- Case-insensitive: Today, TODAY, Yesterday, YESTERDAY