### PR TITLE
feat: add IsMember, HasUnreads, LastRead, MentionCount to channel list Description:

### DIFF
--- a/pkg/handler/channels.go
+++ b/pkg/handler/channels.go
@@ -16,12 +16,16 @@ import (
 )
 
 type Channel struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Topic       string `json:"topic"`
-	Purpose     string `json:"purpose"`
-	MemberCount int    `json:"memberCount"`
-	Cursor      string `json:"cursor"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Topic        string `json:"topic"`
+	Purpose      string `json:"purpose"`
+	MemberCount  int    `json:"memberCount"`
+	IsMember     bool   `json:"isMember"`
+	HasUnreads   bool   `json:"hasUnreads"`
+	LastRead     string `json:"lastRead"`
+	MentionCount int    `json:"mentionCount"`
+	Cursor       string `json:"cursor"`
 }
 
 type ChannelsHandler struct {
@@ -79,11 +83,15 @@ func (ch *ChannelsHandler) ChannelsResource(ctx context.Context, request mcp.Rea
 
 	for _, channel := range channels {
 		channelList = append(channelList, Channel{
-			ID:          channel.ID,
-			Name:        channel.Name,
-			Topic:       channel.Topic,
-			Purpose:     channel.Purpose,
-			MemberCount: channel.MemberCount,
+			ID:           channel.ID,
+			Name:         channel.Name,
+			Topic:        channel.Topic,
+			Purpose:      channel.Purpose,
+			MemberCount:  channel.MemberCount,
+			IsMember:     channel.IsMember,
+			HasUnreads:   channel.HasUnreads,
+			LastRead:     channel.LastRead,
+			MentionCount: channel.MentionCount,
 		})
 	}
 
@@ -177,11 +185,15 @@ func (ch *ChannelsHandler) ChannelsHandler(ctx context.Context, request mcp.Call
 
 	for _, channel := range chans {
 		channelList = append(channelList, Channel{
-			ID:          channel.ID,
-			Name:        channel.Name,
-			Topic:       channel.Topic,
-			Purpose:     channel.Purpose,
-			MemberCount: channel.MemberCount,
+			ID:           channel.ID,
+			Name:         channel.Name,
+			Topic:        channel.Topic,
+			Purpose:      channel.Purpose,
+			MemberCount:  channel.MemberCount,
+			IsMember:     channel.IsMember,
+			HasUnreads:   channel.HasUnreads,
+			LastRead:     channel.LastRead,
+			MentionCount: channel.MentionCount,
 		})
 	}
 

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -41,20 +41,20 @@ var validFilterKeys = map[string]struct{}{
 }
 
 type Message struct {
-	MsgID     string `json:"msgID"`
-	UserID    string `json:"userID"`
-	UserName  string `json:"userUser"`
-	RealName  string `json:"realName"`
-	Channel   string `json:"channelID"`
-	ThreadTs  string `json:"ThreadTs"`
-	Text      string `json:"text"`
-	Time      string `json:"time"`
-	Reactions string `json:"reactions,omitempty"`
-	BotName   string `json:"botName,omitempty"`
-	FileCount int    `json:"fileCount,omitempty"`
-	AttachmentIDs   string `json:"attachmentIDs,omitempty"`
-	HasMedia  bool   `json:"hasMedia,omitempty"`
-	Cursor    string `json:"cursor"`
+	MsgID         string `json:"msgID"`
+	UserID        string `json:"userID"`
+	UserName      string `json:"userUser"`
+	RealName      string `json:"realName"`
+	Channel       string `json:"channelID"`
+	ThreadTs      string `json:"ThreadTs"`
+	Text          string `json:"text"`
+	Time          string `json:"time"`
+	Reactions     string `json:"reactions,omitempty"`
+	BotName       string `json:"botName,omitempty"`
+	FileCount     int    `json:"fileCount,omitempty"`
+	AttachmentIDs string `json:"attachmentIDs,omitempty"`
+	HasMedia      bool   `json:"hasMedia,omitempty"`
+	Cursor        string `json:"cursor"`
 }
 
 type User struct {
@@ -722,19 +722,19 @@ func (ch *ConversationsHandler) convertMessagesFromHistory(slackMessages []slack
 		attachmentIDsStr := strings.Join(attachmentIDs, ",")
 
 		messages = append(messages, Message{
-			MsgID:     msg.Timestamp,
-			UserID:    msg.User,
-			UserName:  userName,
-			RealName:  realName,
-			Text:      text.ProcessText(msgText),
-			Channel:   channel,
-			ThreadTs:  msg.ThreadTimestamp,
-			Time:      timestamp,
-			Reactions: reactionsString,
-			BotName:   botName,
-			FileCount: fileCount,
-			AttachmentIDs:   attachmentIDsStr,
-			HasMedia:  hasMedia,
+			MsgID:         msg.Timestamp,
+			UserID:        msg.User,
+			UserName:      userName,
+			RealName:      realName,
+			Text:          text.ProcessText(msgText),
+			Channel:       channel,
+			ThreadTs:      msg.ThreadTimestamp,
+			Time:          timestamp,
+			Reactions:     reactionsString,
+			BotName:       botName,
+			FileCount:     fileCount,
+			AttachmentIDs: attachmentIDsStr,
+			HasMedia:      hasMedia,
 		})
 	}
 

--- a/pkg/provider/cache_test.go
+++ b/pkg/provider/cache_test.go
@@ -256,12 +256,12 @@ func TestChannelIDPatterns(t *testing.T) {
 		channel string
 		needs   bool
 	}{
-		{"C1234567890", false},  // Standard channel ID
-		{"G1234567890", false},  // Private channel ID (legacy)
-		{"D1234567890", false},  // DM ID
-		{"#general", true},      // Channel name - needs lookup
-		{"@john.doe", true},     // User DM name - needs lookup
-		{"", false},             // Empty - no lookup
+		{"C1234567890", false}, // Standard channel ID
+		{"G1234567890", false}, // Private channel ID (legacy)
+		{"D1234567890", false}, // DM ID
+		{"#general", true},     // Channel name - needs lookup
+		{"@john.doe", true},    // User DM name - needs lookup
+		{"", false},            // Empty - no lookup
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Adds richer channel metadata to the channels list so MCP clients can show membership, unread state, and mention counts.

## Changes
- **Channel struct** (provider): New fields `IsMember`, `HasUnreads`, `LastRead`, `MentionCount`.
- **channels_list handler**: Returns the new fields in the channel list response.
- **conversations handlers**: Message/channel responses keep the same structure; new fields are populated where the data source provides them.
- **Provider**: For browser/edge clients, unread data is filled from the edge `ClientCounts` API; for OAuth/bot tokens without edge, the new fields stay false/zero.

## Rationale
Clients (e.g. Cursor, IDEs) can use this to:
- Show which channels the user is in (`IsMember`).
- Highlight channels with unread messages (`HasUnreads`, `MentionCount`).
- Order or filter by last read time (`LastRead`).

Backward compatible: new fields are additive; existing clients can ignore them.