### PR TITLE
feat: add query and query_targets parameters to channels_list tool

### DIFF
--- a/pkg/handler/channels.go
+++ b/pkg/handler/channels.go
@@ -167,8 +167,22 @@ func (ch *ChannelsHandler) ChannelsHandler(ctx context.Context, request mcp.Call
 	ch.logger.Debug("Channels after filtering by type", zap.Int("count", len(channels)))
 
 	if query != "" {
-		targets := parseQueryTargets(queryTargets)
-		channels = filterChannelsByQuery(channels, query, targets)
+		validTargets := map[string]bool{"name": true, "topic": true, "purpose": true}
+		targetSet := make(map[string]bool)
+		for _, t := range strings.Split(queryTargets, ",") {
+			t = strings.TrimSpace(strings.ToLower(t))
+			if validTargets[t] {
+				targetSet[t] = true
+			} else if t != "" {
+				ch.logger.Warn("Invalid query target ignored", zap.String("target", t))
+			}
+		}
+		if len(targetSet) == 0 {
+			ch.logger.Debug("No valid query targets provided, using default (name)")
+			targetSet["name"] = true
+		}
+
+		channels = filterChannelsByQuery(channels, query, targetSet)
 		ch.logger.Debug("Channels after keyword filter", zap.Int("count", len(channels)))
 	}
 
@@ -265,37 +279,13 @@ func filterChannelsByTypes(channels map[string]provider.Channel, types []string)
 	return result
 }
 
