### PR TITLE
fix: use default Slack API URL for OAuth tokens on Enterprise Grid

### DIFF
--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -283,18 +283,6 @@ func NewMCPSlackClient(authProvider auth.Provider, logger *zap.Logger) (*MCPSlac
 		BotID:        authResp.BotID,
 	}
 
-	slackClient = slack.New(authProvider.SlackToken(),
-		slack.OptionHTTPClient(httpClient),
-		slack.OptionAPIURL(authResp.URL+"api/"),
-	)
-
-	edgeClient, err := edge.NewWithInfo(authResponse, authProvider,
-		edge.OptionHTTPClient(httpClient),
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	isEnterprise := authResp.EnterpriseID != ""
 	token := authProvider.SlackToken()
 
@@ -303,6 +291,25 @@ func NewMCPSlackClient(authProvider auth.Provider, logger *zap.Logger) (*MCPSlac
 	// isBotToken: Bot token - determines feature availability (e.g., search)
 	isOAuth := strings.HasPrefix(token, "xoxp-") || strings.HasPrefix(token, "xoxb-")
 	isBotToken := strings.HasPrefix(token, "xoxb-")
+
+	// OAuth tokens (xoxp/xoxb) must use the default Slack API URL (slack.com/api/).
+	// On Enterprise Grid workspaces, the workspace-specific URL (e.g. myorg.slack.com/api/)
+	// returns missing_scope errors for standard API methods like conversations.list.
+	// Cookie-based tokens (xoxc/xoxd) require the workspace URL for authentication.
+	slackOpts = []slack.Option{slack.OptionHTTPClient(httpClient)}
+	if !isOAuth {
+		slackOpts = append(slackOpts, slack.OptionAPIURL(authResp.URL+"api/"))
+	} else if os.Getenv("SLACK_MCP_GOVSLACK") == "true" {
+		slackOpts = append(slackOpts, slack.OptionAPIURL("https://slack-gov.com/api/"))
+	}
+	slackClient = slack.New(authProvider.SlackToken(), slackOpts...)
+
+	edgeClient, err := edge.NewWithInfo(authResponse, authProvider,
+		edge.OptionHTTPClient(httpClient),
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	return &MCPSlackClient{
 		slackClient:  slackClient,


### PR DESCRIPTION
## Summary

- On Enterprise Grid workspaces, `NewMCPSlackClient` was setting the Slack API URL to the workspace-specific endpoint (e.g. `https://myorg.slack.com/api/`) for **all** token types. This causes `missing_scope` errors for standard API methods like `conversations.list` when using OAuth tokens (`xoxp`/`xoxb`).
- Only cookie-based tokens (`xoxc`/`xoxd`) require the workspace URL. OAuth tokens must use the default `https://slack.com/api/` endpoint.
- Moves token type detection (`isOAuth`) before the Slack client is recreated so the API URL can be set conditionally.

## Root Cause

`auth.test` returns the workspace URL (e.g. `https://appfolio.slack.com/`). Line 288 unconditionally used this as the API base URL for all token types:

```go
slackClient = slack.New(authProvider.SlackToken(),
    slack.OptionHTTPClient(httpClient),
    slack.OptionAPIURL(authResp.URL+"api/"),
)
```

On Enterprise Grid, the workspace-specific endpoint rejects OAuth tokens with `missing_scope` for `conversations.list` (and likely other methods), even though the same token works fine against `slack.com/api/`.

## Fix

Set the API URL conditionally based on token type:
- **OAuth tokens (`xoxp`/`xoxb`)**: Use default `slack.com/api/` (or `slack-gov.com/api/` for GovSlack)
- **Cookie tokens (`xoxc`/`xoxd`)**: Use workspace URL as before

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] Unit tests pass (`go test ./...` — integration tests require ngrok/OpenAI keys)
- [x] Verified `conversations.list` returns `ok: true` with `xoxp` token against `slack.com/api/`
- [x] Verified `conversations.list` returns `missing_scope` with same token against `myorg.slack.com/api/`

Fixes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)