### PR TITLE
feat: add channels_starred tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,18 @@ Get list of channels
   - `limit` (number, default: 100): The maximum number of items to return. Must be an integer between 1 and 1000 (maximum 999).
   - `cursor` (string, optional): Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request.
 
-### 6. reactions_add:
+### 6. channels_starred:
+List channels and DMs that the user has starred (saved/bookmarked). Returns a curated subset of all channels — useful for focused workflows that only care about high-priority channels.
+
+> **Note:** This tool is not available when using bot tokens (`xoxb-*`). With browser session tokens (`xoxc`/`xoxd`), it uses the efficient `client.userBoot` API. With OAuth tokens (`xoxp`), it uses the `stars.list` API.
+
+- **Parameters:**
+  - `channel_types` (string, default: "all"): Filter by channel type: `all`, `dm` (direct messages), `group_dm` (group DMs), `partner` (ext-shared channels), `internal` (regular workspace channels).
+  - `limit` (number, default: 100): Maximum number of starred channels to return (1-1000).
+
+- **Returns:** CSV with fields: `channel_id`, `channel_name`, `channel_type`, `is_muted`, `member_count`
+
+### 7. reactions_add:
 Add an emoji reaction to a message in a public channel, private channel, or direct message (DM, or IM) conversation.
 
 > **Note:** Adding reactions is disabled by default for safety. To enable, set the `SLACK_MCP_ADD_MESSAGE_TOOL` environment variable. If set to a comma-separated list of channel IDs, reactions are enabled only for those specific channels. See the Environment Variables section below for details.
@@ -95,7 +106,7 @@ Add an emoji reaction to a message in a public channel, private channel, or dire
   - `timestamp` (string, required): Timestamp of the message to add reaction to, in format `1234567890.123456`.
   - `emoji` (string, required): The name of the emoji to add as a reaction (without colons). Example: `thumbsup`, `heart`, `rocket`.
 
-### 7. reactions_remove:
+### 8. reactions_remove:
 Remove an emoji reaction from a message in a public channel, private channel, or direct message (DM, or IM) conversation.
 
 > **Note:** Removing reactions follows the same permission model as `reactions_add`. To enable, set the `SLACK_MCP_ADD_MESSAGE_TOOL` environment variable.
@@ -105,7 +116,7 @@ Remove an emoji reaction from a message in a public channel, private channel, or
   - `timestamp` (string, required): Timestamp of the message to remove reaction from, in format `1234567890.123456`.
   - `emoji` (string, required): The name of the emoji to remove as a reaction (without colons). Example: `thumbsup`, `heart`, `rocket`.
 
-### 8. users_search:
+### 9. users_search:
 Search for users by name, email, or display name. Returns user details and DM channel ID if available.
 
 > **Note:** For OAuth tokens (`xoxp`/`xoxb`), this tool searches the local users cache using pattern matching. For browser session tokens (`xoxc`/`xoxd`), it uses the Slack edge API for real-time search.
@@ -123,7 +134,7 @@ Search for users by name, email, or display name. Returns user details and DM ch
   - `Title`: User's job title
   - `DMChannelID`: DM channel ID if available in cache (for quick messaging)
 
-### 9. usergroups_list:
+### 10. usergroups_list:
 List all user groups (subteams) in the workspace.
 
 - **Parameters:**
@@ -135,7 +146,7 @@ List all user groups (subteams) in the workspace.
 
 > **Required OAuth scopes:** `usergroups:read`
 
-### 10. usergroups_create:
+### 11. usergroups_create:
 Create a new user group in the workspace.
 
 - **Parameters:**
@@ -148,7 +159,7 @@ Create a new user group in the workspace.
 
 > **Required OAuth scopes:** `usergroups:write`
 
-### 11. usergroups_update:
+### 12. usergroups_update:
 Update an existing user group's metadata.
 
 - **Parameters:**
@@ -162,7 +173,7 @@ Update an existing user group's metadata.
 
 > **Required OAuth scopes:** `usergroups:write`
 
-### 12. usergroups_users_update:
+### 13. usergroups_users_update:
 Update the members of a user group. This replaces all existing members.
 
 - **Parameters:**
