### PR TITLE
fix: include thread_broadcast replies in conversations_replies

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -559,7 +559,7 @@ func (ch *ConversationsHandler) convertMessagesFromHistory(slackMessages []slack
 	warn := false
 
 	for _, msg := range slackMessages {
-		if (msg.SubType != "" && msg.SubType != "bot_message") && !includeActivity {
+		if (msg.SubType != "" && msg.SubType != "bot_message" && msg.SubType != "thread_broadcast") && !includeActivity {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

`conversations_replies` returns incomplete results when a thread contains replies that were sent with Slack's "also send to channel" option. These messages have `SubType: "thread_broadcast"` and are being incorrectly filtered out.

## Root Cause

In `convertMessagesFromHistory()`, there's a filter that skips messages with a non-empty `SubType` (except `bot_message`):

```go
if (msg.SubType != "" && msg.SubType != "bot_message") && !includeActivity {
    continue
}
```

When a user sends a threaded reply with "also send to channel", Slack sets `SubType: "thread_broadcast"`. This causes the message to be filtered out, even though it's a legitimate user message that should be returned.

## How I Found This

While using `conversations_replies` to fetch thread messages, I noticed certain replies were missing. Investigation showed:

1. `conversations_replies` returned only the parent message for affected threads
2. `conversations_search_messages` found the missing replies correctly
3. The missing replies all had `SubType: "thread_broadcast"` (sent with "also send to channel")
4. Other threads without broadcast replies worked correctly

## The Fix

Add `thread_broadcast` to the allowlist of SubTypes that should be included:

```go
if (msg.SubType != "" && msg.SubType != "bot_message" && msg.SubType != "thread_broadcast") && !includeActivity {
    continue
}
```

## Testing

- Manual testing confirmed broadcast replies now appear in `conversations_replies` results
- The change is minimal and backwards-compatible (only adds messages that were incorrectly filtered)

---

🤖 Generated with [Claude Code](https://claude.ai/code)