### PR TITLE
Fix: Redirect console logs to stderr for stdio transport compatibility

### DIFF
--- a/cmd/slack-mcp-server/main.go
+++ b/cmd/slack-mcp-server/main.go
@@ -25,7 +25,7 @@ func main() {
 	flag.StringVar(&transport, "transport", "stdio", "Transport type (stdio or sse)")
 	flag.Parse()
 
-	logger, err := newLogger()
+	logger, err := newLogger(transport)
 	if err != nil {
 		panic(err)
 	}
@@ -188,7 +188,7 @@ func validateToolConfig(config string) error {
 	return nil
 }
 
-func newLogger() (*zap.Logger, error) {
+func newLogger(transport string) (*zap.Logger, error) {
 	atomicLevel := zap.NewAtomicLevelAt(zap.InfoLevel)
 	if envLevel := os.Getenv("SLACK_MCP_LOG_LEVEL"); envLevel != "" {
 		if err := atomicLevel.UnmarshalText([]byte(envLevel)); err != nil {
@@ -199,6 +199,14 @@ func newLogger() (*zap.Logger, error) {
 	useJSON := shouldUseJSONFormat()
 	useColors := shouldUseColors() && !useJSON
 
+	// Determine output path based on transport type
+	// For stdio transport, use stderr to avoid JSON-RPC protocol conflicts
+	// For sse transport, use stdout to preserve existing behavior
+	outputPath := "stdout"
+	if transport == "stdio" {
+		outputPath = "stderr"
+	}
+
 	var config zap.Config
 
 	if useJSON {
@@ -206,7 +214,7 @@ func newLogger() (*zap.Logger, error) {
 			Level:            atomicLevel,
 			Development:      false,
 			Encoding:         "json",
-			OutputPaths:      []string{"stderr"},
+			OutputPaths:      []string{outputPath},
 			ErrorOutputPaths: []string{"stderr"},
 			EncoderConfig: zapcore.EncoderConfig{
 				TimeKey:       "timestamp",
@@ -224,7 +232,7 @@ func newLogger() (*zap.Logger, error) {
 			Level:            atomicLevel,
 			Development:      true,
 			Encoding:         "console",
-			OutputPaths:      []string{"stderr"},
+			OutputPaths:      []string{outputPath},
 			ErrorOutputPaths: []string{"stderr"},
 			EncoderConfig: zapcore.EncoderConfig{
 				TimeKey:          "timestamp",

--- a/cmd/slack-mcp-server/main.go
+++ b/cmd/slack-mcp-server/main.go
@@ -206,7 +206,7 @@ func newLogger() (*zap.Logger, error) {
 			Level:            atomicLevel,
 			Development:      false,
 			Encoding:         "json",
-			OutputPaths:      []string{"stdout"},
+			OutputPaths:      []string{"stderr"},
 			ErrorOutputPaths: []string{"stderr"},
 			EncoderConfig: zapcore.EncoderConfig{
 				TimeKey:       "timestamp",
@@ -224,7 +224,7 @@ func newLogger() (*zap.Logger, error) {
 			Level:            atomicLevel,
 			Development:      true,
 			Encoding:         "console",
-			OutputPaths:      []string{"stdout"},
+			OutputPaths:      []string{"stderr"},
 			ErrorOutputPaths: []string{"stderr"},
 			EncoderConfig: zapcore.EncoderConfig{
 				TimeKey:          "timestamp",

--- a/cmd/slack-mcp-server/main.go
+++ b/cmd/slack-mcp-server/main.go
@@ -199,9 +199,6 @@ func newLogger(transport string) (*zap.Logger, error) {
 	useJSON := shouldUseJSONFormat()
 	useColors := shouldUseColors() && !useJSON
 
-	// Determine output path based on transport type
-	// For stdio transport, use stderr to avoid JSON-RPC protocol conflicts
-	// For sse transport, use stdout to preserve existing behavior
 	outputPath := "stdout"
 	if transport == "stdio" {
 		outputPath = "stderr"


### PR DESCRIPTION
The server was outputting structured JSON logs to stdout when using stdio transport, breaking JSON-RPC 2.0 protocol compliance with MCP clients like Claude Code.

Root cause: zap logger configured with OutputPaths: ["stdout"] was sending all diagnostic logs to stdout, interfering with JSON-RPC messages that MCP clients expect exclusively on stdout.

Solution: Redirect all console logs to stderr while preserving stdout exclusively for JSON-RPC protocol communication.

Fixes compatibility with all MCP clients using stdio transport including Claude Code CLI, MCP Inspector, and other implementations.