### PR TITLE
Fix filter by private channel id, and private channel name

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -713,13 +713,14 @@ func (ch *ConversationsHandler) paramFormatChannel(raw string) (string, error) {
 	cms := ch.apiProvider.ProvideChannelsMaps()
 	if strings.HasPrefix(raw, "#") {
 		if id, ok := cms.ChannelsInv[raw]; ok {
-			return "#" + cms.Channels[id].Name, nil
+			return cms.Channels[id].Name, nil
 		}
 		return "", fmt.Errorf("channel %q not found", raw)
 	}
-	if strings.HasPrefix(raw, "C") {
+	// Handle both C (standard channels) and G (private groups/channels) prefixes
+	if strings.HasPrefix(raw, "C") || strings.HasPrefix(raw, "G") {
 		if chn, ok := cms.Channels[raw]; ok {
-			return "#" + chn.Name, nil
+			return chn.Name, nil
 		}
 		return "", fmt.Errorf("channel %q not found", raw)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -99,7 +99,7 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 			mcp.Description("Search query to filter messages. Example: 'marketing report' or full URL of Slack message e.g. 'https://slack.com/archives/C1234567890/p1234567890123456', then the tool will return a single message matching given URL, herewith all other parameters will be ignored."),
 		),
 		mcp.WithString("filter_in_channel",
-			mcp.Description("Filter messages in a specific channel by its ID or name. Example: 'C1234567890' or '#general'. If not provided, all channels will be searched."),
+			mcp.Description("Filter messages in a specific public/private channel by its ID or name. Example: 'C1234567890', 'G1234567890', or '#general'. If not provided, all channels will be searched."),
 		),
 		mcp.WithString("filter_in_im_or_mpim",
 			mcp.Description("Filter messages in a direct message (DM) or multi-person direct message (MPIM) conversation by its ID or name. Example: 'D1234567890' or '@username_dm'. If not provided, all DMs and MPIMs will be searched."),


### PR DESCRIPTION
Note: Please check against newer Slack API Specs. This is how my company's slack api returns. 


## Fix: Remove duplicate `#` in channel search filter, and parsing error when searching by private channel id

### Problem
When using the `conversations_search_messages` tool with the `filter_in_channel` parameter, providing a channel name with a `#` prefix (e.g., `#general`) resulted in a malformed Slack search query with a double hash: `in:##general`, causing zero search results.

**Example of broken request:**
```json
{
  "filter_in_channel": "#general",
  "search_query": "meeting"
}
```

**Resulted in invalid Slack query:**
```
"meeting in:##general"
```

### Root Cause
The `paramFormatChannel` function was returning the channel name with a `#` prefix, which was then concatenated with the `in:` filter by `buildQuery`, resulting in `in:#channel-name`. However, when the user already provided the `#` in their input, this created a double `##`.

### Solution
- Modified `paramFormatChannel` to return the channel name **without** the `#` prefix
- The `buildQuery` function then correctly formats it as `in:channel-name` 
- Added support for `G` prefix (private groups/channels) in addition to existing `C` prefix (standard channels)

**Now correctly generates:**
```
"meeting in:general"
```

### Changes
- Updated `paramFormatChannel()` to strip `#` from return value
- Added support for both `C` and `G` channel ID prefixes
- Simplified comment to clarify the function's behavior

### Testing
- ✅ Builds successfully
- ✅ Handles `#channel-name` format
- ✅ Handles `C123456789` channel ID format  
- ✅ Handles `G123456789` private group ID format
