### PR TITLE
feat: extract email metadata from file-type messages

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -1565,6 +1565,9 @@ func (ch *ConversationsHandler) convertMessagesFromHistory(slackMessages []slack
 		if msgText == "" {
 			msgText = text.BlocksToText(msg.Blocks)
 		}
+		if msgText == "" {
+			msgText = text.FilesToText(msg.Files)
+		}
 		msgText += text.AttachmentsTo2CSV(msgText, msg.Attachments)
 
 		var reactionParts []string

--- a/pkg/text/text_processor.go
+++ b/pkg/text/text_processor.go
@@ -106,6 +106,50 @@ func BlocksToText(blocks slack.Blocks) string {
 	return strings.Join(parts, " ")
 }
 
+// FilesToText extracts text metadata from email file attachments.
+// Separators are chosen so the metadata survives the text-processing pipeline.
+func FilesToText(files []slack.File) string {
+	var parts []string
+
+	for _, f := range files {
+		if f.Filetype != "email" && f.Mode != "email" {
+			continue
+		}
+
+		var emailParts []string
+
+		if len(f.From) > 0 {
+			if s := formatEmailUser(f.From[0]); s != "" {
+				emailParts = append(emailParts, "From: "+s)
+			}
+		}
+
+		if len(f.Cc) > 0 {
+			var ccParts []string
+			for _, c := range f.Cc {
+				if s := formatEmailUser(c); s != "" {
+					ccParts = append(ccParts, s)
+				}
+			}
+			if len(ccParts) > 0 {
+				emailParts = append(emailParts, "CC: "+strings.Join(ccParts, "/"))
+			}
+		}
+
+		if f.Subject != "" {
+			emailParts = append(emailParts, fmt.Sprintf("Subject: %s", f.Subject))
+		} else if f.Title != "" {
+			emailParts = append(emailParts, fmt.Sprintf("Subject: %s", f.Title))
+		}
+
+		if len(emailParts) > 0 {
+			parts = append(parts, "Email, "+strings.Join(emailParts, ", "))
+		}
+	}
+
+	return strings.Join(parts, " ")
+}
+
 func richTextBlockToText(rtb *slack.RichTextBlock) string {
 	var parts []string
 
@@ -134,6 +178,18 @@ func richTextElementToText(elem slack.RichTextElement) string {
 		return richTextSectionToText((*slack.RichTextSection)(e))
 	case *slack.RichTextPreformatted:
 		return richTextSectionToText(&e.RichTextSection)
+	}
+	return ""
+}
+
+func formatEmailUser(u slack.EmailFileUserInfo) string {
+	addr := strings.ReplaceAll(u.Address, "@", " at ")
+	if u.Name != "" && addr != "" {
+		return u.Name + " - " + addr
+	} else if u.Name != "" {
+		return u.Name
+	} else if addr != "" {
+		return addr
 	}
 	return ""
 }

--- a/pkg/text/text_processor_test.go
+++ b/pkg/text/text_processor_test.go
@@ -769,3 +769,153 @@ func TestProcessText_PreservesContent(t *testing.T) {
 		})
 	}
 }
