### PR TITLE
fix(dxt): add missing xoxb_token workaround for DXT bug

### DIFF
--- a/npm/slack-mcp-server/bin/index.js
+++ b/npm/slack-mcp-server/bin/index.js
@@ -25,6 +25,9 @@ function resolveBinaryPath() {
         if (process.env.SLACK_MCP_XOXP_TOKEN === '${user_config.xoxp_token}') {
             process.env.SLACK_MCP_XOXP_TOKEN = '';
         }
+        if (process.env.SLACK_MCP_XOXB_TOKEN === '${user_config.xoxb_token}') {
+            process.env.SLACK_MCP_XOXB_TOKEN = '';
+        }
         if (process.env.SLACK_MCP_ADD_MESSAGE_TOOL === '${user_config.add_message_tool}') {
             process.env.SLACK_MCP_ADD_MESSAGE_TOOL = '';
         }


### PR DESCRIPTION
## Summary

- Add missing `SLACK_MCP_XOXB_TOKEN` check to the DXT bug workaround in `index.js`

## Problem

When xoxb support was added in v1.1.27 (commit bb9469d), the DXT bug workaround in `npm/slack-mcp-server/bin/index.js` was not updated to include `SLACK_MCP_XOXB_TOKEN`.

DXT has a bug where empty config fields pass the literal template string (e.g., `${user_config.xoxb_token}`) instead of an empty string. The existing workaround clears these for xoxc, xoxd, xoxp, and add_message_tool, but was missing xoxb.

This causes authentication failures when users configure xoxc/xoxd authentication with an empty xoxb_token field, because:
1. `SLACK_MCP_XOXB_TOKEN` gets set to `"${user_config.xoxb_token}"` (literal string)
2. Go code sees `xoxbToken != ""` and uses priority 2 (xoxb) instead of priority 3 (xoxc/xoxd)
3. Authentication fails with an invalid token

## Fix

Add the missing check:
```javascript
if (process.env.SLACK_MCP_XOXB_TOKEN === '${user_config.xoxb_token}') {
    process.env.SLACK_MCP_XOXB_TOKEN = '';
}
```

Fixes #177