### PR TITLE
fix pagination

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -334,8 +334,8 @@ func (ch *ConversationsHandler) ConversationsSearchHandler(ctx context.Context, 
 	ch.logger.Debug("Search completed", zap.Int("matches", len(messagesRes.Matches)))
 
 	messages := ch.convertMessagesFromSearch(messagesRes.Matches)
-	if len(messages) > 0 && ((messagesRes.Pagination.PerPage * messagesRes.Pagination.PageCount) < messagesRes.Pagination.TotalCount) {
-		nextCursor := fmt.Sprintf("page:%d", messagesRes.Pagination.PageCount+1)
+	if len(messages) > 0 && messagesRes.Pagination.Page < messagesRes.Pagination.PageCount {
+		nextCursor := fmt.Sprintf("page:%d", messagesRes.Pagination.Page+1)
 		messages[len(messages)-1].Cursor = base64.StdEncoding.EncodeToString([]byte(nextCursor))
 	}
 	return marshalMessagesToCSV(messages)


### PR DESCRIPTION

## Bug Fix: Search Messages Pagination Cursor Not Returned

### Problem
The `conversations_search_messages` tool was not returning pagination cursors even when more results were available, making it impossible to paginate through search results.

### Root Cause
The condition for determining whether to return a pagination cursor was incorrectly calculating whether more pages exist:

```go
// BEFORE (incorrect)
if len(messages) > 0 && ((messagesRes.Pagination.PerPage * messagesRes.Pagination.PageCount) < messagesRes.Pagination.TotalCount) {
    nextCursor := fmt.Sprintf("page:%d", messagesRes.Pagination.PageCount+1)
    messages[len(messages)-1].Cursor = base64.StdEncoding.EncodeToString([]byte(nextCursor))
}
```

**Example that demonstrates the bug:**
When searching with `limit=1` and there are 25,406 total results:
- `PerPage = 1`
- `PageCount = 25,406` (total number of pages)
- `TotalCount = 25,406` (total results)
- Condition: `(1 * 25,406) < 25,406` = `25,406 < 25,406` = **false** ❌
- Result: No cursor returned despite being on page 1 of 25,406 pages!

The logic was multiplying `PerPage` by `PageCount` (total pages), which equals `TotalCount`, so the condition would only be true in edge cases.

### Solution
Fixed the condition to properly check if the current page is less than the total page count:

```go
// AFTER (correct)
if len(messages) > 0 && messagesRes.Pagination.Page < messagesRes.Pagination.PageCount {
    nextCursor := fmt.Sprintf("page:%d", messagesRes.Pagination.Page+1)
    messages[len(messages)-1].Cursor = base64.StdEncoding.EncodeToString([]byte(nextCursor))
}
```

**Now with the same example:**
- `Page = 1` (current page)
- `PageCount = 25,406` (total pages)
- Condition: `1 < 25,406` = **true** ✓
- Result: Cursor correctly returned as `page:2` (base64 encoded)

### Changes
- **File:** `pkg/handler/conversations.go`
- **Line:** 337
- Changed pagination logic to compare current page against total page count
- Also updated next cursor calculation to use `Page+1` instead of `PageCount+1`

### Testing
- ✅ Compiles successfully
- ✅ Existing tests pass
- Manual testing shows cursor is now correctly returned for paginated search results

### Impact
Users can now properly paginate through search results using the returned cursor values, enabling complete traversal of large search result sets.
