### PR TITLE
Add get_permalink tool to generate Slack message URLs

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -135,6 +135,18 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 		),
 	), conversationsHandler.ConversationsSearchHandler)
 
+	s.AddTool(mcp.NewTool("get_permalink",
+		mcp.WithDescription("Get the Slack permalink URL for a specific message"),
+		mcp.WithString("channel_id",
+			mcp.Required(),
+			mcp.Description("ID of the channel. Example: 'C1234567890' for channels, 'D1234567890' for DMs."),
+		),
+		mcp.WithString("message_ts",
+			mcp.Required(),
+			mcp.Description("Message timestamp in format 1234567890.123456. This is the unique identifier for the message."),
+		),
+	), conversationsHandler.GetPermalinkHandler)
+
 	channelsHandler := handler.NewChannelsHandler(provider, logger)
 
 	s.AddTool(mcp.NewTool("channels_list",

--- a/pkg/text/text_processor.go
+++ b/pkg/text/text_processor.go
@@ -173,6 +173,14 @@ func TimestampToIsoRFC3339(slackTS string) (string, error) {
 	return t.UTC().Format(time.RFC3339), nil
 }
 
+func FormatPermalinkTimestamp(slackTS string) (string, error) {
+	parts := strings.Split(slackTS, ".")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid slack timestamp format: %s", slackTS)
+	}
+	return parts[0] + parts[1], nil
+}
+
 func ProcessText(s string) string {
 	s = filterSpecialChars(s)
 


### PR DESCRIPTION
## Summary
Implements a new MCP tool `get_permalink` that constructs Slack permalinks from channel IDs and message timestamps. This addresses feature request #100.

## Motivation
As requested in #100 by @cmarken, this enables users to include permalink sources when summarizing Slack conversations. This is particularly valuable for daily standup summaries, citations, and quick navigation back to important messages.

## Changes
- **Added** `FormatPermalinkTimestamp()` helper function in `pkg/text/text_processor.go` to convert Slack timestamp format (`1234567890.123456`) to permalink format (`1234567890123456`)
- **Added** `GetPermalinkHandler()` method in `pkg/handler/conversations.go` that:
  - Accepts `channel_id` and `message_ts` parameters
  - Retrieves workspace name via `Slack().AuthTest()`
  - Constructs and returns the permalink URL
- **Added** `parseParamsToolGetPermalink()` validation method
- **Registered** the new tool in `pkg/server/server.go` with proper parameter descriptions

## Usage Example
```go
get_permalink({
  channel_id: "C1234567890",  // or D1234567890 for DMs
  message_ts: "1234567890.123456"
})
```

Returns:
```
https://{workspace}.slack.com/archives/C1234567890/p1234567890123456
```

## Testing
Tested locally with real Slack workspace messages. The tool successfully:
- Extracts workspace name from auth response
- Formats timestamps correctly
- Generates valid, clickable Slack permalinks

## Related Issues
Closes #100

cc @cmarken @Brandfirst @freddyhaddad