### PR TITLE
Update Docker install docs

### DIFF
--- a/docs/03-configuration-and-usage.md
+++ b/docs/03-configuration-and-usage.md
@@ -223,6 +223,7 @@ Or, the docker-compose way:
 wget -O docker-compose.yml https://github.com/korotovsky/slack-mcp-server/releases/latest/download/docker-compose.yml
 wget -O .env https://github.com/korotovsky/slack-mcp-server/releases/latest/download/default.env.dist
 nano .env # Edit .env file with your tokens from step 1 of the setup guide
+docker network create app-tier
 docker-compose up -d
 ```
 


### PR DESCRIPTION
### Problem

When trying to install using `docker-compose`:
```
% docker-compose up -d
[+] Running 5/5
 ✔ mcp-server 4 layers [⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                    2.7s 
   ✔ 6e174226ea69 Pull complete                                                                                                                         0.7s 
   ✔ 31bbabbb202b Pull complete                                                                                                                         0.9s 
   ✔ 630ab7035b4d Pull complete                                                                                                                         0.9s 
   ✔ 280e0d4d42aa Pull complete                                                                                                                         1.3s 
[+] Building 0.0s (0/0)                                                                                                                 docker:desktop-linux
Error response from daemon: network app-tier not found
```

It is assumed that the docker network `app-tier` already exists but install documentation doesn't reflect that.

To make it right, we should run `docker network create app-tier` before attempting to spin up docker-compose
If the network already exists, it would simply return an error message.