### PR TITLE
fix: wait for cache to be ready before serving stdio requests

### DIFF
--- a/cmd/slack-mcp-server/main.go
+++ b/cmd/slack-mcp-server/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/korotovsky/slack-mcp-server/pkg/provider"
 	"github.com/korotovsky/slack-mcp-server/pkg/server"
@@ -51,6 +52,12 @@ func main() {
 
 	switch transport {
 	case "stdio":
+		for {
+			if ready, _ := p.IsReady(); ready {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
 		if err := s.ServeStdio(); err != nil {
 			logger.Fatal("Server error",
 				zap.String("context", "console"),


### PR DESCRIPTION
## Summary

- Wait for cache to be ready before starting stdio server to fix race condition

## Problem

stdio transport starts accepting requests immediately while cache loading runs in a goroutine. For large workspaces (e.g., ~4.5k users, ~3.5k channels), the cache takes ~1 second to load from disk, but requests arrive in milliseconds - causing "cache not ready" errors.

SSE/HTTP transports don't have this issue because their server setup takes enough time for the cache to load.

## Solution

Add a simple wait loop before `ServeStdio()` that polls `IsReady()` until the cache is loaded.

## Test plan

- [x] Tested with large workspace (~4.5k users, ~3.5k channels)
- [x] Verified cache loads from disk in ~1 second
- [x] Verified requests succeed after fix

Fixes #135