### PR TITLE
feat: add Slack Lists API support

### DIFF
--- a/pkg/handler/lists.go
+++ b/pkg/handler/lists.go
@@ -1,0 +1,323 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gocarina/gocsv"
+	"github.com/korotovsky/slack-mcp-server/pkg/provider"
+	"github.com/korotovsky/slack-mcp-server/pkg/provider/edge"
+	"github.com/mark3labs/mcp-go/mcp"
+	"go.uber.org/zap"
+)
+
+type ListItemCSV struct {
+	ID        string `json:"id" csv:"ID"`
+	ListID    string `json:"list_id" csv:"ListID"`
+	CreatedBy string `json:"created_by" csv:"CreatedBy"`
+	UpdatedBy string `json:"updated_by" csv:"UpdatedBy"`
+	Archived  bool   `json:"archived" csv:"Archived"`
+	ParentID  string `json:"parent_id" csv:"ParentID"`
+	Fields    string `json:"fields" csv:"Fields"`
+	Cursor    string `json:"cursor" csv:"Cursor"`
+}
+
+type ListsHandler struct {
+	apiProvider *provider.ApiProvider
+	logger      *zap.Logger
+}
+
+func NewListsHandler(apiProvider *provider.ApiProvider, logger *zap.Logger) *ListsHandler {
+	return &ListsHandler{
+		apiProvider: apiProvider,
+		logger:      logger,
+	}
+}
+
+func (lh *ListsHandler) ListsItemsListHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	lh.logger.Debug("ListsItemsListHandler called")
+
+	if ready, err := lh.apiProvider.IsReady(); !ready {
+		lh.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	listID := request.GetString("list_id", "")
+	if listID == "" {
+		lh.logger.Error("list_id is required")
+		return nil, fmt.Errorf("list_id is required")
+	}
+
+	limit := request.GetInt("limit", 100)
+	cursor := request.GetString("cursor", "")
+	archived := request.GetBool("archived", false)
+
+	lh.logger.Debug("Request parameters",
+		zap.String("list_id", listID),
+		zap.Int("limit", limit),
+		zap.String("cursor", cursor),
+		zap.Bool("archived", archived),
+	)
+
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		lh.logger.Warn("Limit exceeds maximum, capping to 1000", zap.Int("requested", limit))
+		limit = 1000
+	}
+
+	resp, err := lh.apiProvider.Slack().ListsItemsList(ctx, listID, limit, cursor, archived)
+	if err != nil {
+		lh.logger.Error("Failed to list items", zap.Error(err))
+		return nil, err
+	}
+
+	var itemList []ListItemCSV
+	for _, item := range resp.Items {
+		fieldsJSON, err := json.Marshal(item.Fields)
+		if err != nil {
+			fieldsJSON = []byte("[]")
+		}
+
+		itemList = append(itemList, ListItemCSV{
+			ID:        item.ID,
+			ListID:    item.ListID,
+			CreatedBy: item.CreatedBy,
+			UpdatedBy: item.UpdatedBy,
+			Archived:  item.Archived,
+			ParentID:  item.ParentID,
+			Fields:    string(fieldsJSON),
+		})
+	}
+
+	if len(itemList) > 0 && resp.ResponseMetadata.NextCursor != "" {
+		itemList[len(itemList)-1].Cursor = resp.ResponseMetadata.NextCursor
+		lh.logger.Debug("Added cursor to last item", zap.String("cursor", resp.ResponseMetadata.NextCursor))
+	}
+
+	csvBytes, err := gocsv.MarshalBytes(&itemList)
+	if err != nil {
+		lh.logger.Error("Failed to marshal items to CSV", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(csvBytes)), nil
+}
+
+func (lh *ListsHandler) ListsItemsInfoHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	lh.logger.Debug("ListsItemsInfoHandler called")
+
+	if ready, err := lh.apiProvider.IsReady(); !ready {
+		lh.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	listID := request.GetString("list_id", "")
+	if listID == "" {
+		lh.logger.Error("list_id is required")
+		return nil, fmt.Errorf("list_id is required")
+	}
+
+	itemID := request.GetString("item_id", "")
+	if itemID == "" {
+		lh.logger.Error("item_id is required")
+		return nil, fmt.Errorf("item_id is required")
+	}
+
+	lh.logger.Debug("Request parameters",
+		zap.String("list_id", listID),
+		zap.String("item_id", itemID),
+	)
+
+	resp, err := lh.apiProvider.Slack().ListsItemsInfo(ctx, listID, itemID)
+	if err != nil {
+		lh.logger.Error("Failed to get item info", zap.Error(err))
+		return nil, err
+	}
+
+	fieldsJSON, err := json.Marshal(resp.Item.Fields)
+	if err != nil {
+		fieldsJSON = []byte("[]")
+	}
+
+	itemList := []ListItemCSV{{
+		ID:        resp.Item.ID,
+		ListID:    resp.Item.ListID,
+		CreatedBy: resp.Item.CreatedBy,
+		UpdatedBy: resp.Item.UpdatedBy,
+		Archived:  resp.Item.Archived,
+		ParentID:  resp.Item.ParentID,
+		Fields:    string(fieldsJSON),
+	}}
+
+	csvBytes, err := gocsv.MarshalBytes(&itemList)
+	if err != nil {
+		lh.logger.Error("Failed to marshal item to CSV", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(csvBytes)), nil
+}
+
+func (lh *ListsHandler) ListsItemsCreateHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	lh.logger.Debug("ListsItemsCreateHandler called")
+
+	if ready, err := lh.apiProvider.IsReady(); !ready {
+		lh.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	listID := request.GetString("list_id", "")
+	if listID == "" {
+		lh.logger.Error("list_id is required")
+		return nil, fmt.Errorf("list_id is required")
+	}
+
+	fieldsJSON := request.GetString("fields", "")
+	parentItemID := request.GetString("parent_item_id", "")
+
+	lh.logger.Debug("Request parameters",
+		zap.String("list_id", listID),
+		zap.String("fields", fieldsJSON),
+		zap.String("parent_item_id", parentItemID),
+	)
+
+	var fields []edge.ListItemField
+	if fieldsJSON != "" {
+		if err := json.Unmarshal([]byte(fieldsJSON), &fields); err != nil {
+			lh.logger.Error("Failed to parse fields JSON", zap.Error(err))
+			return nil, fmt.Errorf("invalid fields JSON: %v", err)
+		}
+	}
+
+	resp, err := lh.apiProvider.Slack().ListsItemsCreate(ctx, listID, fields, parentItemID)
+	if err != nil {
+		lh.logger.Error("Failed to create item", zap.Error(err))
+		return nil, err
+	}
+
+	respFieldsJSON, err := json.Marshal(resp.Item.Fields)
+	if err != nil {
+		respFieldsJSON = []byte("[]")
+	}
+
+	itemList := []ListItemCSV{{
+		ID:        resp.Item.ID,
+		ListID:    resp.Item.ListID,
+		CreatedBy: resp.Item.CreatedBy,
+		UpdatedBy: resp.Item.UpdatedBy,
+		Archived:  resp.Item.Archived,
+		ParentID:  resp.Item.ParentID,
+		Fields:    string(respFieldsJSON),
+	}}
+
+	csvBytes, err := gocsv.MarshalBytes(&itemList)
+	if err != nil {
+		lh.logger.Error("Failed to marshal item to CSV", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(csvBytes)), nil
+}
+
+func (lh *ListsHandler) ListsItemsUpdateHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	lh.logger.Debug("ListsItemsUpdateHandler called")
+
+	if ready, err := lh.apiProvider.IsReady(); !ready {
+		lh.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	listID := request.GetString("list_id", "")
+	if listID == "" {
+		lh.logger.Error("list_id is required")
+		return nil, fmt.Errorf("list_id is required")
+	}
+
+	itemID := request.GetString("item_id", "")
+	if itemID == "" {
+		lh.logger.Error("item_id is required")
+		return nil, fmt.Errorf("item_id is required")
+	}
+
+	fieldsJSON := request.GetString("fields", "")
+
+	lh.logger.Debug("Request parameters",
+		zap.String("list_id", listID),
+		zap.String("item_id", itemID),
+		zap.String("fields", fieldsJSON),
+	)
+
+	var fields []edge.ListItemField
+	if fieldsJSON != "" {
+		if err := json.Unmarshal([]byte(fieldsJSON), &fields); err != nil {
+			lh.logger.Error("Failed to parse fields JSON", zap.Error(err))
+			return nil, fmt.Errorf("invalid fields JSON: %v", err)
+		}
+	}
+
+	resp, err := lh.apiProvider.Slack().ListsItemsUpdate(ctx, listID, itemID, fields)
+	if err != nil {
+		lh.logger.Error("Failed to update item", zap.Error(err))
+		return nil, err
+	}
+
+	respFieldsJSON, err := json.Marshal(resp.Item.Fields)
+	if err != nil {
+		respFieldsJSON = []byte("[]")
+	}
+
+	itemList := []ListItemCSV{{
+		ID:        resp.Item.ID,
+		ListID:    resp.Item.ListID,
+		CreatedBy: resp.Item.CreatedBy,
+		UpdatedBy: resp.Item.UpdatedBy,
+		Archived:  resp.Item.Archived,
+		ParentID:  resp.Item.ParentID,
+		Fields:    string(respFieldsJSON),
+	}}
+
+	csvBytes, err := gocsv.MarshalBytes(&itemList)
+	if err != nil {
+		lh.logger.Error("Failed to marshal item to CSV", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(csvBytes)), nil
+}
+
+func (lh *ListsHandler) ListsItemsDeleteHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	lh.logger.Debug("ListsItemsDeleteHandler called")
+
+	if ready, err := lh.apiProvider.IsReady(); !ready {
+		lh.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	listID := request.GetString("list_id", "")
+	if listID == "" {
+		lh.logger.Error("list_id is required")
+		return nil, fmt.Errorf("list_id is required")
+	}
+
+	itemID := request.GetString("item_id", "")
+	if itemID == "" {
+		lh.logger.Error("item_id is required")
+		return nil, fmt.Errorf("item_id is required")
+	}
+
+	lh.logger.Debug("Request parameters",
+		zap.String("list_id", listID),
+		zap.String("item_id", itemID),
+	)
+
+	_, err := lh.apiProvider.Slack().ListsItemsDelete(ctx, listID, itemID)
+	if err != nil {
+		lh.logger.Error("Failed to delete item", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText("Item deleted successfully"), nil
+}

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -87,6 +87,13 @@ type SlackAPI interface {
 
 	// Edge API methods
 	ClientUserBoot(ctx context.Context) (*edge.ClientUserBootResponse, error)
+
+	// Lists API methods
+	ListsItemsList(ctx context.Context, listID string, limit int, cursor string, archived bool) (*edge.ListsItemsListResponse, error)
+	ListsItemsInfo(ctx context.Context, listID, itemID string) (*edge.ListsItemsInfoResponse, error)
+	ListsItemsCreate(ctx context.Context, listID string, fields []edge.ListItemField, parentItemID string) (*edge.ListsItemsCreateResponse, error)
+	ListsItemsUpdate(ctx context.Context, listID, itemID string, fields []edge.ListItemField) (*edge.ListsItemsUpdateResponse, error)
+	ListsItemsDelete(ctx context.Context, listID, itemID string) (*edge.ListsItemsDeleteResponse, error)
 }
 
 type MCPSlackClient struct {
@@ -286,6 +293,26 @@ func (c *MCPSlackClient) PostMessageContext(ctx context.Context, channelID strin
 
 func (c *MCPSlackClient) ClientUserBoot(ctx context.Context) (*edge.ClientUserBootResponse, error) {
 	return c.edgeClient.ClientUserBoot(ctx)
+}
+
+func (c *MCPSlackClient) ListsItemsList(ctx context.Context, listID string, limit int, cursor string, archived bool) (*edge.ListsItemsListResponse, error) {
+	return c.edgeClient.ListsItemsList(ctx, listID, limit, cursor, archived)
+}
+
+func (c *MCPSlackClient) ListsItemsInfo(ctx context.Context, listID, itemID string) (*edge.ListsItemsInfoResponse, error) {
+	return c.edgeClient.ListsItemsInfo(ctx, listID, itemID)
+}
+
+func (c *MCPSlackClient) ListsItemsCreate(ctx context.Context, listID string, fields []edge.ListItemField, parentItemID string) (*edge.ListsItemsCreateResponse, error) {
+	return c.edgeClient.ListsItemsCreate(ctx, listID, fields, parentItemID)
+}
+
+func (c *MCPSlackClient) ListsItemsUpdate(ctx context.Context, listID, itemID string, fields []edge.ListItemField) (*edge.ListsItemsUpdateResponse, error) {
+	return c.edgeClient.ListsItemsUpdate(ctx, listID, itemID, fields)
+}
+
+func (c *MCPSlackClient) ListsItemsDelete(ctx context.Context, listID, itemID string) (*edge.ListsItemsDeleteResponse, error) {
+	return c.edgeClient.ListsItemsDelete(ctx, listID, itemID)
 }
 
 func (c *MCPSlackClient) IsEnterprise() bool {

--- a/pkg/provider/edge/lists.go
+++ b/pkg/provider/edge/lists.go
@@ -1,0 +1,224 @@
+package edge
+
+import (
+	"context"
+	"runtime/trace"
+)
+
+// Lists API types and methods
+
+type ListItem struct {
+	ID        string          `json:"id"`
+	ListID    string          `json:"list_id"`
+	CreatedBy string          `json:"created_by,omitempty"`
+	Created   int64           `json:"date_created,omitempty"`
+	Updated   int64           `json:"updated_timestamp,omitempty"`
+	UpdatedBy string          `json:"updated_by,omitempty"`
+	Archived  bool            `json:"archived,omitempty"`
+	Fields    []ListItemField `json:"fields,omitempty"`
+	ParentID  string          `json:"parent_record_id,omitempty"`
+}
+
+type ListItemField struct {
+	ColumnID string      `json:"column_id"`
+	Key      string      `json:"key,omitempty"`
+	Value    interface{} `json:"value,omitempty"`
+}
+
+type ListsItemsListRequest struct {
+	BaseRequest
+	ListID   string `json:"list_id"`
+	Limit    int    `json:"limit,omitempty"`
+	Cursor   string `json:"cursor,omitempty"`
+	Archived bool   `json:"archived,omitempty"`
+}
+
+type ListsItemsListResponse struct {
+	baseResponse
+	Items            []ListItem       `json:"items"`
+	ResponseMetadata ResponseMetadata `json:"response_metadata,omitempty"`
+}
+
+type ListsItemsInfoRequest struct {
+	BaseRequest
+	ListID string `json:"list_id"`
+	ItemID string `json:"item_id"`
+}
+
+type ListsItemsInfoResponse struct {
+	baseResponse
+	Item ListItem `json:"item"`
+}
+
+type ListsItemsCreateRequest struct {
+	BaseRequest
+	ListID        string          `json:"list_id"`
+	InitialFields []ListItemField `json:"initial_fields,omitempty"`
+	ParentItemID  string          `json:"parent_item_id,omitempty"`
+}
+
+type ListsItemsCreateResponse struct {
+	baseResponse
+	Item ListItem `json:"item"`
+}
+
+type ListsItemsUpdateRequest struct {
+	BaseRequest
+	ListID string          `json:"list_id"`
+	ItemID string          `json:"item_id"`
+	Fields []ListItemField `json:"fields,omitempty"`
+}
+
+type ListsItemsUpdateResponse struct {
+	baseResponse
+	Item ListItem `json:"item"`
+}
+
+type ListsItemsDeleteRequest struct {
+	BaseRequest
+	ListID string `json:"list_id"`
+	ItemID string `json:"item_id"`
+}
+
+type ListsItemsDeleteResponse struct {
+	baseResponse
+}
+
+func (cl *Client) ListsItemsList(ctx context.Context, listID string, limit int, cursor string, archived bool) (*ListsItemsListResponse, error) {
+	ctx, task := trace.NewTask(ctx, "ListsItemsList")
+	defer task.End()
+
+	form := ListsItemsListRequest{
+		BaseRequest: BaseRequest{Token: cl.token},
+		ListID:      listID,
+		Limit:       limit,
+		Cursor:      cursor,
+		Archived:    archived,
+	}
+
+	resp, err := cl.PostForm(ctx, "slackLists.items.list", values(form, true))
+	if err != nil {
+		return nil, err
+	}
+
+	r := &ListsItemsListResponse{}
+	if err := cl.ParseResponse(r, resp); err != nil {
+		return nil, err
+	}
+
+	if err := r.validate("slackLists.items.list"); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (cl *Client) ListsItemsInfo(ctx context.Context, listID, itemID string) (*ListsItemsInfoResponse, error) {
+	ctx, task := trace.NewTask(ctx, "ListsItemsInfo")
+	defer task.End()
+
+	form := ListsItemsInfoRequest{
+		BaseRequest: BaseRequest{Token: cl.token},
+		ListID:      listID,
+		ItemID:      itemID,
+	}
+
+	resp, err := cl.PostForm(ctx, "slackLists.items.info", values(form, true))
+	if err != nil {
+		return nil, err
+	}
+
+	r := &ListsItemsInfoResponse{}
+	if err := cl.ParseResponse(r, resp); err != nil {
+		return nil, err
+	}
+
+	if err := r.validate("slackLists.items.info"); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (cl *Client) ListsItemsCreate(ctx context.Context, listID string, fields []ListItemField, parentItemID string) (*ListsItemsCreateResponse, error) {
+	ctx, task := trace.NewTask(ctx, "ListsItemsCreate")
+	defer task.End()
+
+	form := ListsItemsCreateRequest{
+		BaseRequest:   BaseRequest{Token: cl.token},
+		ListID:        listID,
+		InitialFields: fields,
+		ParentItemID:  parentItemID,
+	}
+
+	resp, err := cl.PostForm(ctx, "slackLists.items.create", values(form, true))
+	if err != nil {
+		return nil, err
+	}
+
+	r := &ListsItemsCreateResponse{}
+	if err := cl.ParseResponse(r, resp); err != nil {
+		return nil, err
+	}
+
+	if err := r.validate("slackLists.items.create"); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (cl *Client) ListsItemsUpdate(ctx context.Context, listID, itemID string, fields []ListItemField) (*ListsItemsUpdateResponse, error) {
+	ctx, task := trace.NewTask(ctx, "ListsItemsUpdate")
+	defer task.End()
+
+	form := ListsItemsUpdateRequest{
+		BaseRequest: BaseRequest{Token: cl.token},
+		ListID:      listID,
+		ItemID:      itemID,
+		Fields:      fields,
+	}
+
+	resp, err := cl.PostForm(ctx, "slackLists.items.update", values(form, true))
+	if err != nil {
+		return nil, err
+	}
+
+	r := &ListsItemsUpdateResponse{}
+	if err := cl.ParseResponse(r, resp); err != nil {
+		return nil, err
+	}
+
+	if err := r.validate("slackLists.items.update"); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (cl *Client) ListsItemsDelete(ctx context.Context, listID, itemID string) (*ListsItemsDeleteResponse, error) {
+	ctx, task := trace.NewTask(ctx, "ListsItemsDelete")
+	defer task.End()
+
+	form := ListsItemsDeleteRequest{
+		BaseRequest: BaseRequest{Token: cl.token},
+		ListID:      listID,
+		ItemID:      itemID,
+	}
+
+	resp, err := cl.PostForm(ctx, "slackLists.items.delete", values(form, true))
+	if err != nil {
+		return nil, err
+	}
+
+	r := &ListsItemsDeleteResponse{}
+	if err := cl.ParseResponse(r, resp); err != nil {
+		return nil, err
+	}
+
+	if err := r.validate("slackLists.items.delete"); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,6 +148,7 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 	}
 
 	channelsHandler := handler.NewChannelsHandler(provider, logger)
+	listsHandler := handler.NewListsHandler(provider, logger)
 
 	s.AddTool(mcp.NewTool("channels_list",
 		mcp.WithDescription("Get list of channels"),
@@ -168,6 +169,88 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 			mcp.Description("Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request."),
 		),
 	), channelsHandler.ChannelsHandler)
+
+	s.AddTool(mcp.NewTool("lists_items_list",
+		mcp.WithDescription("Get items from a Slack List. Lists are only available to workspaces on a paid plan."),
+		mcp.WithTitleAnnotation("List Items"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("list_id",
+			mcp.Required(),
+			mcp.Description("The encoded identifier for the target List."),
+		),
+		mcp.WithNumber("limit",
+			mcp.DefaultNumber(100),
+			mcp.Description("Maximum number of items to retrieve. Must be between 1 and 1000."),
+		),
+		mcp.WithString("cursor",
+			mcp.Description("Cursor for pagination. Use the value from the Cursor column in the last row of the previous response."),
+		),
+		mcp.WithBoolean("archived",
+			mcp.Description("Include archived items in results. Default is false."),
+			mcp.DefaultBool(false),
+		),
+	), listsHandler.ListsItemsListHandler)
+
+	s.AddTool(mcp.NewTool("lists_items_info",
+		mcp.WithDescription("Get detailed information about a specific item in a Slack List."),
+		mcp.WithTitleAnnotation("Get List Item Info"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("list_id",
+			mcp.Required(),
+			mcp.Description("The encoded identifier for the target List."),
+		),
+		mcp.WithString("item_id",
+			mcp.Required(),
+			mcp.Description("The encoded identifier for the target item."),
+		),
+	), listsHandler.ListsItemsInfoHandler)
+
+	s.AddTool(mcp.NewTool("lists_items_create",
+		mcp.WithDescription("Create a new item in a Slack List."),
+		mcp.WithTitleAnnotation("Create List Item"),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("list_id",
+			mcp.Required(),
+			mcp.Description("The encoded identifier for the target List."),
+		),
+		mcp.WithString("fields",
+			mcp.Description("JSON array of field objects with column_id and value. Example: [{\"column_id\":\"col1\",\"value\":\"text\"}]"),
+		),
+		mcp.WithString("parent_item_id",
+			mcp.Description("The encoded identifier of the parent item, if creating a subtask."),
+		),
+	), listsHandler.ListsItemsCreateHandler)
+
+	s.AddTool(mcp.NewTool("lists_items_update",
+		mcp.WithDescription("Update an existing item in a Slack List."),
+		mcp.WithTitleAnnotation("Update List Item"),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("list_id",
+			mcp.Required(),
+			mcp.Description("The encoded identifier for the target List."),
+		),
+		mcp.WithString("item_id",
+			mcp.Required(),
+			mcp.Description("The encoded identifier for the target item."),
+		),
+		mcp.WithString("fields",
+			mcp.Description("JSON array of field objects with column_id and value to update."),
+		),
+	), listsHandler.ListsItemsUpdateHandler)
+
+	s.AddTool(mcp.NewTool("lists_items_delete",
+		mcp.WithDescription("Delete an item from a Slack List."),
+		mcp.WithTitleAnnotation("Delete List Item"),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("list_id",
+			mcp.Required(),
+			mcp.Description("The encoded identifier for the target List."),
+		),
+		mcp.WithString("item_id",
+			mcp.Required(),
+			mcp.Description("The encoded identifier for the item to delete."),
+		),
+	), listsHandler.ListsItemsDeleteHandler)
 
 	logger.Info("Authenticating with Slack API...",
 		zap.String("context", "console"),


### PR DESCRIPTION
Fixes #95

## Changes
- Add edge client methods for Slack Lists API (list, info, create, update, delete)
- Add MCP tool handlers for Lists operations
- Register 5 new MCP tools: lists_items_list, lists_items_info, lists_items_create, lists_items_update, lists_items_delete
- Support pagination via cursor for listing items