@@ -173,7 +184,7 @@ Update the members of a user group. This replaces all existing members.
 
 > **Required OAuth scopes:** `usergroups:write`
 
-### 13. usergroups_me:
+### 14. usergroups_me:
 Manage your user group membership: list groups you're in, join a group, or leave a group.
 
 - **Parameters:**
@@ -186,7 +197,7 @@ Manage your user group membership: list groups you're in, join a group, or leave
 
 > **Required OAuth scopes:** `usergroups:read` (for list), `usergroups:read` + `usergroups:write` (for join/leave)
 
-### 14. conversations_unreads
+### 15. conversations_unreads
 Get unread messages across all channels efficiently. Uses a single API call to identify channels with unreads, then fetches only those messages. Results are prioritized: DMs > partner channels (Slack Connect) > internal channels.
 
 > **Note:** This tool works best with browser session tokens (`xoxc`/`xoxd`), which use the efficient `client.counts` API. For standard OAuth tokens (`xoxp`), a fallback method using `conversations.info` is used, which requires one API call per channel and may be slower for large workspaces. Not available with bot tokens (`xoxb`).
@@ -198,7 +209,7 @@ Get unread messages across all channels efficiently. Uses a single API call to i
   - `max_messages_per_channel` (number, default: 10): Maximum messages to fetch per channel.
   - `mentions_only` (boolean, default: false): If true, only returns channels where you have @mentions. Note: This filter only works with browser tokens; OAuth tokens will return all unread channels.
 
-### 15. conversations_mark
+### 16. conversations_mark
 Mark a channel or DM as read.
 
 > **Note:** Marking messages as read is disabled by default for safety. To enable, set the `SLACK_MCP_MARK_TOOL` environment variable to `true` or `1`. See the Environment Variables section below for details.
@@ -266,7 +277,7 @@ Fetches a CSV directory of all users in the workspace.
 | `SLACK_MCP_CHANNELS_CACHE`        | No        | `~/Library/Caches/slack-mcp-server/channels_cache_v2.json` (macOS)<br>`~/.cache/slack-mcp-server/channels_cache_v2.json` (Linux)<br>`%LocalAppData%/slack-mcp-server/channels_cache_v2.json` (Windows) | Path to the channels cache file. Used to cache Slack channel information to avoid repeated API calls on startup. |
 | `SLACK_MCP_LOG_LEVEL`             | No        | `info`                    | Log-level for stdout or stderr. Valid values are: `debug`, `info`, `warn`, `error`, `panic` and `fatal`                                                                                                                                                                                   |
 | `SLACK_MCP_GOVSLACK`              | No        | `nil`                     | Set to `true` to enable [GovSlack](https://slack.com/solutions/govslack) mode. Routes API calls to `slack-gov.com` endpoints instead of `slack.com` for FedRAMP-compliant government workspaces.                                                                                          |
-| `SLACK_MCP_ENABLED_TOOLS`         | No        | `nil`                     | Comma-separated list of tools to register. If empty, all read-only tools and usergroups tools are registered; write tools (`conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`) require their specific env var OR must be explicitly listed here. When a write tool is listed here, it's enabled without channel restrictions. Available tools: `conversations_history`, `conversations_replies`, `conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`, `conversations_search_messages`, `channels_list`, `usergroups_list`, `usergroups_me`, `usergroups_create`, `usergroups_update`, `usergroups_users_update`. |
+| `SLACK_MCP_ENABLED_TOOLS`         | No        | `nil`                     | Comma-separated list of tools to register. If empty, all read-only tools and usergroups tools are registered; write tools (`conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`) require their specific env var OR must be explicitly listed here. When a write tool is listed here, it's enabled without channel restrictions. Available tools: `conversations_history`, `conversations_replies`, `conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`, `conversations_search_messages`, `channels_list`, `channels_starred`, `usergroups_list`, `usergroups_me`, `usergroups_create`, `usergroups_update`, `usergroups_users_update`. |
 
 *You need one of: `xoxp` (user), `xoxb` (bot), or both `xoxc`/`xoxd` tokens for authentication.
 

--- a/pkg/handler/channels.go
+++ b/pkg/handler/channels.go
@@ -255,6 +255,113 @@ func filterChannelsByTypes(channels map[string]provider.Channel, types []string)
 	return result
 }
 
