### PR TITLE
Add delete, update, and open conversation tools

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -285,6 +285,143 @@ func (ch *ConversationsHandler) ConversationsAddMessageHandler(ctx context.Conte
 	return marshalMessagesToCSV(messages)
 }
 
+// ConversationsDeleteMessageHandler deletes a message
+func (ch *ConversationsHandler) ConversationsDeleteMessageHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsDeleteMessageHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	channelRaw := request.GetString("channel_id", "")
+	if channelRaw == "" {
+		return nil, errors.New("channel_id is required")
+	}
+	channel, err := ch.resolveChannelID(ctx, channelRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve channel_id: %w", err)
+	}
+
+	timestamp := request.GetString("timestamp", "")
+	if timestamp == "" {
+		return nil, errors.New("timestamp is required")
+	}
+
+	_, _, err = ch.apiProvider.Slack().DeleteMessage(channel, timestamp)
+	if err != nil {
+		ch.logger.Error("Slack DeleteMessage failed", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText("Message deleted successfully"), nil
+}
+
+// ConversationsUpdateMessageHandler updates an existing message
+func (ch *ConversationsHandler) ConversationsUpdateMessageHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsUpdateMessageHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	channelRaw := request.GetString("channel_id", "")
+	if channelRaw == "" {
+		return nil, errors.New("channel_id is required")
+	}
+	channel, err := ch.resolveChannelID(ctx, channelRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve channel_id: %w", err)
+	}
+
+	timestamp := request.GetString("timestamp", "")
+	if timestamp == "" {
+		return nil, errors.New("timestamp is required")
+	}
+
+	msgText := request.GetString("text", "")
+	if msgText == "" {
+		return nil, errors.New("text is required")
+	}
+
+	contentType := request.GetString("content_type", "text/markdown")
+
+	var options []slack.MsgOption
+	switch contentType {
+	case "text/plain":
+		options = append(options, slack.MsgOptionDisableMarkdown())
+		options = append(options, slack.MsgOptionText(msgText, false))
+	case "text/markdown":
+		blocks, err := slackGoUtil.ConvertMarkdownTextToBlocks(msgText)
+		if err != nil {
+			ch.logger.Warn("Markdown parsing error", zap.Error(err))
+			options = append(options, slack.MsgOptionDisableMarkdown())
+			options = append(options, slack.MsgOptionText(msgText, false))
+		} else {
+			options = append(options, slack.MsgOptionBlocks(blocks...))
+		}
+	default:
+		return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")
+	}
+
+	respChannel, respTimestamp, _, err := ch.apiProvider.Slack().UpdateMessage(channel, timestamp, options...)
+	if err != nil {
+		ch.logger.Error("Slack UpdateMessage failed", zap.Error(err))
+		return nil, err
+	}
+
+	// fetch the updated message
+	historyParams := slack.GetConversationHistoryParameters{
+		ChannelID: respChannel,
+		Limit:     1,
+		Oldest:    respTimestamp,
+		Latest:    respTimestamp,
+		Inclusive: true,
+	}
+	history, err := ch.apiProvider.Slack().GetConversationHistoryContext(ctx, &historyParams)
+	if err != nil {
+		ch.logger.Error("GetConversationHistoryContext failed", zap.Error(err))
+		return nil, err
+	}
+
+	messages := ch.convertMessagesFromHistory(history.Messages, historyParams.ChannelID, false)
+	return marshalMessagesToCSV(messages)
+}
+
+// ConversationsOpenHandler opens or resumes a DM or group DM
+func (ch *ConversationsHandler) ConversationsOpenHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsOpenHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	usersRaw := request.GetString("users", "")
+	if usersRaw == "" {
+		return nil, errors.New("users is required")
+	}
+
+	userIDs := strings.Split(usersRaw, ",")
+	for i := range userIDs {
+		userIDs[i] = strings.TrimSpace(userIDs[i])
+	}
+
+	params := &slack.OpenConversationParameters{
+		Users: userIDs,
+	}
+
+	channel, _, _, err := ch.apiProvider.Slack().OpenConversation(params)
+	if err != nil {
+		ch.logger.Error("Slack OpenConversation failed", zap.Error(err))
+		return nil, err
+	}
+
+	result := fmt.Sprintf("channel_id: %s\nchannel_name: %s\nis_group: %t", channel.ID, channel.Name, channel.IsGroup)
+	return mcp.NewToolResultText(result), nil
+}
+
 // ReactionsAddHandler adds an emoji reaction to a message
 func (ch *ConversationsHandler) ReactionsAddHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	ch.logger.Debug("ReactionsAddHandler called", zap.Any("params", request.Params))

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -213,6 +213,11 @@ type SlackAPI interface {
 	ClientCounts(ctx context.Context) (edge.ClientCountsResponse, error)
 	GetMutedChannels(ctx context.Context) (map[string]bool, error)
 
+	// Message management methods
+	DeleteMessage(channel, messageTimestamp string) (string, string, error)
+	UpdateMessage(channelID, timestamp string, options ...slack.MsgOption) (string, string, string, error)
+	OpenConversation(params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
+
 	// User groups API methods
 	GetUserGroupsContext(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error)
 	GetUserGroupMembersContext(ctx context.Context, userGroup string, options ...slack.GetUserGroupMembersOption) ([]string, error)
@@ -479,6 +484,18 @@ func (c *MCPSlackClient) AddReactionContext(ctx context.Context, name string, it
 
 func (c *MCPSlackClient) RemoveReactionContext(ctx context.Context, name string, item slack.ItemRef) error {
 	return c.slackClient.RemoveReactionContext(ctx, name, item)
+}
+
+func (c *MCPSlackClient) DeleteMessage(channel, messageTimestamp string) (string, string, error) {
+	return c.slackClient.DeleteMessage(channel, messageTimestamp)
+}
+
+func (c *MCPSlackClient) UpdateMessage(channelID, timestamp string, options ...slack.MsgOption) (string, string, string, error) {
+	return c.slackClient.UpdateMessage(channelID, timestamp, options...)
+}
+
+func (c *MCPSlackClient) OpenConversation(params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+	return c.slackClient.OpenConversation(params)
 }
 
 func (c *MCPSlackClient) GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*slack.File, []slack.Comment, *slack.Paging, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -41,6 +41,9 @@ const (
 	ToolUsergroupsUpdate            = "usergroups_update"
 	ToolUsergroupsUsersUpdate       = "usergroups_users_update"
 	ToolUsersSearch                 = "users_search"
+	ToolConversationsDeleteMessage  = "conversations_delete_message"
+	ToolConversationsUpdateMessage  = "conversations_update_message"
+	ToolConversationsOpen           = "conversations_open"
 )
 
 var ValidToolNames = []string{
@@ -60,6 +63,9 @@ var ValidToolNames = []string{
 	ToolUsergroupsUpdate,
 	ToolUsergroupsUsersUpdate,
 	ToolUsersSearch,
+	ToolConversationsDeleteMessage,
+	ToolConversationsUpdateMessage,
+	ToolConversationsOpen,
 }
 
 func ValidateEnabledTools(tools []string) error {
@@ -184,6 +190,57 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'."),
 			),
 		), conversationsHandler.ConversationsAddMessageHandler)
+	}
+
+	if shouldAddTool(ToolConversationsDeleteMessage, enabledTools, "SLACK_MCP_DELETE_MESSAGE_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsDeleteMessage,
+			mcp.WithDescription("Delete a message from a public channel, private channel, or direct message (DM, or IM) conversation. Only messages posted by the authenticated user (or bot) can be deleted."),
+			mcp.WithTitleAnnotation("Delete Message"),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
+			),
+			mcp.WithString("timestamp",
+				mcp.Required(),
+				mcp.Description("Timestamp of the message to delete, in format 1234567890.123456."),
+			),
+		), conversationsHandler.ConversationsDeleteMessageHandler)
+	}
+
+	if shouldAddTool(ToolConversationsUpdateMessage, enabledTools, "SLACK_MCP_UPDATE_MESSAGE_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsUpdateMessage,
+			mcp.WithDescription("Update (edit) an existing message in a public channel, private channel, or direct message (DM, or IM) conversation. Only messages posted by the authenticated user (or bot) can be updated."),
+			mcp.WithTitleAnnotation("Update Message"),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
+			),
+			mcp.WithString("timestamp",
+				mcp.Required(),
+				mcp.Description("Timestamp of the message to update, in format 1234567890.123456."),
+			),
+			mcp.WithString("text",
+				mcp.Required(),
+				mcp.Description("New message text in specified content_type format."),
+			),
+			mcp.WithString("content_type",
+				mcp.DefaultString("text/markdown"),
+				mcp.Description("Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'."),
+			),
+		), conversationsHandler.ConversationsUpdateMessageHandler)
+	}
+
+	if shouldAddTool(ToolConversationsOpen, enabledTools, "SLACK_MCP_OPEN_CONVERSATION_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsOpen,
+			mcp.WithDescription("Open or resume a direct message (DM) or group direct message (group DM) conversation. Use this to create a new DM or group DM, or to get the channel ID for an existing one. Returns the conversation's channel ID which can be used with other tools."),
+			mcp.WithTitleAnnotation("Open Conversation"),
+			mcp.WithString("users",
+				mcp.Required(),
+				mcp.Description("Comma-separated list of user IDs (e.g., 'U1234567890,U9876543210'). One user ID for a DM, multiple for a group DM."),
+			),
+		), conversationsHandler.ConversationsOpenHandler)
 	}
 
 	if shouldAddTool(ToolReactionsAdd, enabledTools, "SLACK_MCP_REACTION_TOOL") {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -110,6 +110,9 @@ func TestValidToolNames(t *testing.T) {
 			ToolUsergroupsUpdate:            true,
 			ToolUsergroupsUsersUpdate:       true,
 			ToolUsersSearch:                 true,
+			ToolConversationsDeleteMessage:  true,
+			ToolConversationsUpdateMessage:  true,
+			ToolConversationsOpen:           true,
 		}
 
 		assert.Equal(t, len(expectedTools), len(ValidToolNames), "ValidToolNames should have %d tools", len(expectedTools))
@@ -136,6 +139,9 @@ func TestValidToolNames(t *testing.T) {
 		assert.Equal(t, "usergroups_update", ToolUsergroupsUpdate)
 		assert.Equal(t, "usergroups_users_update", ToolUsergroupsUsersUpdate)
 		assert.Equal(t, "users_search", ToolUsersSearch)
+		assert.Equal(t, "conversations_delete_message", ToolConversationsDeleteMessage)
+		assert.Equal(t, "conversations_update_message", ToolConversationsUpdateMessage)
+		assert.Equal(t, "conversations_open", ToolConversationsOpen)
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds three new message management tools that are commonly needed for conversational AI workflows:

- **`conversations_delete_message`** — Delete messages via `chat.delete` API
- **`conversations_update_message`** — Edit existing messages via `chat.update` API (supports markdown and plain text)
- **`conversations_open`** — Open or resume DMs and group DMs via `conversations.open` API, returning the channel ID

All three follow the existing safety pattern — gated behind environment variables (`SLACK_MCP_DELETE_MESSAGE_TOOL`, `SLACK_MCP_UPDATE_MESSAGE_TOOL`, `SLACK_MCP_OPEN_CONVERSATION_TOOL`) so they're disabled by default.

### Motivation

These are frequently needed operations when using Slack MCP from AI assistants:
- **Delete**: Correct mistakes, clean up duplicate messages
- **Update**: Edit messages instead of deleting and reposting
- **Open conversation**: Create group DMs programmatically without needing to know channel IDs in advance

### Changes

| File | Change |
|---|---|
| `pkg/server/server.go` | Tool constants, registration with env var gates |
| `pkg/handler/conversations.go` | Three new handler methods |
| `pkg/provider/api.go` | Interface + `MCPSlackClient` delegation methods |
| `pkg/server/server_test.go` | Updated `TestValidToolNames` for new tools |

### Environment variables

| Variable | Default | Description |
|---|---|---|
| `SLACK_MCP_DELETE_MESSAGE_TOOL` | disabled | Set to enable `conversations_delete_message` |
| `SLACK_MCP_UPDATE_MESSAGE_TOOL` | disabled | Set to enable `conversations_update_message` |
| `SLACK_MCP_OPEN_CONVERSATION_TOOL` | disabled | Set to enable `conversations_open` |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/server/ ./pkg/provider/ ./pkg/limiter/ ./pkg/text/` passes
- [ ] Integration test with real Slack workspace (delete, update, open group DM)
