### PR TITLE
Fix newline preservation in text processing

### DIFF
--- a/pkg/text/text_processor.go
+++ b/pkg/text/text_processor.go
@@ -275,7 +275,7 @@ func filterSpecialChars(text string) string {
 		cleaned = strings.Replace(cleaned, placeholder, url, 1)
 	}
 
-	spaceRegex := regexp.MustCompile(`\s+`)
+	spaceRegex := regexp.MustCompile(`[ \t]+`)
 	cleaned = spaceRegex.ReplaceAllString(cleaned, " ")
 
 	return strings.TrimSpace(cleaned)


### PR DESCRIPTION
Hello!

Text processing was removing all newlines, causing multi-line messages to become unreadable. With this fix we'll keep newlines and still remove other whitespace characters