### PR TITLE
docs: fix incorrect env var references for reactions and add missing tool env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Get list of channels
 ### 6. reactions_add:
 Add an emoji reaction to a message in a public channel, private channel, or direct message (DM, or IM) conversation.
 
-> **Note:** Adding reactions is disabled by default for safety. To enable, set the `SLACK_MCP_ADD_MESSAGE_TOOL` environment variable. If set to a comma-separated list of channel IDs, reactions are enabled only for those specific channels. See the Environment Variables section below for details.
+> **Note:** Adding reactions is disabled by default for safety. To enable, set the `SLACK_MCP_REACTION_TOOL` environment variable. If set to a comma-separated list of channel IDs, reactions are enabled only for those specific channels. See the Environment Variables section below for details.
 
 - **Parameters:**
   - `channel_id` (string, required): ID of the channel in format `Cxxxxxxxxxx` or its name starting with `#...` or `@...` aka `#general` or `@username_dm`.
@@ -98,7 +98,7 @@ Add an emoji reaction to a message in a public channel, private channel, or dire
 ### 7. reactions_remove:
 Remove an emoji reaction from a message in a public channel, private channel, or direct message (DM, or IM) conversation.
 
-> **Note:** Removing reactions follows the same permission model as `reactions_add`. To enable, set the `SLACK_MCP_ADD_MESSAGE_TOOL` environment variable.
+> **Note:** Removing reactions follows the same permission model as `reactions_add`. To enable, set the `SLACK_MCP_REACTION_TOOL` environment variable.
 
 - **Parameters:**
   - `channel_id` (string, required): ID of the channel in format `Cxxxxxxxxxx` or its name starting with `#...` or `@...` aka `#general` or `@username_dm`.
@@ -261,6 +261,8 @@ Fetches a CSV directory of all users in the workspace.
 | `SLACK_MCP_ADD_MESSAGE_TOOL`      | No        | `nil`                     | Enable message posting via `conversations_add_message` by setting it to `true` for all channels, a comma-separated list of channel IDs to whitelist specific channels, or use `!` before a channel ID to allow all except specified ones. If empty, the tool is only registered when explicitly listed in `SLACK_MCP_ENABLED_TOOLS`. |
 | `SLACK_MCP_ADD_MESSAGE_MARK`      | No        | `nil`                     | When `conversations_add_message` is enabled (via `SLACK_MCP_ADD_MESSAGE_TOOL` or `SLACK_MCP_ENABLED_TOOLS`), setting this to `true` will automatically mark sent messages as read.                                                                                                        |
 | `SLACK_MCP_ADD_MESSAGE_UNFURLING` | No        | `nil`                     | Enable to let Slack unfurl posted links or set comma-separated list of domains e.g. `github.com,slack.com` to whitelist unfurling only for them. If text contains whitelisted and unknown domain unfurling will be disabled for security reasons.                                         |
+| `SLACK_MCP_REACTION_TOOL`        | No        | `nil`                     | Enable `reactions_add` and `reactions_remove` tools by setting to `true` for all channels, a comma-separated list of channel IDs to whitelist specific channels, or use `!` before a channel ID to allow all except specified ones. If empty, the tools are only registered when explicitly listed in `SLACK_MCP_ENABLED_TOOLS`. |
+| `SLACK_MCP_ATTACHMENT_TOOL`      | No        | `nil`                     | Enable the `attachment_get_data` tool by setting to `true`, `1`, or `yes`. Does not support channel-level restrictions. If empty, the tool is only registered when explicitly listed in `SLACK_MCP_ENABLED_TOOLS`. |
 | `SLACK_MCP_MARK_TOOL`             | No        | `nil`                     | Enable the `conversations_mark` tool by setting to `true` or `1`. Disabled by default to prevent accidental marking of messages as read.                                                                                                                                                  |
 | `SLACK_MCP_USERS_CACHE`           | No        | `~/Library/Caches/slack-mcp-server/users_cache.json` (macOS)<br>`~/.cache/slack-mcp-server/users_cache.json` (Linux)<br>`%LocalAppData%/slack-mcp-server/users_cache.json` (Windows) | Path to the users cache file. Used to cache Slack user information to avoid repeated API calls on startup. |
 | `SLACK_MCP_CHANNELS_CACHE`        | No        | `~/Library/Caches/slack-mcp-server/channels_cache_v2.json` (macOS)<br>`~/.cache/slack-mcp-server/channels_cache_v2.json` (Linux)<br>`%LocalAppData%/slack-mcp-server/channels_cache_v2.json` (Windows) | Path to the channels cache file. Used to cache Slack channel information to avoid repeated API calls on startup. |


### PR DESCRIPTION
## Summary

The README incorrectly tells users to set `SLACK_MCP_ADD_MESSAGE_TOOL` to enable `reactions_add` and `reactions_remove`, but the code (`pkg/server/server.go` and `pkg/handler/conversations.go`) gates these tools behind `SLACK_MCP_REACTION_TOOL`. Users following the README cannot enable reaction tools.

Additionally, `SLACK_MCP_REACTION_TOOL` and `SLACK_MCP_ATTACHMENT_TOOL` are completely absent from the Environment Variables table.

## Changes

- Fix `reactions_add` tool note (line 91) to reference `SLACK_MCP_REACTION_TOOL` instead of `SLACK_MCP_ADD_MESSAGE_TOOL`
- Fix `reactions_remove` tool note (line 101) to reference `SLACK_MCP_REACTION_TOOL` instead of `SLACK_MCP_ADD_MESSAGE_TOOL`
- Add `SLACK_MCP_REACTION_TOOL` row to the Environment Variables table (supports `true`, channel ID whitelist, and `!` exclusion — matching `isChannelAllowedForConfig` logic)
- Add `SLACK_MCP_ATTACHMENT_TOOL` row to the Environment Variables table (supports `true`/`1`/`yes` only — no channel-level restrictions, matching `parseParamsToolFilesGet` logic)

## Code references

- `pkg/server/server.go:189` — `shouldAddTool(ToolReactionsAdd, enabledTools, "SLACK_MCP_REACTION_TOOL")`
- `pkg/server/server.go:208` — `shouldAddTool(ToolReactionsRemove, enabledTools, "SLACK_MCP_REACTION_TOOL")`
- `pkg/server/server.go:227` — `shouldAddTool(ToolAttachmentGetData, enabledTools, "SLACK_MCP_ATTACHMENT_TOOL")`
- `pkg/handler/conversations.go:1721` — `toolConfig := os.Getenv("SLACK_MCP_REACTION_TOOL")`
- `pkg/handler/conversations.go:1769` — `toolConfig := os.Getenv("SLACK_MCP_ATTACHMENT_TOOL")`