+type StarredChannel struct {
+	ChannelID   string `csv:"channel_id"`
+	ChannelName string `csv:"channel_name"`
+	ChannelType string `csv:"channel_type"` // "dm", "group_dm", "internal", "partner"
+	IsMuted     bool   `csv:"is_muted"`
+	MemberCount int    `csv:"member_count"`
+}
+
+func (ch *ChannelsHandler) ChannelsStarredHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ChannelsStarredHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	if ch.apiProvider.IsBotToken() {
+		return nil, fmt.Errorf(
+			"channels_starred requires a user token (xoxp) or browser session tokens (xoxc/xoxd); " +
+				"bot tokens (xoxb) do not support starred items",
+		)
+	}
+
+	channelTypesFilter := request.GetString("channel_types", "all")
+	limit := request.GetInt("limit", 100)
+
+	ch.logger.Debug("Request parameters",
+		zap.String("channel_types", channelTypesFilter),
+		zap.Int("limit", limit),
+	)
+
+	// Get starred channel IDs from Slack API
+	starredIDs, err := ch.apiProvider.Slack().GetStarredChannelIDs(ctx, limit)
+	if err != nil {
+		ch.logger.Error("Failed to get starred channel IDs", zap.Error(err))
+		return nil, fmt.Errorf("failed to get starred channels: %v", err)
+	}
+
+	ch.logger.Debug("Got starred channel IDs", zap.Int("count", len(starredIDs)))
+
+	// Fetch muted channels for the is_muted column
+	mutedChannels := make(map[string]bool)
+	if !ch.apiProvider.IsOAuth() {
+		mc, err := ch.apiProvider.Slack().GetMutedChannels(ctx)
+		if err != nil {
+			ch.logger.Warn("Failed to fetch muted channels, proceeding without mute info", zap.Error(err))
+		} else {
+			mutedChannels = mc
+		}
+	}
+
+	// Resolve channel details from cache
+	channelsMaps := ch.apiProvider.ProvideChannelsMaps()
+
+	var result []StarredChannel
+	for _, id := range starredIDs {
+		sc := StarredChannel{
+			ChannelID: id,
+			IsMuted:   mutedChannels[id],
+		}
+
+		if cached, ok := channelsMaps.Channels[id]; ok {
+			sc.ChannelName = cached.Name
+			sc.MemberCount = cached.MemberCount
+			sc.ChannelType = classifyChannelType(cached)
+		} else {
+			// Channel not in cache — use ID as name, type unknown
+			sc.ChannelName = id
+			sc.ChannelType = "internal"
+		}
+
+		// Apply channel_types filter
+		if channelTypesFilter != "all" && sc.ChannelType != channelTypesFilter {
+			continue
+		}
+
+		result = append(result, sc)
+		if len(result) >= limit {
+			break
+		}
+	}
+
+	ch.logger.Debug("Returning starred channels", zap.Int("count", len(result)))
+
+	csvBytes, err := gocsv.MarshalBytes(&result)
+	if err != nil {
+		ch.logger.Error("Failed to marshal starred channels to CSV", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(csvBytes)), nil
+}
+
+// classifyChannelType returns "dm", "group_dm", "partner", or "internal" for a cached channel.
+func classifyChannelType(ch provider.Channel) string {
+	if ch.IsIM {
+		return "dm"
+	}
+	if ch.IsMpIM {
+		return "group_dm"
+	}
+	if ch.IsExtShared {
+		return "partner"
+	}
+	return "internal"
+}
+
 func paginateChannels(channels []provider.Channel, cursor string, limit int) ([]provider.Channel, string) {
 	logger := zap.L()
 

--- a/pkg/handler/channels_test.go
+++ b/pkg/handler/channels_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/korotovsky/slack-mcp-server/pkg/provider"
 	"github.com/korotovsky/slack-mcp-server/pkg/test/util"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -134,6 +135,52 @@ func runChannelTest(t *testing.T, env *testEnv, channelType string, expectedChan
 		}
 		assert.Truef(t, found, "No row in column %q matched %q; full CSV:\n%s",
 			rule.csvFieldName, rule.csvFieldValueRE, toolOutput.String())
+	}
+}
+
+func TestUnitClassifyChannelType(t *testing.T) {
+	tests := []struct {
+		name     string
+		channel  provider.Channel
+		expected string
+	}{
+		{
+			name:     "regular public channel",
+			channel:  provider.Channel{ID: "C123", Name: "#general"},
+			expected: "internal",
+		},
+		{
+			name:     "private channel",
+			channel:  provider.Channel{ID: "C456", Name: "#secret", IsPrivate: true},
+			expected: "internal",
+		},
+		{
+			name:     "DM channel",
+			channel:  provider.Channel{ID: "D123", Name: "@alice", IsIM: true},
+			expected: "dm",
+		},
+		{
+			name:     "group DM",
+			channel:  provider.Channel{ID: "G123", Name: "mpdm-alice-bob", IsMpIM: true},
+			expected: "group_dm",
+		},
+		{
+			name:     "external shared channel",
+			channel:  provider.Channel{ID: "C789", Name: "#ext-partner", IsExtShared: true},
+			expected: "partner",
+		},
+		{
+			name:     "ext shared takes precedence over private",
+			channel:  provider.Channel{ID: "C999", Name: "#ext-priv", IsPrivate: true, IsExtShared: true},
+			expected: "partner",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyChannelType(tt.channel)
+			assert.Equal(t, tt.expected, got)
+		})
 	}
 }
 

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -213,6 +213,9 @@ type SlackAPI interface {
 	ClientCounts(ctx context.Context) (edge.ClientCountsResponse, error)
 	GetMutedChannels(ctx context.Context) (map[string]bool, error)
 
+	// Stars API methods
+	GetStarredChannelIDs(ctx context.Context, limit int) ([]string, error)
+
 	// User groups API methods
 	GetUserGroupsContext(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error)
 	GetUserGroupMembersContext(ctx context.Context, userGroup string, options ...slack.GetUserGroupMembersOption) ([]string, error)
@@ -507,6 +510,43 @@ func (c *MCPSlackClient) ClientCounts(ctx context.Context) (edge.ClientCountsRes
 
 func (c *MCPSlackClient) GetMutedChannels(ctx context.Context) (map[string]bool, error) {
 	return c.edgeClient.GetMutedChannels(ctx)
+}
+
+func (c *MCPSlackClient) GetStarredChannelIDs(ctx context.Context, limit int) ([]string, error) {
+	if c.isOAuth {
+		// xoxp tokens: use stars.list standard API and filter for channel-like items
+		params := slack.StarsParameters{
+			Count: limit,
+			Page:  1,
+		}
+		items, _, err := c.slackClient.ListStarsContext(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		var channelIDs []string
+		for _, item := range items {
+			switch item.Type {
+			case slack.TYPE_CHANNEL, slack.TYPE_IM, slack.TYPE_GROUP:
+				if item.Channel != "" {
+					channelIDs = append(channelIDs, item.Channel)
+				}
+			}
+		}
+		return channelIDs, nil
+	}
+
+	// xoxc/xoxd tokens: use client.userBoot which returns starred channel IDs
+	ub, err := c.edgeClient.ClientUserBoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var channelIDs []string
+	for _, item := range ub.Starred {
+		if id, ok := item.(string); ok {
+			channelIDs = append(channelIDs, id)
+		}
+	}
+	return channelIDs, nil
 }
 
 func (c *MCPSlackClient) GetUserGroupsContext(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,6 +35,7 @@ const (
 	ToolConversationsUnreads        = "conversations_unreads"
 	ToolConversationsMark           = "conversations_mark"
 	ToolChannelsList                = "channels_list"
+	ToolChannelsStarred             = "channels_starred"
 	ToolUsergroupsList              = "usergroups_list"
 	ToolUsergroupsMe                = "usergroups_me"
 	ToolUsergroupsCreate            = "usergroups_create"
@@ -54,6 +55,7 @@ var ValidToolNames = []string{
 	ToolConversationsUnreads,
 	ToolConversationsMark,
 	ToolChannelsList,
+	ToolChannelsStarred,
 	ToolUsergroupsList,
 	ToolUsergroupsMe,
 	ToolUsergroupsCreate,
@@ -372,6 +374,23 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request."),
 			),
 		), channelsHandler.ChannelsHandler)
+	}
+
+	// Starred channels tool - not available with bot tokens (starring is a user-level concept)
+	if !provider.IsBotToken() && shouldAddTool(ToolChannelsStarred, enabledTools, "") {
+		s.AddTool(mcp.NewTool(ToolChannelsStarred,
+			mcp.WithDescription("List channels and DMs that the user has starred (saved/bookmarked). Returns a curated subset of all channels — useful for focused workflows that only care about high-priority channels."),
+			mcp.WithTitleAnnotation("List Starred Channels"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithString("channel_types",
+				mcp.Description("Filter by channel type: 'all' (default), 'dm' (direct messages), 'group_dm' (group DMs), 'partner' (ext-shared channels), 'internal' (regular workspace channels)."),
+				mcp.DefaultString("all"),
+			),
+			mcp.WithNumber("limit",
+				mcp.DefaultNumber(100),
+				mcp.Description("Maximum number of starred channels to return (1-1000). Default is 100."),
+			),
+		), channelsHandler.ChannelsStarredHandler)
 	}
 
 	// User groups tools

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -104,6 +104,7 @@ func TestValidToolNames(t *testing.T) {
 			ToolConversationsUnreads:        true,
 			ToolConversationsMark:           true,
 			ToolChannelsList:                true,
+			ToolChannelsStarred:             true,
 			ToolUsergroupsList:              true,
 			ToolUsergroupsMe:                true,
 			ToolUsergroupsCreate:            true,
@@ -130,6 +131,7 @@ func TestValidToolNames(t *testing.T) {
 		assert.Equal(t, "conversations_unreads", ToolConversationsUnreads)
 		assert.Equal(t, "conversations_mark", ToolConversationsMark)
 		assert.Equal(t, "channels_list", ToolChannelsList)
+		assert.Equal(t, "channels_starred", ToolChannelsStarred)
 		assert.Equal(t, "usergroups_list", ToolUsergroupsList)
 		assert.Equal(t, "usergroups_me", ToolUsergroupsMe)
 		assert.Equal(t, "usergroups_create", ToolUsergroupsCreate)


### PR DESCRIPTION
## Summary

- Add new `channels_starred` MCP tool that returns the user's starred (saved/bookmarked) channels and DMs
- Dual API path: `client.userBoot` for browser tokens (xoxc/xoxd), `stars.list` for OAuth tokens (xoxp)
- Returns CSV with columns: `channel_id`, `channel_name`, `channel_type`, `is_muted`, `member_count`
- Supports `channel_types` filter (all/dm/group_dm/partner/internal) and `limit` parameter

## Motivation

Starred channels represent a user-curated list of high-priority channels. This tool enables attention management workflows where an LLM only needs to focus on a specific subset of channels rather than the entire workspace.

## Implementation

| Token type | API used | Notes |
|---|---|---|
| xoxc/xoxd (browser) | `client.userBoot` → `Starred` field | Single API call, returns channel IDs directly |
| xoxp (OAuth) | `stars.list` | Filters for `TYPE_CHANNEL`, `TYPE_IM`, `TYPE_GROUP` items |
| xoxb (bot) | Not supported | Starring is a user-level concept |

Follows existing codebase conventions:
- Handler on `ChannelsHandler` (same as `channels_list`)
- Registered as read-only tool, no env var gating needed
- Bot token exclusion (same pattern as `conversations_unreads`)
- CSV output via `gocsv`
- Channel type classification reuses the same "dm/group_dm/partner/internal" taxonomy as `conversations_unreads`

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go vet ./...` — no warnings
- [x] `TestUnitClassifyChannelType` — 6 test cases for channel type classification
- [x] `TestValidToolNames` — updated to include `channels_starred`
- [x] All existing unit tests still pass
- [ ] Manual testing with xoxc/xoxd tokens
- [ ] Manual testing with xoxp tokens