### PR TITLE
feat: return image attachments as native MCP image content

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -462,6 +462,19 @@ func (ch *ConversationsHandler) FilesGetHandler(ctx context.Context, request mcp
 	}
 
 	content := buf.Bytes()
+
+	// For image files, return as native MCP image content so the client
+	// can render them directly without base64-in-JSON overflow.
+	if isImageMimetype(fileInfo.Mimetype) {
+		imageData := base64.StdEncoding.EncodeToString(content)
+		metadata := fmt.Sprintf(`{"file_id":"%s","filename":"%s","mimetype":"%s","size":%d}`,
+			fileInfo.ID,
+			escapeJSON(fileInfo.Name),
+			escapeJSON(fileInfo.Mimetype),
+			len(content))
+		return mcp.NewToolResultImage(metadata, imageData, fileInfo.Mimetype), nil
+	}
+
 	encoding := "none"
 	var contentStr string
 
@@ -481,6 +494,10 @@ func (ch *ConversationsHandler) FilesGetHandler(ctx context.Context, request mcp
 		escapeJSON(contentStr))
 
 	return mcp.NewToolResultText(result), nil
+}
+
+func isImageMimetype(mimetype string) bool {
+	return strings.HasPrefix(mimetype, "image/")
 }
 
 func isTextMimetype(mimetype string) bool {


### PR DESCRIPTION
## Summary

- Image attachments (any `image/*` mimetype) are now returned using `mcp.NewToolResultImage` instead of embedding base64 inside a JSON text response
- File metadata (file_id, filename, mimetype, size) is included as the text component
- Non-image binary files retain the existing base64-in-text behavior
- No new dependencies; uses existing `mcp-go` SDK capability

## Problem

`attachment_get_data` returns binary files as base64-encoded strings inside a JSON text response. A typical Slack image (100-200KB) expands to 130-270KB of base64 text. This exceeds the token limits of MCP clients (e.g. Claude Code), which then save the overflow to a temp file — requiring the user to manually decode base64, write to disk, and open the image separately.

This turns a single tool call into a multi-step workaround involving bash, python, and manual file management.

## Solution

The MCP SDK already provides `NewToolResultImage(text, imageData, mimeType)` which returns images as native `ImageContent`. MCP clients that support image rendering (Claude Code, Claude Desktop) can display these directly.

For `image/*` mimetypes, the handler now returns:
- **Text content**: JSON metadata (`file_id`, `filename`, `mimetype`, `size`)
- **Image content**: the base64 image data with proper MIME type

This is a non-breaking change — text files and non-image binary files are unaffected.

## Test plan

- [x] Verified with Claude Code: `attachment_get_data` on a Slack PNG attachment now returns the image inline in a single tool call, rendered directly by the client
- [ ] Text file attachments still return as plain text (existing behavior)
- [ ] Non-image binary files still return as base64-in-text (existing behavior)

Fixes #88 (partially — improves the image attachment experience specifically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)