### PR TITLE
ci: add Dependabot for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps(go)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps(gha)"


### PR DESCRIPTION
## What
Adds Dependabot configuration for:
- Go modules (gomod)
- GitHub Actions

## Why
Keep Go dependencies and CI actions up to date with a low-noise weekly cadence and small PR limit.

## Settings
- Weekly schedule
- PR limits: 3 (Go) / 2 (Actions)
- Grouped updates to reduce churn