-type queryTargetSet struct {
-	name    bool
-	topic   bool
-	purpose bool
-}
-
-func parseQueryTargets(raw string) queryTargetSet {
-	ts := queryTargetSet{}
-	for _, t := range strings.Split(raw, ",") {
-		switch strings.TrimSpace(strings.ToLower(t)) {
-		case "name":
-			ts.name = true
-		case "topic":
-			ts.topic = true
-		case "purpose":
-			ts.purpose = true
-		}
-	}
-	if !ts.name && !ts.topic && !ts.purpose {
-		ts.name = true
-	}
-	return ts
-}
-
-func filterChannelsByQuery(channels []provider.Channel, query string, targets queryTargetSet) []provider.Channel {
+func filterChannelsByQuery(channels []provider.Channel, query string, targetSet map[string]bool) []provider.Channel {
 	q := strings.ToLower(query)
 	var result []provider.Channel
 	for _, ch := range channels {
-		if (targets.name && strings.Contains(strings.ToLower(ch.Name), q)) ||
-			(targets.topic && strings.Contains(strings.ToLower(ch.Topic), q)) ||
-			(targets.purpose && strings.Contains(strings.ToLower(ch.Purpose), q)) {
+		if (targetSet["name"] && strings.Contains(strings.ToLower(ch.Name), q)) ||
+			(targetSet["topic"] && strings.Contains(strings.ToLower(ch.Topic), q)) ||
+			(targetSet["purpose"] && strings.Contains(strings.ToLower(ch.Purpose), q)) {
 			result = append(result, ch)
 		}
 	}

--- a/pkg/handler/channels.go
+++ b/pkg/handler/channels.go
@@ -114,12 +114,16 @@ func (ch *ChannelsHandler) ChannelsHandler(ctx context.Context, request mcp.Call
 	types := request.GetString("channel_types", provider.PubChanType)
 	cursor := request.GetString("cursor", "")
 	limit := request.GetInt("limit", 0)
+	query := request.GetString("query", "")
+	queryTargets := request.GetString("query_targets", "name")
 
 	ch.logger.Debug("Request parameters",
 		zap.String("sort", sortType),
 		zap.String("channel_types", types),
 		zap.String("cursor", cursor),
 		zap.Int("limit", limit),
+		zap.String("query", query),
+		zap.String("query_targets", queryTargets),
 	)
 
 	// MCP Inspector v0.14.0 has issues with Slice type
@@ -161,6 +165,12 @@ func (ch *ChannelsHandler) ChannelsHandler(ctx context.Context, request mcp.Call
 
 	channels := filterChannelsByTypes(allChannels, channelTypes)
 	ch.logger.Debug("Channels after filtering by type", zap.Int("count", len(channels)))
+
+	if query != "" {
+		targets := parseQueryTargets(queryTargets)
+		channels = filterChannelsByQuery(channels, query, targets)
+		ch.logger.Debug("Channels after keyword filter", zap.Int("count", len(channels)))
+	}
 
 	var chans []provider.Channel
 
@@ -252,6 +262,43 @@ func filterChannelsByTypes(channels map[string]provider.Channel, types []string)
 		zap.Int("mpims", mpimCount),
 	)
 
+	return result
+}
+
+type queryTargetSet struct {
+	name    bool
+	topic   bool
+	purpose bool
+}
+
+func parseQueryTargets(raw string) queryTargetSet {
+	ts := queryTargetSet{}
+	for _, t := range strings.Split(raw, ",") {
+		switch strings.TrimSpace(strings.ToLower(t)) {
+		case "name":
+			ts.name = true
+		case "topic":
+			ts.topic = true
+		case "purpose":
+			ts.purpose = true
+		}
+	}
+	if !ts.name && !ts.topic && !ts.purpose {
+		ts.name = true
+	}
+	return ts
+}
+
+func filterChannelsByQuery(channels []provider.Channel, query string, targets queryTargetSet) []provider.Channel {
+	q := strings.ToLower(query)
+	var result []provider.Channel
+	for _, ch := range channels {
+		if (targets.name && strings.Contains(strings.ToLower(ch.Name), q)) ||
+			(targets.topic && strings.Contains(strings.ToLower(ch.Topic), q)) ||
+			(targets.purpose && strings.Contains(strings.ToLower(ch.Purpose), q)) {
+			result = append(result, ch)
+		}
+	}
 	return result
 }
 

--- a/pkg/handler/channels_test.go
+++ b/pkg/handler/channels_test.go
@@ -168,6 +168,8 @@ func TestIntegrationChannelsListQueryFilter(t *testing.T) {
 	for _, row := range dataRows {
 		assert.Containsf(t, strings.ToLower(row[0]), "testcase",
 			"Expected all results to match query 'testcase', got: %s", row[0])
+		assert.NotContainsf(t, strings.ToLower(row[0]), "general",
+			"Expected #general to be filtered out, but found: %s", row[0])
 	}
 	assert.GreaterOrEqual(t, len(dataRows), 3, "Expected at least testcase-1, testcase-2, testcase-3")
 }

--- a/pkg/handler/channels_test.go
+++ b/pkg/handler/channels_test.go
@@ -137,6 +137,41 @@ func runChannelTest(t *testing.T, env *testEnv, channelType string, expectedChan
 	}
 }
 
+func TestIntegrationChannelsListQueryFilter(t *testing.T) {
+	env, cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	callReq := mcp.CallToolRequest{}
+	callReq.Params.Name = "channels_list"
+	callReq.Params.Arguments = map[string]any{
+		"channel_types": "public_channel",
+		"query":         "testcase",
+	}
+
+	result, err := env.mcpClient.CallTool(env.ctx, callReq)
+	require.NoError(t, err, "Tool call failed")
+	require.NotNil(t, result, "Tool result is nil")
+	require.False(t, result.IsError, "Tool returned error")
+
+	var toolOutput strings.Builder
+	for _, content := range result.Content {
+		if textContent, ok := content.(mcp.TextContent); ok {
+			toolOutput.WriteString(textContent.Text)
+		}
+	}
+
+	reader := csv.NewReader(strings.NewReader(toolOutput.String()))
+	rows, err := reader.ReadAll()
+	require.NoError(t, err, "Failed to parse CSV")
+
+	dataRows := rows[1:]
+	for _, row := range dataRows {
+		assert.Containsf(t, strings.ToLower(row[0]), "testcase",
+			"Expected all results to match query 'testcase', got: %s", row[0])
+	}
+	assert.GreaterOrEqual(t, len(dataRows), 3, "Expected at least testcase-1, testcase-2, testcase-3")
+}
+
 func TestIntegrationPublicChannelsList(t *testing.T) {
 	env, cleanup := setupTestEnv(t)
 	defer cleanup()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -371,6 +371,13 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 			mcp.WithString("cursor",
 				mcp.Description("Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request."),
 			),
+			mcp.WithString("query",
+				mcp.Description("Optional keyword to filter channels. Case-insensitive substring match against the fields specified by query_targets. Example: 'marketing' returns channels like #marketing, #marketing-ops."),
+			),
+			mcp.WithString("query_targets",
+				mcp.DefaultString("name"),
+				mcp.Description("Comma-separated list of fields to match the query against. Allowed values: 'name', 'topic', 'purpose'. Example: 'name,topic,purpose' to search all fields. Default is 'name'."),
+			),
 		), channelsHandler.ChannelsHandler)
 	}
 


### PR DESCRIPTION
## Summary
- Adds `query` parameter for case-insensitive keyword filtering on `channels_list`
- Adds `query_targets` parameter to control which fields are searched (`name` by default, optionally `topic`, `purpose`)
- Filtering is applied after type filtering and before pagination, operating on the in-memory channel cache

Closes #251

## Test plan
- [ ] Integration test `TestIntegrationChannelsListQueryFilter` verifies filtering with `query=testcase`
- [ ] Verify `query` alone defaults to name-only matching
- [ ] Verify `query_targets=name,topic,purpose` broadens the search
- [ ] Verify no regression on existing `channels_list` behavior without `query`