### PR TITLE
ci: add Trivy scan for Go dependencies

### DIFF
--- a/.github/workflows/security-trivy.yaml
+++ b/.github/workflows/security-trivy.yaml
@@ -1,0 +1,31 @@
+name: Security (Trivy)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-fs:
+    name: Trivy filesystem scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+
+      - name: Run Trivy (Go dependencies)
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          vuln-type: library
+          severity: CRITICAL,HIGH
+          format: table
+          ignore-unfixed: true
+          exit-code: 1


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow that runs Trivy vulnerability scanning against Go (library) dependencies in the repository.

## Why
Detect vulnerable Go dependencies early in CI and fail PRs when HIGH/CRITICAL issues are found.

## Notes
- Uses aquasecurity/trivy-action@0.33.1
- Fails on HIGH,CRITICAL and ignores unfixed vulnerabilities