### PR TITLE
feat: Add conversations_unread tool to check for unread messages

### DIFF
--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -85,8 +85,12 @@ type SlackAPI interface {
 	// Used to get channels list from both Slack and Enterprise Grid versions
 	GetConversationsContext(ctx context.Context, params *slack.GetConversationsParameters) ([]slack.Channel, string, error)
 
+	// Used to get channel info including unread counts
+	GetConversationInfoContext(ctx context.Context, channelID string, includeLocale bool) (*slack.Channel, error)
+
 	// Edge API methods
 	ClientUserBoot(ctx context.Context) (*edge.ClientUserBootResponse, error)
+	ClientCounts(ctx context.Context) (*edge.ClientCountsResponse, error)
 }
 
 type MCPSlackClient struct {
@@ -280,12 +284,25 @@ func (c *MCPSlackClient) SearchContext(ctx context.Context, query string, params
 	return c.slackClient.SearchContext(ctx, query, params)
 }
 
+func (c *MCPSlackClient) GetConversationInfoContext(ctx context.Context, channelID string, includeLocale bool) (*slack.Channel, error) {
+	return c.slackClient.GetConversationInfoContext(ctx, &slack.GetConversationInfoInput{
+		ChannelID:         channelID,
+		IncludeLocale:     includeLocale,
+		IncludeNumMembers: true,
+	})
+}
+
 func (c *MCPSlackClient) PostMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error) {
 	return c.slackClient.PostMessageContext(ctx, channelID, options...)
 }
 
 func (c *MCPSlackClient) ClientUserBoot(ctx context.Context) (*edge.ClientUserBootResponse, error) {
 	return c.edgeClient.ClientUserBoot(ctx)
+}
+
+func (c *MCPSlackClient) ClientCounts(ctx context.Context) (*edge.ClientCountsResponse, error) {
+	resp, err := c.edgeClient.ClientCounts(ctx)
+	return &resp, err
 }
 
 func (c *MCPSlackClient) IsEnterprise() bool {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -169,6 +169,16 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 		),
 	), channelsHandler.ChannelsHandler)
 
+	s.AddTool(mcp.NewTool("conversations_unread",
+		mcp.WithDescription("Get list of channels and DMs with unread messages. Returns channel ID, name, unread count, and purpose for each conversation with unread messages."),
+		mcp.WithTitleAnnotation("Get Unread Conversations"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("channel_types",
+			mcp.DefaultString("im,mpim,public_channel,private_channel"),
+			mcp.Description("Comma-separated channel types to check for unread messages. Allowed values: 'mpim', 'im', 'public_channel', 'private_channel'. Default: all types."),
+		),
+	), conversationsHandler.ConversationsUnreadHandler)
+
 	logger.Info("Authenticating with Slack API...",
 		zap.String("context", "console"),
 	)


### PR DESCRIPTION
## Summary

This PR adds a new `conversations_unread` tool that lets users quickly check which channels and DMs have unread messages.

### The Problem

I wanted to use Claude Code to check if I had any unread Slack messages before diving into work. The existing MCP server has great tools for reading conversations and sending messages, but no way to see *which* conversations need attention.

### What I Tried

My first attempt used the `conversations.info` API to get unread counts for each channel individually. This worked but was **way too slow** - it made N API calls (one per channel), which caused timeouts when you have hundreds of channels.

### The Solution

I discovered the `client.counts` edge API that's already used elsewhere in this codebase. It returns unread status for **all channels in a single API call**. Much faster!

**Trade-off:** The `client.counts` API only returns `HasUnreads: true/false`, not the actual unread count. So the tool reports `UnreadCount: 1` for any channel with unreads. If exact counts are needed, that would require the slower per-channel approach.

## Changes

- **`pkg/provider/api.go`**: Added `ClientCounts` method to the `SlackAPI` interface and `MCPSlackClient`
- **`pkg/handler/conversations.go`**: Added `ConversationsUnreadHandler` and `UnreadChannel` struct
- **`pkg/server/server.go`**: Registered the new `conversations_unread` tool

## Usage

```
conversations_unread(channel_types: "im,mpim,public_channel,private_channel")
```

Returns CSV with columns: `ChannelID`, `ChannelName`, `UnreadCount`, `Purpose`

The `channel_types` parameter is optional and defaults to all types.

## Testing

- ✅ Tested locally with a user OAuth token (xoxp)
- ✅ Verified it returns results quickly (single API call)
- ✅ Verified empty response when no unreads (just CSV headers)
- ✅ Verified channel type filtering works correctly

## Screenshots

Example response when no unreads:
```
ChannelID,ChannelName,UnreadCount,Purpose
```

Example response with unreads:
```
ChannelID,ChannelName,UnreadCount,Purpose
D1234567890,@john.doe,1,DM with John Doe
C9876543210,#general,1,Company-wide announcements
```