### PR TITLE
Include Fields and TitleLinks from attachments

### DIFF
--- a/pkg/text/text_processor.go
+++ b/pkg/text/text_processor.go
@@ -18,7 +18,11 @@ func AttachmentToText(att slack.Attachment) string {
 	var parts []string
 
 	if att.Title != "" {
-		parts = append(parts, fmt.Sprintf("Title: %s", att.Title))
+		if att.TitleLink != "" {
+			parts = append(parts, fmt.Sprintf("Title: %s (%s)", att.Title, att.TitleLink))
+		} else {
+			parts = append(parts, fmt.Sprintf("Title: %s", att.Title))
+		}
 	}
 
 	if att.AuthorName != "" {
@@ -33,10 +37,25 @@ func AttachmentToText(att slack.Attachment) string {
 		parts = append(parts, fmt.Sprintf("Text: %s", att.Text))
 	}
 
+	for _, f := range att.Fields {
+		if f.Title != "" && f.Value != "" {
+			parts = append(parts, fmt.Sprintf("%s: %s", f.Title, f.Value))
+		} else if f.Value != "" {
+			parts = append(parts, f.Value)
+		} else if f.Title != "" {
+			parts = append(parts, f.Title)
+		}
+	}
+
 	if att.Footer != "" {
 		ts, _ := TimestampToIsoRFC3339(string(att.Ts) + ".000000")
 
 		parts = append(parts, fmt.Sprintf("Footer: %s @ %s", att.Footer, ts))
+	}
+
+	// Use fallback text when no other meaningful content was extracted
+	if len(parts) == 0 && att.Fallback != "" {
+		parts = append(parts, att.Fallback)
 	}
 
 	result := strings.Join(parts, "; ")


### PR DESCRIPTION
This includes additional information from `Attachment` objects in the text returned by the MCP.

One motivation for this is that Honeycomb's Slack app generates some messages where the only useful information is in the `Field`s of an `Attachment`.

Disclosure: Claude generated this code and I'm not experienced with Go. But the code looks reasonable to me, `make clean && make test` passes, and I built the docker image locally and tested the MCP with Claude Code and it seems to work as desired.