### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,6 +35,8 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 
 	s.AddTool(mcp.NewTool("conversations_history",
 		mcp.WithDescription("Get messages from the channel (or DM) by channel_id, the last row/column in the response is used as 'cursor' parameter for pagination if not empty"),
+		mcp.WithTitleAnnotation("Get Conversation History"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("channel_id",
 			mcp.Required(),
 			mcp.Description("    - `channel_id` (string): ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
@@ -54,6 +56,8 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 
 	s.AddTool(mcp.NewTool("conversations_replies",
 		mcp.WithDescription("Get a thread of messages posted to a conversation by channelID and thread_ts, the last row/column in the response is used as 'cursor' parameter for pagination if not empty"),
+		mcp.WithTitleAnnotation("Get Thread Replies"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("channel_id",
 			mcp.Required(),
 			mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
@@ -77,6 +81,8 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 
 	s.AddTool(mcp.NewTool("conversations_add_message",
 		mcp.WithDescription("Add a message to a public channel, private channel, or direct message (DM, or IM) conversation by channel_id and thread_ts."),
+		mcp.WithTitleAnnotation("Send Message"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("channel_id",
 			mcp.Required(),
 			mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
@@ -95,6 +101,8 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 
 	conversationsSearchTool := mcp.NewTool("conversations_search_messages",
 		mcp.WithDescription("Search messages in a public channel, private channel, or direct message (DM, or IM) conversation using filters. All filters are optional, if not provided then search_query is required."),
+		mcp.WithTitleAnnotation("Search Messages"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("search_query",
 			mcp.Description("Search query to filter messages. Example: 'marketing report' or full URL of Slack message e.g. 'https://slack.com/archives/C1234567890/p1234567890123456', then the tool will return a single message matching given URL, herewith all other parameters will be ignored."),
 		),
@@ -143,6 +151,8 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 
 	s.AddTool(mcp.NewTool("channels_list",
 		mcp.WithDescription("Get list of channels"),
+		mcp.WithTitleAnnotation("List Channels"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("channel_types",
 			mcp.Required(),
 			mcp.Description("Comma-separated channel types. Allowed values: 'mpim', 'im', 'public_channel', 'private_channel'. Example: 'public_channel,private_channel,im'"),


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `readOnlyHint: true` to read-only tools:
  - `conversations_history` - Get Conversation History
  - `conversations_replies` - Get Thread Replies
  - `conversations_search_messages` - Search Messages
  - `channels_list` - List Channels
- Added `destructiveHint: true` to `conversations_add_message` (Send Message)
- Added human-readable `title` annotations to all tools

## Why This Matters

Tool annotations provide semantic metadata that helps LLMs understand tool behavior beyond just the description:
- **readOnlyHint**: Tells LLMs the tool is safe to call without side effects
- **destructiveHint**: Signals that the tool modifies data (posts messages)
- **title**: Provides a human-readable name for better UX

This enables:
- Safer tool execution by distinguishing read-only from write operations
- Better tool prioritization (read-only tools can be used freely for information gathering)
- Improved user experience in MCP clients that display tool metadata

## Before/After

**Before:**
```go
s.AddTool(mcp.NewTool("conversations_history",
    mcp.WithDescription("Get messages from the channel..."),
    // No annotations
), handler)
```

**After:**
```go
s.AddTool(mcp.NewTool("conversations_history",
    mcp.WithDescription("Get messages from the channel..."),
    mcp.WithTitleAnnotation("Get Conversation History"),
    mcp.WithReadOnlyHintAnnotation(true),
), handler)
```

## Testing

The changes use the existing `mcp-go` v0.40.0 annotation API:
- `mcp.WithTitleAnnotation(string)` 
- `mcp.WithReadOnlyHintAnnotation(bool)`
- `mcp.WithDestructiveHintAnnotation(bool)`

These are standard functions from `github.com/mark3labs/mcp-go/mcp` that are already imported.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>