+func TestFilesToText(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []slack.File
+		want  string
+	}{
+		{
+			name:  "empty files",
+			files: nil,
+			want:  "",
+		},
+		{
+			// Covers: non-email filtering, From name+address, CC name+address,
+			// CC address-only, "/" separator, "@" → "at" conversion, Subject
+			name: "extracts email metadata and skips non-email files",
+			files: []slack.File{
+				{Filetype: "pdf", Title: "report.pdf"},
+				{
+					Filetype: "email",
+					Subject:  "Team Update",
+					From: []slack.EmailFileUserInfo{
+						{Name: "Alice", Address: "alice@example.com"},
+					},
+					Cc: []slack.EmailFileUserInfo{
+						{Name: "Bob Smith", Address: "bob@example.com"},
+						{Address: "carol@example.com"},
+					},
+				},
+				{Filetype: "png", Title: "chart.png"},
+			},
+			want: "Email, From: Alice - alice at example.com, CC: Bob Smith - bob at example.com/carol at example.com, Subject: Team Update",
+		},
+		{
+			name: "from with name only",
+			files: []slack.File{
+				{
+					Filetype: "email",
+					Subject:  "Test",
+					From: []slack.EmailFileUserInfo{
+						{Name: "Support Team"},
+					},
+				},
+			},
+			want: "Email, From: Support Team, Subject: Test",
+		},
+		{
+			name: "from with address only",
+			files: []slack.File{
+				{
+					Filetype: "email",
+					Subject:  "Test",
+					From: []slack.EmailFileUserInfo{
+						{Address: "noreply@example.com"},
+					},
+				},
+			},
+			want: "Email, From: noreply at example.com, Subject: Test",
+		},
+		{
+			// Covers: Mode-based detection and Title → Subject fallback
+			name: "mode detection with title fallback",
+			files: []slack.File{
+				{Mode: "email", Title: "Fwd: Hello"},
+			},
+			want: "Email, Subject: Fwd: Hello",
+		},
+		{
+			name: "multiple email files",
+			files: []slack.File{
+				{Filetype: "email", Subject: "First"},
+				{Filetype: "email", Subject: "Second"},
+			},
+			want: "Email, Subject: First Email, Subject: Second",
+		},
+		{
+			name: "empty from and cc entries skipped",
+			files: []slack.File{
+				{
+					Filetype: "email",
+					Subject:  "Newsletter",
+					From:     []slack.EmailFileUserInfo{{Name: "", Address: ""}},
+					Cc:       []slack.EmailFileUserInfo{{Name: "", Address: ""}},
+				},
+			},
+			want: "Email, Subject: Newsletter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilesToText(tt.files)
+			if got != tt.want {
+				t.Errorf("FilesToText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFilesToTextProcessTextPipeline verifies that FilesToText output
+// survives the ProcessText pipeline (filterSpecialChars) without losing structure.
+func TestFilesToTextProcessTextPipeline(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []slack.File
+		want  string
+	}{
+		{
+			// Covers: format survival, unicode \p{L}\p{M}, CC "/" separator
+			name: "format with unicode and cc survives",
+			files: []slack.File{
+				{
+					Filetype: "email",
+					Subject:  "R\u00e9union g\u00e9n\u00e9rale",
+					From: []slack.EmailFileUserInfo{
+						{Name: "Ren\u00e9 M\u00fcller", Address: "rene@example.com"},
+					},
+					Cc: []slack.EmailFileUserInfo{
+						{Address: "bob@example.com"},
+					},
+				},
+			},
+			want: "Email, From: Ren\u00e9 M\u00fcller - rene at example.com, CC: bob at example.com, Subject: R\u00e9union g\u00e9n\u00e9rale",
+		},
+		{
+			// Covers: punctuation preserved post-#281; URL preserved by placeholder mechanism
+			name: "punctuation preserved and URL preserved",
+			files: []slack.File{
+				{
+					Filetype: "email",
+					Subject:  "[Alert] $100 payment - https://example.com/invoice?id=42",
+					From: []slack.EmailFileUserInfo{
+						{Name: "Billing", Address: "billing@example.com"},
+					},
+				},
+			},
+			want: "Email, From: Billing - billing at example.com, Subject: [Alert] $100 payment - https://example.com/invoice?id=42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := FilesToText(tt.files)
+			got := ProcessText(raw)
+			if got != tt.want {
+				t.Errorf("ProcessText(FilesToText()) = %q, want %q\n  raw = %q", got, tt.want, raw)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary

- Add `FilesToText()` to extract email metadata (From, CC, Subject) from `files[]` when `msg.Text` is empty
- Email messages forwarded to Slack channels store content in `files[]` with `filetype: "email"`, resulting in completely empty text output — this PR fills that gap

Ref #191 (partial fix — metadata only; email body requires upstream dependency update)

## Before / After

### Slack API response (forwarded email)

```json
{
  "text": "",
  "files": [{
    "filetype": "email",
    "subject": "Meeting Tomorrow",
    "from": [{"name": "John Doe", "address": "john@example.com"}],
    "cc": [{"address": "team@example.com"}]
  }]
}
```

### conversations_history CSV output

**Before:**
```csv
MsgID,UserID,UserName,RealName,Channel,ThreadTs,Text,Time,BotName,Cursor
1770523338.574369,USLACKBOT,Email,Email,C001,,,2026-02-08T04:02:18Z,Email,
```

**After:**
```csv
MsgID,UserID,UserName,RealName,Channel,ThreadTs,Text,Time,BotName,Cursor
1770523338.574369,USLACKBOT,Email,Email,C001,,Email, From: John Doe - john at example.com, CC: team at example.com, Subject: Meeting Tomorrow,2026-02-08T04:02:18Z,Email,
```

## Design decisions

- **Format separators** chosen to survive `filterSpecialChars` (`,` instead of `;`, ` at ` instead of `@`, `/` between CC recipients)
- **`To` / `BCC` omitted** — `To` contains Slack internal routing addresses (e.g. `Email <>`); `BCC` is not included in the Slack API response
- **Email body not included** — the `slack-go/slack` `File` struct does not yet map the `plain_text` field; this will be possible after slack-go/slack#1522 is released (see #191 for details)
- **`conversations_search` not covered** — Slack's `SearchMessage` type has no `Files` field; only `conversations_history` and `conversations_replies` are supported

## Conflict with #190

This PR conflicts with #190 (Block Kit text extraction) at `conversations.go` L702, since both modify the same fallback logic. The resolution is to chain the fallbacks:

```go
msgText := msg.Text
if msgText == "" {
    msgText = text.BlocksToText(msg.Blocks)   // #190
}
if msgText == "" {
    msgText = text.FilesToText(msg.Files)      // this PR
}
msgText += text.AttachmentsTo2CSV(msgText, msg.Attachments)
```

Whichever PR merges first, the other can be rebased with this 3-line addition.

## Test plan

- [x] 7 unit tests for `FilesToText` (filtering, all field combinations, edge cases)
- [x] 2 pipeline tests verifying output survives `ProcessText`/`filterSpecialChars`
- [x] Verified against real Slack email messages (with/without CC, with attachments, with inline images)