### PR TITLE
feat: add conversations_draft_message tool for message preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,16 @@ Add a message to a public channel, private channel, or direct message (DM, or IM
   - `payload` (string, required): Message payload in specified content_type format. Example: 'Hello, world!' for text/plain or '# Hello, world!' for text/markdown.
   - `content_type` (string, default: "text/markdown"): Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'.
 
-### 4. conversations_search_messages
+### 4. conversations_draft_message
+Draft a message for a public channel, private channel, or direct message (DM, or IM) conversation. Returns a formatted preview of the message without sending it. Use `conversations_add_message` to send the message after reviewing the draft.
+
+- **Parameters:**
+  - `channel_id` (string, required): ID of the channel in format `Cxxxxxxxxxx` or its name starting with `#...` or `@...` aka `#general` or `@username_dm`.
+  - `thread_ts` (string, optional): Unique identifier of either a thread's parent message or a message in the thread_ts must be the timestamp in format `1234567890.123456` of an existing message with 0 or more replies. Optional, if not provided the message will be drafted for the channel itself, otherwise it will be drafted as a thread reply.
+  - `text` (string, required): Message text in specified content_type format. Example: 'Hello, world!' for text/plain or '# Hello, world!' for text/markdown.
+  - `content_type` (string, default: "text/markdown"): Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'.
+
+### 5. conversations_search_messages
 Search messages in a public channel, private channel, or direct message (DM, or IM) conversation using filters. All filters are optional, if not provided then search_query is required.
 
 > **Note**: This tool is not available when using bot tokens (`xoxb-*`). Bot tokens cannot use the `search.messages` API.
@@ -77,7 +86,7 @@ Search messages in a public channel, private channel, or direct message (DM, or 
   - `cursor` (string, default: ""): Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request.
   - `limit` (number, default: 20): The maximum number of items to return. Must be an integer between 1 and 100.
 
-### 5. channels_list:
+### 6. channels_list:
 Get list of channels
 - **Parameters:**
   - `channel_types` (string, required): Comma-separated channel types. Allowed values: `mpim`, `im`, `public_channel`, `private_channel`. Example: `public_channel,private_channel,im`
@@ -85,7 +94,7 @@ Get list of channels
   - `limit` (number, default: 100): The maximum number of items to return. Must be an integer between 1 and 1000 (maximum 999).
   - `cursor` (string, optional): Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request.
 
-### 6. reactions_add:
+### 7. reactions_add:
 Add an emoji reaction to a message in a public channel, private channel, or direct message (DM, or IM) conversation.
 
 > **Note:** Adding reactions is disabled by default for safety. To enable, set the `SLACK_MCP_ADD_MESSAGE_TOOL` environment variable. If set to a comma-separated list of channel IDs, reactions are enabled only for those specific channels. See the Environment Variables section below for details.
@@ -95,7 +104,7 @@ Add an emoji reaction to a message in a public channel, private channel, or dire
   - `timestamp` (string, required): Timestamp of the message to add reaction to, in format `1234567890.123456`.
   - `emoji` (string, required): The name of the emoji to add as a reaction (without colons). Example: `thumbsup`, `heart`, `rocket`.
 
-### 7. reactions_remove:
+### 8. reactions_remove:
 Remove an emoji reaction from a message in a public channel, private channel, or direct message (DM, or IM) conversation.
 
 > **Note:** Removing reactions follows the same permission model as `reactions_add`. To enable, set the `SLACK_MCP_ADD_MESSAGE_TOOL` environment variable.
@@ -105,7 +114,7 @@ Remove an emoji reaction from a message in a public channel, private channel, or
   - `timestamp` (string, required): Timestamp of the message to remove reaction from, in format `1234567890.123456`.
   - `emoji` (string, required): The name of the emoji to remove as a reaction (without colons). Example: `thumbsup`, `heart`, `rocket`.
 
-### 8. users_search:
+### 9. users_search:
 Search for users by name, email, or display name. Returns user details and DM channel ID if available.
 
 > **Note:** For OAuth tokens (`xoxp`/`xoxb`), this tool searches the local users cache using pattern matching. For browser session tokens (`xoxc`/`xoxd`), it uses the Slack edge API for real-time search.
@@ -123,7 +132,7 @@ Search for users by name, email, or display name. Returns user details and DM ch
   - `Title`: User's job title
   - `DMChannelID`: DM channel ID if available in cache (for quick messaging)
 
-### 9. usergroups_list:
+### 10. usergroups_list:
 List all user groups (subteams) in the workspace.
 
 - **Parameters:**
@@ -135,7 +144,7 @@ List all user groups (subteams) in the workspace.
 
 > **Required OAuth scopes:** `usergroups:read`
 
-### 10. usergroups_create:
+### 11. usergroups_create:
 Create a new user group in the workspace.
 
 - **Parameters:**
@@ -148,7 +157,7 @@ Create a new user group in the workspace.
 
 > **Required OAuth scopes:** `usergroups:write`
 
-### 11. usergroups_update:
+### 12. usergroups_update:
 Update an existing user group's metadata.
 
 - **Parameters:**
@@ -162,7 +171,7 @@ Update an existing user group's metadata.
 
 > **Required OAuth scopes:** `usergroups:write`
 
-### 12. usergroups_users_update:
+### 13. usergroups_users_update:
 Update the members of a user group. This replaces all existing members.
 
 - **Parameters:**
@@ -173,7 +182,7 @@ Update the members of a user group. This replaces all existing members.
 
 > **Required OAuth scopes:** `usergroups:write`
 
-### 13. usergroups_me:
+### 14. usergroups_me:
 Manage your user group membership: list groups you're in, join a group, or leave a group.
 
 - **Parameters:**
@@ -186,7 +195,7 @@ Manage your user group membership: list groups you're in, join a group, or leave
 
 > **Required OAuth scopes:** `usergroups:read` (for list), `usergroups:read` + `usergroups:write` (for join/leave)
 
-### 14. conversations_unreads
+### 15. conversations_unreads
 Get unread messages across all channels efficiently. Uses a single API call to identify channels with unreads, then fetches only those messages. Results are prioritized: DMs > partner channels (Slack Connect) > internal channels.
 
 > **Note:** This tool works best with browser session tokens (`xoxc`/`xoxd`), which use the efficient `client.counts` API. For standard OAuth tokens (`xoxp`), a fallback method using `conversations.info` is used, which requires one API call per channel and may be slower for large workspaces. Not available with bot tokens (`xoxb`).
@@ -198,7 +207,7 @@ Get unread messages across all channels efficiently. Uses a single API call to i
   - `max_messages_per_channel` (number, default: 10): Maximum messages to fetch per channel.
   - `mentions_only` (boolean, default: false): If true, only returns channels where you have @mentions. Note: This filter only works with browser tokens; OAuth tokens will return all unread channels.
 
-### 15. conversations_mark
+### 16. conversations_mark
 Mark a channel or DM as read.
 
 > **Note:** Marking messages as read is disabled by default for safety. To enable, set the `SLACK_MCP_MARK_TOOL` environment variable to `true` or `1`. See the Environment Variables section below for details.
@@ -266,7 +275,7 @@ Fetches a CSV directory of all users in the workspace.
 | `SLACK_MCP_CHANNELS_CACHE`        | No        | `~/Library/Caches/slack-mcp-server/channels_cache_v2.json` (macOS)<br>`~/.cache/slack-mcp-server/channels_cache_v2.json` (Linux)<br>`%LocalAppData%/slack-mcp-server/channels_cache_v2.json` (Windows) | Path to the channels cache file. Used to cache Slack channel information to avoid repeated API calls on startup. |
 | `SLACK_MCP_LOG_LEVEL`             | No        | `info`                    | Log-level for stdout or stderr. Valid values are: `debug`, `info`, `warn`, `error`, `panic` and `fatal`                                                                                                                                                                                   |
 | `SLACK_MCP_GOVSLACK`              | No        | `nil`                     | Set to `true` to enable [GovSlack](https://slack.com/solutions/govslack) mode. Routes API calls to `slack-gov.com` endpoints instead of `slack.com` for FedRAMP-compliant government workspaces.                                                                                          |
-| `SLACK_MCP_ENABLED_TOOLS`         | No        | `nil`                     | Comma-separated list of tools to register. If empty, all read-only tools and usergroups tools are registered; write tools (`conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`) require their specific env var OR must be explicitly listed here. When a write tool is listed here, it's enabled without channel restrictions. Available tools: `conversations_history`, `conversations_replies`, `conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`, `conversations_search_messages`, `channels_list`, `usergroups_list`, `usergroups_me`, `usergroups_create`, `usergroups_update`, `usergroups_users_update`. |
+| `SLACK_MCP_ENABLED_TOOLS`         | No        | `nil`                     | Comma-separated list of tools to register. If empty, all read-only tools and usergroups tools are registered; write tools (`conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`) require their specific env var OR must be explicitly listed here. When a write tool is listed here, it's enabled without channel restrictions. Available tools: `conversations_history`, `conversations_replies`, `conversations_add_message`, `conversations_draft_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`, `conversations_search_messages`, `channels_list`, `usergroups_list`, `usergroups_me`, `usergroups_create`, `usergroups_update`, `usergroups_users_update`. |
 
 *You need one of: `xoxp` (user), `xoxb` (bot), or both `xoxc`/`xoxd` tokens for authentication.
 

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -285,6 +285,66 @@ func (ch *ConversationsHandler) ConversationsAddMessageHandler(ctx context.Conte
 	return marshalMessagesToCSV(messages)
 }
 
+// ConversationsDraftMessageHandler validates and formats a message without sending it.
+// Returns a preview of what the message would look like, allowing the user to review
+// before sending via conversations_add_message.
+func (ch *ConversationsHandler) ConversationsDraftMessageHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsDraftMessageHandler called", zap.Any("params", request.Params))
+
+	// provider readiness
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	params, err := ch.parseParamsToolDraftMessage(ctx, request)
+	if err != nil {
+		ch.logger.Error("Failed to parse draft-message params", zap.Error(err))
+		return nil, err
+	}
+
+	// Validate content type and check markdown parsing, matching conversations_add_message behavior.
+	var formatStatus string
+
+	switch params.contentType {
+	case "text/plain":
+		formatStatus = "plain_text"
+	case "text/markdown":
+		blocks, err := slackGoUtil.ConvertMarkdownTextToBlocks(params.text)
+		if err != nil {
+			ch.logger.Warn("Markdown parsing error", zap.Error(err))
+			formatStatus = "plain_text (markdown parse failed, will send as plain text)"
+		} else {
+			formatStatus = fmt.Sprintf("markdown (%d block(s))", len(blocks))
+		}
+	default:
+		return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")
+	}
+
+	sendability := checkSendStatus(params.channel)
+
+	// Build the draft preview response.
+	// Use labeled sections instead of delimiter lines to avoid ambiguity
+	// when the message text itself contains delimiter-like patterns.
+	preview := fmt.Sprintf("[Draft message preview]\n"+
+		"Channel: %s\n"+
+		"Thread: %s\n"+
+		"Format: %s\n"+
+		"Send status: %s\n\n"+
+		"[Message text]\n"+
+		"%s\n\n"+
+		"[End of draft]\n"+
+		"To send this message, use conversations_add_message with the same parameters.",
+		params.channel,
+		formatThreadTs(params.threadTs),
+		formatStatus,
+		sendability,
+		params.text,
+	)
+
+	return mcp.NewToolResultText(preview), nil
+}
+
 // ReactionsAddHandler adds an emoji reaction to a message
 func (ch *ConversationsHandler) ReactionsAddHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	ch.logger.Debug("ReactionsAddHandler called", zap.Any("params", request.Params))
@@ -1414,6 +1474,20 @@ func isChannelAllowed(channel string) bool {
 	return isChannelAllowedForConfig(channel, os.Getenv("SLACK_MCP_ADD_MESSAGE_TOOL"))
 }
 
+// checkSendStatus reports whether conversations_add_message would accept a message
+// to the given channel. Returns a human-readable status string.
+func checkSendStatus(channel string) string {
+	addMessageTool := os.Getenv("SLACK_MCP_ADD_MESSAGE_TOOL")
+	addMessageEnabled := os.Getenv("SLACK_MCP_ENABLED_TOOLS")
+	if addMessageTool == "" && !isToolInEnabledList(addMessageEnabled, "conversations_add_message") {
+		return "not available"
+	}
+	if !isChannelAllowedForConfig(channel, addMessageTool) {
+		return "not available for this channel"
+	}
+	return "available"
+}
+
 func (ch *ConversationsHandler) resolveChannelID(ctx context.Context, channel string) (string, error) {
 	if !strings.HasPrefix(channel, "#") && !strings.HasPrefix(channel, "@") {
 		return channel, nil
@@ -1652,6 +1726,66 @@ func (ch *ConversationsHandler) parseParamsToolConversations(ctx context.Context
 		latest:   paramLatest,
 		cursor:   cursor,
 		activity: activity,
+	}, nil
+}
+
+// isToolInEnabledList checks for an exact tool name match in a comma-separated list.
+// Unlike strings.Contains, this avoids false positives from partial matches
+// in comma-separated lists (e.g., matching "foo" inside "foobar,baz").
+func isToolInEnabledList(enabledTools, toolName string) bool {
+	if enabledTools == "" {
+		return false
+	}
+	for _, t := range strings.Split(enabledTools, ",") {
+		if strings.TrimSpace(t) == toolName {
+			return true
+		}
+	}
+	return false
+}
+
+func formatThreadTs(threadTs string) string {
+	if threadTs == "" {
+		return "(top-level message)"
+	}
+	return threadTs
+}
+
+func (ch *ConversationsHandler) parseParamsToolDraftMessage(ctx context.Context, request mcp.CallToolRequest) (*addMessageParams, error) {
+	channel := request.GetString("channel_id", "")
+	if channel == "" {
+		ch.logger.Error("channel_id missing in draft-message params")
+		return nil, errors.New("channel_id must be a string")
+	}
+	channel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		ch.logger.Error("Channel not found", zap.String("channel", channel), zap.Error(err))
+		return nil, err
+	}
+
+	threadTs := request.GetString("thread_ts", "")
+	if threadTs != "" && !strings.Contains(threadTs, ".") {
+		ch.logger.Error("Invalid thread_ts format", zap.String("thread_ts", threadTs))
+		return nil, errors.New("thread_ts must be a valid timestamp in format 1234567890.123456")
+	}
+
+	msgText := request.GetString("text", "")
+	if msgText == "" {
+		ch.logger.Error("Message text missing")
+		return nil, errors.New("text is required and must not be empty")
+	}
+
+	contentType := request.GetString("content_type", "text/markdown")
+	if contentType != "text/plain" && contentType != "text/markdown" {
+		ch.logger.Error("Invalid content_type", zap.String("content_type", contentType))
+		return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")
+	}
+
+	return &addMessageParams{
+		channel:     channel,
+		threadTs:    threadTs,
+		text:        msgText,
+		contentType: contentType,
 	}, nil
 }
 

--- a/pkg/handler/conversations_test.go
+++ b/pkg/handler/conversations_test.go
@@ -633,6 +633,123 @@ func TestUnitIsChannelAllowedForConfig(t *testing.T) {
 	}
 }
 
+func TestUnitCheckSendStatus(t *testing.T) {
+	setEnv := func(key, value string) func() {
+		old, existed := os.LookupEnv(key)
+		os.Setenv(key, value)
+		return func() {
+			if existed {
+				os.Setenv(key, old)
+			} else {
+				os.Unsetenv(key)
+			}
+		}
+	}
+
+	t.Run("not available when add_message not enabled", func(t *testing.T) {
+		cleanup1 := setEnv("SLACK_MCP_ADD_MESSAGE_TOOL", "")
+		cleanup2 := setEnv("SLACK_MCP_ENABLED_TOOLS", "")
+		defer cleanup1()
+		defer cleanup2()
+
+		got := checkSendStatus("C123")
+		if got != "not available" {
+			t.Errorf("expected 'not available', got %q", got)
+		}
+	})
+
+	t.Run("available when add_message enabled via env var", func(t *testing.T) {
+		cleanup1 := setEnv("SLACK_MCP_ADD_MESSAGE_TOOL", "true")
+		cleanup2 := setEnv("SLACK_MCP_ENABLED_TOOLS", "")
+		defer cleanup1()
+		defer cleanup2()
+
+		got := checkSendStatus("C123")
+		if got != "available" {
+			t.Errorf("expected 'available', got %q", got)
+		}
+	})
+
+	t.Run("available when add_message in enabled tools list", func(t *testing.T) {
+		cleanup1 := setEnv("SLACK_MCP_ADD_MESSAGE_TOOL", "")
+		cleanup2 := setEnv("SLACK_MCP_ENABLED_TOOLS", "conversations_add_message,channels_list")
+		defer cleanup1()
+		defer cleanup2()
+
+		got := checkSendStatus("C123")
+		if got != "available" {
+			t.Errorf("expected 'available', got %q", got)
+		}
+	})
+
+	t.Run("not available when channel not in allowlist", func(t *testing.T) {
+		cleanup1 := setEnv("SLACK_MCP_ADD_MESSAGE_TOOL", "C456,C789")
+		cleanup2 := setEnv("SLACK_MCP_ENABLED_TOOLS", "")
+		defer cleanup1()
+		defer cleanup2()
+
+		got := checkSendStatus("C123")
+		if got != "not available for this channel" {
+			t.Errorf("expected 'not available for this channel', got %q", got)
+		}
+	})
+
+	t.Run("available when channel in allowlist", func(t *testing.T) {
+		cleanup1 := setEnv("SLACK_MCP_ADD_MESSAGE_TOOL", "C123,C456")
+		cleanup2 := setEnv("SLACK_MCP_ENABLED_TOOLS", "")
+		defer cleanup1()
+		defer cleanup2()
+
+		got := checkSendStatus("C123")
+		if got != "available" {
+			t.Errorf("expected 'available', got %q", got)
+		}
+	})
+
+	t.Run("not available when channel in blocklist", func(t *testing.T) {
+		cleanup1 := setEnv("SLACK_MCP_ADD_MESSAGE_TOOL", "!C123")
+		cleanup2 := setEnv("SLACK_MCP_ENABLED_TOOLS", "")
+		defer cleanup1()
+		defer cleanup2()
+
+		got := checkSendStatus("C123")
+		if got != "not available for this channel" {
+			t.Errorf("expected 'not available for this channel', got %q", got)
+		}
+	})
+
+	t.Run("not available when only draft tool in enabled list (substring false positive)", func(t *testing.T) {
+		cleanup1 := setEnv("SLACK_MCP_ADD_MESSAGE_TOOL", "")
+		cleanup2 := setEnv("SLACK_MCP_ENABLED_TOOLS", "conversations_draft_message,channels_list")
+		defer cleanup1()
+		defer cleanup2()
+
+		got := checkSendStatus("C123")
+		if got != "not available" {
+			t.Errorf("expected 'not available' (draft tool name is superstring of add_message), got %q", got)
+		}
+	})
+}
+
+func TestUnitFormatThreadTs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty returns top-level", "", "(top-level message)"},
+		{"timestamp passes through", "1234567890.123456", "1234567890.123456"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatThreadTs(tt.input)
+			if got != tt.want {
+				t.Errorf("formatThreadTs(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUnitIsSlackUserIDPrefix(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,6 +28,7 @@ const (
 	ToolConversationsHistory        = "conversations_history"
 	ToolConversationsReplies        = "conversations_replies"
 	ToolConversationsAddMessage     = "conversations_add_message"
+	ToolConversationsDraftMessage   = "conversations_draft_message"
 	ToolReactionsAdd                = "reactions_add"
 	ToolReactionsRemove             = "reactions_remove"
 	ToolAttachmentGetData           = "attachment_get_data"
@@ -47,6 +48,7 @@ var ValidToolNames = []string{
 	ToolConversationsHistory,
 	ToolConversationsReplies,
 	ToolConversationsAddMessage,
+	ToolConversationsDraftMessage,
 	ToolReactionsAdd,
 	ToolReactionsRemove,
 	ToolAttachmentGetData,
@@ -184,6 +186,30 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'."),
 			),
 		), conversationsHandler.ConversationsAddMessageHandler)
+	}
+
+	if shouldAddTool(ToolConversationsDraftMessage, enabledTools, "") {
+		s.AddTool(mcp.NewTool(ToolConversationsDraftMessage,
+			mcp.WithDescription("Draft a message for a public channel, private channel, or direct message (DM, or IM) conversation. Returns a formatted preview of the message without sending it. Use conversations_add_message to send the message after reviewing the draft."),
+			mcp.WithTitleAnnotation("Draft Message"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
+			),
+			mcp.WithString("thread_ts",
+				mcp.Description("Unique identifier of either a thread's parent message or a message in the thread_ts must be the timestamp in format 1234567890.123456 of an existing message with 0 or more replies. Optional, if not provided the message will be drafted for the channel itself, otherwise it will be drafted as a thread reply."),
+			),
+			mcp.WithString("text",
+				mcp.Required(),
+				mcp.Description("Message text in specified content_type format. Example: 'Hello, world!' for text/plain or '# Hello, world!' for text/markdown."),
+			),
+			mcp.WithString("content_type",
+				mcp.DefaultString("text/markdown"),
+				mcp.Description("Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'."),
+			),
+		), conversationsHandler.ConversationsDraftMessageHandler)
 	}
 
 	if shouldAddTool(ToolReactionsAdd, enabledTools, "SLACK_MCP_REACTION_TOOL") {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -97,6 +97,7 @@ func TestValidToolNames(t *testing.T) {
 			ToolConversationsHistory:        true,
 			ToolConversationsReplies:        true,
 			ToolConversationsAddMessage:     true,
+			ToolConversationsDraftMessage:   true,
 			ToolReactionsAdd:                true,
 			ToolReactionsRemove:             true,
 			ToolAttachmentGetData:           true,
@@ -123,6 +124,7 @@ func TestValidToolNames(t *testing.T) {
 		assert.Equal(t, "conversations_history", ToolConversationsHistory)
 		assert.Equal(t, "conversations_replies", ToolConversationsReplies)
 		assert.Equal(t, "conversations_add_message", ToolConversationsAddMessage)
+		assert.Equal(t, "conversations_draft_message", ToolConversationsDraftMessage)
 		assert.Equal(t, "reactions_add", ToolReactionsAdd)
 		assert.Equal(t, "reactions_remove", ToolReactionsRemove)
 		assert.Equal(t, "attachment_get_data", ToolAttachmentGetData)
@@ -297,6 +299,25 @@ func TestShouldAddTool_WriteTool_Attachment(t *testing.T) {
 
 		result := shouldAddTool(ToolAttachmentGetData, []string{ToolAttachmentGetData}, "SLACK_MCP_ATTACHMENT_TOOL")
 		assert.True(t, result, "attachment_get_data should be registered when explicitly in enabledTools")
+	})
+}
+
+func TestShouldAddTool_DraftMessage(t *testing.T) {
+	// conversations_draft_message is read-only (no env var gate), same as conversations_history.
+	// It follows the read-only tool pattern: registered by default, filtered only via enabledTools.
+	t.Run("empty enabledTools - registered by default", func(t *testing.T) {
+		result := shouldAddTool(ToolConversationsDraftMessage, []string{}, "")
+		assert.True(t, result, "read-only draft tool should be registered by default")
+	})
+
+	t.Run("explicit enabledTools includes tool - registered", func(t *testing.T) {
+		result := shouldAddTool(ToolConversationsDraftMessage, []string{ToolConversationsDraftMessage}, "")
+		assert.True(t, result, "draft tool should be registered when in enabledTools")
+	})
+
+	t.Run("explicit enabledTools excludes tool - not registered", func(t *testing.T) {
+		result := shouldAddTool(ToolConversationsDraftMessage, []string{ToolConversationsHistory}, "")
+		assert.False(t, result, "draft tool should NOT be registered when not in enabledTools list")
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `conversations_draft_message` tool that validates and formats messages without sending them
- Returns a preview showing channel, thread, format status (with markdown block count), and whether `conversations_add_message` would accept a send to that channel
- Registered as a read-only tool by default (same pattern as `conversations_history`); can be filtered via `SLACK_MCP_ENABLED_TOOLS`
- Annotated with `readOnlyHint: true` and `destructiveHint: false` per MCP tool annotations spec
- Introduces `isToolInEnabledList` helper for exact tool name matching in comma-separated lists (avoids `strings.Contains` false positives)

## Security considerations
- No Slack API write calls are made — the tool only validates inputs and formats a local preview string
- Send-status check uses generic messages ("available" / "not available") to avoid leaking server configuration details
- `text` parameter is marked `Required()` in the schema and validated in the handler
- Channel ID resolution uses the existing `resolveChannelID` path (cache lookup + API fallback), same as all other tools

## Test plan
- `TestUnitCheckSendStatus`: 7 scenarios covering disabled, enabled via env var, enabled via enabled-tools list, channel allowlist, channel blocklist, and substring false-positive prevention
- `TestUnitFormatThreadTs`: empty and non-empty timestamp formatting
- `TestShouldAddTool_DraftMessage`: default registration, explicit inclusion, explicit exclusion
- `TestValidToolNames`: updated to include `conversations_draft_message` constant
- E2E tested via JSON-RPC: plain text (send disabled), markdown (send enabled, 2 blocks), channel blocklist
- All existing tests continue to pass (`go test ./...`)

## Related
- Resolves #246
- Addresses the approval gate concern raised in #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)