### PR TITLE
Allow to filter out users_search tool via enabled-tools

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,7 @@ const (
 	ToolUsergroupsCreate            = "usergroups_create"
 	ToolUsergroupsUpdate            = "usergroups_update"
 	ToolUsergroupsUsersUpdate       = "usergroups_users_update"
+	ToolUsersSearch                 = "users_search"
 )
 
 var ValidToolNames = []string{
@@ -58,6 +59,7 @@ var ValidToolNames = []string{
 	ToolUsergroupsCreate,
 	ToolUsergroupsUpdate,
 	ToolUsergroupsUsersUpdate,
+	ToolUsersSearch,
 }
 
 func ValidateEnabledTools(tools []string) error {
@@ -282,19 +284,21 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 		s.AddTool(conversationsSearchTool, conversationsHandler.ConversationsSearchHandler)
 	}
 
-	s.AddTool(mcp.NewTool("users_search",
-		mcp.WithDescription("Search for users by name, email, or display name. Returns user details and DM channel ID if available."),
-		mcp.WithTitleAnnotation("Search Users"),
-		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithString("query",
-			mcp.Required(),
-			mcp.Description("Search query - matches against real name, display name, username, or email."),
-		),
-		mcp.WithNumber("limit",
-			mcp.DefaultNumber(10),
-			mcp.Description("Maximum number of results to return (1-100). Default is 10."),
-		),
-	), conversationsHandler.UsersSearchHandler)
+	if shouldAddTool(ToolUsersSearch, enabledTools, "") {
+		s.AddTool(mcp.NewTool(ToolUsersSearch,
+			mcp.WithDescription("Search for users by name, email, or display name. Returns user details and DM channel ID if available."),
+			mcp.WithTitleAnnotation("Search Users"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithString("query",
+				mcp.Required(),
+				mcp.Description("Search query - matches against real name, display name, username, or email."),
+			),
+			mcp.WithNumber("limit",
+				mcp.DefaultNumber(10),
+				mcp.Description("Maximum number of results to return (1-100). Default is 10."),
+			),
+		), conversationsHandler.UsersSearchHandler)
+	}
 
 	// Register unreads tool - gets all unread messages across channels efficiently.
 	// Bot tokens (xoxb) don't support unread tracking, so exclude them (same pattern as search tool).

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -24,6 +24,7 @@ func TestShouldAddTool_ReadOnly_EmptyEnabledTools(t *testing.T) {
 			ToolConversationsReplies,
 			ToolConversationsSearchMessages,
 			ToolChannelsList,
+			ToolUsersSearch,
 		}
 		for _, tool := range readOnlyTools {
 			result := shouldAddTool(tool, []string{}, "")
@@ -108,6 +109,7 @@ func TestValidToolNames(t *testing.T) {
 			ToolUsergroupsCreate:            true,
 			ToolUsergroupsUpdate:            true,
 			ToolUsergroupsUsersUpdate:       true,
+			ToolUsersSearch:                 true,
 		}
 
 		assert.Equal(t, len(expectedTools), len(ValidToolNames), "ValidToolNames should have %d tools", len(expectedTools))
@@ -133,6 +135,7 @@ func TestValidToolNames(t *testing.T) {
 		assert.Equal(t, "usergroups_create", ToolUsergroupsCreate)
 		assert.Equal(t, "usergroups_update", ToolUsergroupsUpdate)
 		assert.Equal(t, "usergroups_users_update", ToolUsergroupsUsersUpdate)
+		assert.Equal(t, "users_search", ToolUsersSearch)
 	})
 }
 


### PR DESCRIPTION
Hi,

[v1.2.2](https://github.com/korotovsky/slack-mcp-server/releases/tag/v1.2.2) introduced great feature to filter tools via `SLACK_MCP_ENABLED_TOOLS`.

However, it seems `users_search` tool is enabled anyways because it's missing `shouldAddTool` condition.

Since the tool is always enabled, it errors in case token is missing [search:read.users](https://api.slack.com/scopes/search:read.users) scope ... and agents like to use it ofc.

That's why I'd like to propose to add possibility to filter it out the same way as it is for other tools.

Thanks :)