### PR TITLE
docs: clarify DM channel IDs and user mention formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,42 @@ Add a message to a public channel, private channel, or direct message (DM, or IM
 > **Note:** Posting messages is disabled by default for safety. To enable, set the `SLACK_MCP_ADD_MESSAGE_TOOL` environment variable. If set to a comma-separated list of channel IDs, posting is enabled only for those specific channels. See the Environment Variables section below for details.
 
 - **Parameters:**
-  - `channel_id` (string, required): ID of the channel in format `Cxxxxxxxxxx` or its name starting with `#...` or `@...` aka `#general` or `@username_dm`.
-  - `thread_ts` (string, optional): Unique identifier of either a thread’s parent message or a message in the thread_ts must be the timestamp in format `1234567890.123456` of an existing message with 0 or more replies. Optional, if not provided the message will be added to the channel itself, otherwise it will be added to the thread.
+  - `channel_id` (string, required): ID of the channel in format `Cxxxxxxxxxx` or its name starting with `#...` for public/private channels (e.g., `#general`). **For DMs, you must use the DM channel ID starting with `D` (e.g., `D1234567890`) - the `@username` format does not work for sending messages to DMs.**
+  - `thread_ts` (string, optional): Unique identifier of either a thread's parent message or a message in the thread_ts must be the timestamp in format `1234567890.123456` of an existing message with 0 or more replies. Optional, if not provided the message will be added to the channel itself, otherwise it will be added to the thread.
   - `payload` (string, required): Message payload in specified content_type format. Example: 'Hello, world!' for text/plain or '# Hello, world!' for text/markdown.
   - `content_type` (string, default: "text/markdown"): Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'.
+
+#### Working with DMs and User Mentions
+
+**Finding DM Channel IDs:**
+
+To send a message to a DM, you need the DM channel ID (starts with `D`). You can find it by:
+1. Using `channels_list` with `channel_types: "im"` to list all DM channels
+2. Using `conversations_search_messages` to find recent messages from the user - the Channel field will show the DM channel ID
+
+**Mentioning Users in Messages:**
+
+To mention/tag a user in your message, use the format `<@USER_ID>` in your payload:
+```json
+{
+  "channel_id": "C1234567890",
+  "payload": "Hey <@U1234567890>, can you review this?",
+  "content_type": "text/plain"
+}
+```
+
+You can find user IDs by:
+1. Using the `slack:///users` resource to get a CSV of all users with their IDs
+2. Using `conversations_search_messages` to find messages from a user - the UserID field will show their ID
+
+**Example: Sending a DM with a mention:**
+```json
+{
+  "channel_id": "D1234567890",
+  "payload": "Hi <@U0987654321>, this is a direct message!",
+  "content_type": "text/plain"
+}
+```
 
 ### 4. conversations_search_messages
 Search messages in a public channel, private channel, or direct message (DM, or IM) conversation using filters. All filters are optional, if not provided then search_query is required.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add a message to a public channel, private channel, or direct message (DM, or IM
 **Finding DM Channel IDs:**
 
 To send a message to a DM, you need the DM channel ID (starts with `D`). You can find it by:
-1. Using `channels_list` with `channel_types: "im"` to list all DM channels
+1. Using `channels_list` with `channel_types: "im"` to list all DM channels - the output includes `userId` and `userName` fields to identify who each DM is with
 2. Using `conversations_search_messages` to find recent messages from the user - the Channel field will show the DM channel ID
 
 **Mentioning Users in Messages:**
@@ -113,6 +113,11 @@ Get list of channels
   - `sort` (string, optional): Type of sorting. Allowed values: `popularity` - sort by number of members/participants in each channel.
   - `limit` (number, default: 100): The maximum number of items to return. Must be an integer between 1 and 1000 (maximum 999).
   - `cursor` (string, optional): Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request.
+
+- **Output Fields:**
+  - For all channels: `id`, `name`, `topic`, `purpose`, `memberCount`
+  - For IM (direct message) channels: `userId` (the other user's ID), `userName` (the other user's display name)
+  - For MPIM (group DM) channels: `members` (comma-separated user IDs), `memberNames` (comma-separated display names)
 
 ## Resources
 


### PR DESCRIPTION
This PR includes two improvements to DM and group DM support:

1. **Documentation**: Clarifies that DM messages require channel IDs starting with D (not @username format) and documents how to mention users with <@USER_ID> format. Includes examples for finding DM channel IDs and user IDs.

2. **Feature**: Adds userId, userName, members, and memberNames fields to the channels_list CSV output for IM and MPIM channels, making it easy to identify which user(s) each DM/group DM is with. This resolves the issue where DM channels were listed without any indication of who they were with.