### PR TITLE
Updating the ConversationsMessageAddHandler to have optional attachments

### DIFF
--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -66,6 +66,12 @@ type SlackAPI interface {
 	// Used to get channels list from both Slack and Enterprise Grid versions
 	GetConversationsContext(ctx context.Context, params *slack.GetConversationsParameters) ([]slack.Channel, string, error)
 
+	// Used to upload files
+	UploadFileV2Context(ctx context.Context, params slack.UploadFileV2Parameters) (*slack.FileSummary, error)
+
+	// Used to open/create DM channels
+	OpenConversationContext(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
+
 	// Edge API methods
 	ClientUserBoot(ctx context.Context) (*edge.ClientUserBootResponse, error)
 }
@@ -254,6 +260,14 @@ func (c *MCPSlackClient) SearchContext(ctx context.Context, query string, params
 
 func (c *MCPSlackClient) PostMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error) {
 	return c.slackClient.PostMessageContext(ctx, channelID, options...)
+}
+
+func (c *MCPSlackClient) UploadFileV2Context(ctx context.Context, params slack.UploadFileV2Parameters) (*slack.FileSummary, error) {
+	return c.slackClient.UploadFileV2Context(ctx, params)
+}
+
+func (c *MCPSlackClient) OpenConversationContext(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+	return c.slackClient.OpenConversationContext(ctx, params)
 }
 
 func (c *MCPSlackClient) ClientUserBoot(ctx context.Context) (*edge.ClientUserBootResponse, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -76,7 +76,7 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 	), conversationsHandler.ConversationsRepliesHandler)
 
 	s.AddTool(mcp.NewTool("conversations_add_message",
-		mcp.WithDescription("Add a message to a public channel, private channel, or direct message (DM, or IM) conversation by channel_id and thread_ts."),
+		mcp.WithDescription("Add a message to a public channel, private channel, or direct message (DM, or IM) conversation by channel_id and thread_ts. Optionally attach a file by providing an attachment_url."),
 		mcp.WithString("channel_id",
 			mcp.Required(),
 			mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
@@ -90,6 +90,12 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 		mcp.WithString("content_type",
 			mcp.DefaultString("text/markdown"),
 			mcp.Description("Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'."),
+		),
+		mcp.WithString("attachment_url",
+			mcp.Description("Optional file path or URL to attach to the message. Supports local file paths (e.g., '/path/to/file.pdf'), file:// URLs, or HTTP/HTTPS URLs. The file will be uploaded to Slack. Example: '/Users/me/report.pdf' or 'https://example.com/file.pdf'"),
+		),
+		mcp.WithString("attachment_name",
+			mcp.Description("Optional custom filename for the attachment. If not provided, the filename will be extracted from the attachment_url. Example: 'report.pdf'"),
 		),
 	), conversationsHandler.ConversationsAddMessageHandler)
 


### PR DESCRIPTION
# Overview

For the purposes of [a demo video](https://x.com/chongzluong/status/1983220353813107052) that utilizes Slack MCP and [Cartesia MCP](https://github.com/cartesia-ai/cartesia-mcp/tree/main), I needed to be able to attach files to messages through MCP, so I made the following changes:

## Slack API

- Added [File Upload](https://docs.slack.dev/reference/methods/files.upload/#markdown)
- Added [Open Conversation](https://docs.slack.dev/reference/methods/conversations.open/)

## MCP

- Updated the `addMessageParams` to include a potential `attachmentURL` and `attachmentName`
  - (Optional) `attachmentURL` can be a local file or publicly accessible file URL. The file at this URL will be downloaded in and used as the body for the file upload API
  - (Optional) `attachmentName` the name to use for the uploaded file
- Updated the `ConversationsAddMessageHandler` to incorporate a file attachment path
  - If an `attachment_url` is specified, we interpret local vs remote files , download, and then call the Slack API for uploading files (with an optional initial comment + thread timestamp)
  - If no `attachment_url` is specified, the previous behavior of calling the Slack API to post a message works as it did before

# Testing

The tweet linked above exhibits the functionality in action.
1. I ran `make build` to build the binary
2. I pointed the Claude Desktop config to the binary with the `--transport stdio` arguments and the relevant Slack tokens
3. I ran Cartesia's MCP
4. I had it generate me a script, TTS'd the script into an audio file using Cartesia's MCP, and then sent it to myself afterwards directly over slack. Screenshot below:

<img width="532" height="415" alt="Screenshot 2025-10-28 at 10 24 38 PM" src="https://github.com/user-attachments/assets/0729a41f-c8e4-40bc-93e3-5cabca438180" />