### PR TITLE
feat: add reactions_list tool to list items user has reacted to

### DIFF
--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -79,6 +79,7 @@ type SlackAPI interface {
 	MarkConversationContext(ctx context.Context, channel, ts string) error
 	AddReactionContext(ctx context.Context, name string, item slack.ItemRef) error
 	RemoveReactionContext(ctx context.Context, name string, item slack.ItemRef) error
+	ListReactionsContext(ctx context.Context, params slack.ListReactionsParameters) ([]slack.ReactedItem, *slack.Paging, error)
 
 	// Used to get messages
 	GetConversationHistoryContext(ctx context.Context, params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
@@ -299,6 +300,10 @@ func (c *MCPSlackClient) AddReactionContext(ctx context.Context, name string, it
 
 func (c *MCPSlackClient) RemoveReactionContext(ctx context.Context, name string, item slack.ItemRef) error {
 	return c.slackClient.RemoveReactionContext(ctx, name, item)
+}
+
+func (c *MCPSlackClient) ListReactionsContext(ctx context.Context, params slack.ListReactionsParameters) ([]slack.ReactedItem, *slack.Paging, error) {
+	return c.slackClient.ListReactionsContext(ctx, params)
 }
 
 func (c *MCPSlackClient) GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*slack.File, []slack.Comment, *slack.Paging, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -133,6 +133,24 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger) *MCPServer
 		),
 	), conversationsHandler.ReactionsRemoveHandler)
 
+	s.AddTool(mcp.NewTool("reactions_list",
+		mcp.WithDescription("List items (messages, files) the authenticated user has reacted to. Useful as a workaround for accessing saved/bookmarked items."),
+		mcp.WithTitleAnnotation("List My Reactions"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithNumber("count",
+			mcp.DefaultNumber(100),
+			mcp.Description("Number of items to return per page (default 100, max 1000)."),
+		),
+		mcp.WithNumber("page",
+			mcp.DefaultNumber(1),
+			mcp.Description("Page number for pagination (default 1)."),
+		),
+		mcp.WithBoolean("full",
+			mcp.DefaultBool(true),
+			mcp.Description("If true, return full message/file details. Default is true."),
+		),
+	), conversationsHandler.ReactionsListHandler)
+
 	s.AddTool(mcp.NewTool("attachment_get_data",
 		mcp.WithDescription("Download an attachment's content by file ID. Returns file metadata and content (text files as-is, binary files as base64). Maximum file size is 5MB."),
 		mcp.WithTitleAnnotation("Get Attachment Data"),


### PR DESCRIPTION
## Summary

- Add new `reactions_list` MCP tool that wraps Slack's `reactions.list` API endpoint
- Lists all items (messages, files, file comments) that the authenticated user has reacted to
- Can be used as a workaround for accessing saved/bookmarked items since Slack's "Save for Later" API is not publicly available

## Changes

- **pkg/handler/conversations.go**: Add `ReactionsListHandler`, `convertReactedItems`, and `parseParamsToolReactionsList` functions
- **pkg/provider/api.go**: Add `ListReactionsContext` to `SlackAPI` interface and `MCPSlackClient` implementation
- **pkg/server/server.go**: Register the new `reactions_list` tool with parameters

## Parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `count` | number | 100 | Number of items to return per page (max 1000) |
| `page` | number | 1 | Page number for pagination |
| `full` | boolean | true | If true, return full message/file details |

## Response Format

Returns CSV with columns:
- `type` - item type (message, file, file_comment)
- `channel` - channel ID
- `timestamp` - message timestamp
- `emoji` - reaction emoji name
- `text` - message text or file name (truncated)
- `userID` - author's user ID
- `userName` - author's username
- `time` - ISO 8601 formatted time
- `cursor` - next page number (if more results available)

## Test plan

- [ ] Build the project: `go build ./cmd/slack-mcp-server`
- [ ] Run with valid Slack credentials
- [ ] Call `reactions_list` tool via MCP client
- [ ] Verify pagination works with `page` parameter
- [ ] Verify results include messages, files the user has reacted to

🤖 Generated with [Claude Code](https://claude.com/claude-code)