### PR TITLE
Atomic cache writes and deduplicate AuthTest on startup

### DIFF
--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -114,12 +114,12 @@ func getMinRefreshInterval() time.Duration {
 // This ensures tokens are valid before proceeding and enables cache namespacing
 // to prevent cache contamination when using multiple Slack workspaces.
 // Returns an error if authentication fails - the server should not start with invalid credentials.
-func validateAuthAndGetTeamID(authProvider auth.Provider, logger *zap.Logger) (string, error) {
+func validateAuthAndGetTeamID(authProvider auth.Provider, logger *zap.Logger) (string, *slack.AuthTestResponse, error) {
 	xoxpToken := os.Getenv("SLACK_MCP_XOXP_TOKEN")
 	xoxcToken := os.Getenv("SLACK_MCP_XOXC_TOKEN")
 	xoxdToken := os.Getenv("SLACK_MCP_XOXD_TOKEN")
 	if xoxpToken == "demo" || (xoxcToken == "demo" && xoxdToken == "demo") {
-		return "demo", nil
+		return "demo", nil, nil
 	}
 
 	httpClient := transport.ProvideHTTPClient(authProvider.Cookies(), logger)
@@ -131,7 +131,7 @@ func validateAuthAndGetTeamID(authProvider auth.Provider, logger *zap.Logger) (s
 
 	authResp, err := slackClient.AuthTest()
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	logger.Info("Authenticated to Slack",
@@ -139,7 +139,7 @@ func validateAuthAndGetTeamID(authProvider auth.Provider, logger *zap.Logger) (s
 		zap.String("team_id", authResp.TeamID),
 		zap.String("user", authResp.User))
 
-	return authResp.TeamID, nil
+	return authResp.TeamID, authResp, nil
 }
 
 // getCachePathWithTeamID returns a cache file path prefixed with TeamID for workspace isolation.
@@ -150,6 +150,33 @@ func getCachePathWithTeamID(teamID, filename string) string {
 		return filepath.Join(cacheDir, teamID+"_"+filename)
 	}
 	return filepath.Join(cacheDir, filename)
+}
+
+// atomicWriteFile writes data to a temp file in the same directory, then renames
+// it to the target path. This prevents concurrent readers from seeing partial writes
+// when multiple server instances share the same cache directory.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 type UsersCache struct {
@@ -259,7 +286,7 @@ type ApiProvider struct {
 	channelsMu                sync.RWMutex // protects channelsReady, lastForcedChannelsRefresh
 }
 
-func NewMCPSlackClient(authProvider auth.Provider, logger *zap.Logger) (*MCPSlackClient, error) {
+func NewMCPSlackClient(authProvider auth.Provider, logger *zap.Logger, cachedAuth *slack.AuthTestResponse) (*MCPSlackClient, error) {
 	httpClient := transport.ProvideHTTPClient(authProvider.Cookies(), logger)
 
 	slackOpts := []slack.Option{slack.OptionHTTPClient(httpClient)}
@@ -268,9 +295,15 @@ func NewMCPSlackClient(authProvider auth.Provider, logger *zap.Logger) (*MCPSlac
 	}
 	slackClient := slack.New(authProvider.SlackToken(), slackOpts...)
 
-	authResp, err := slackClient.AuthTest()
-	if err != nil {
-		return nil, err
+	var authResp *slack.AuthTestResponse
+	if cachedAuth != nil {
+		authResp = cachedAuth
+	} else {
+		var err error
+		authResp, err = slackClient.AuthTest()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	authResponse := &slack.AuthTestResponse{
@@ -624,7 +657,7 @@ func newWithXOXP(transport string, authProvider auth.ValueAuth, logger *zap.Logg
 		err    error
 	)
 
-	teamID, err := validateAuthAndGetTeamID(authProvider, logger)
+	teamID, cachedAuth, err := validateAuthAndGetTeamID(authProvider, logger)
 	if err != nil {
 		logger.Fatal("Authentication failed - check your Slack tokens", zap.Error(err))
 	}
@@ -642,7 +675,7 @@ func newWithXOXP(transport string, authProvider auth.ValueAuth, logger *zap.Logg
 	if os.Getenv("SLACK_MCP_XOXP_TOKEN") == "demo" || (os.Getenv("SLACK_MCP_XOXC_TOKEN") == "demo" && os.Getenv("SLACK_MCP_XOXD_TOKEN") == "demo") {
 		logger.Info("Demo credentials are set, skip.")
 	} else {
-		client, err = NewMCPSlackClient(authProvider, logger)
+		client, err = NewMCPSlackClient(authProvider, logger, cachedAuth)
 		if err != nil {
 			logger.Fatal("Failed to create MCP Slack client", zap.Error(err))
 		}
@@ -684,7 +717,7 @@ func newWithXOXC(transport string, authProvider auth.ValueAuth, logger *zap.Logg
 		err    error
 	)
 
-	teamID, err := validateAuthAndGetTeamID(authProvider, logger)
+	teamID, cachedAuth, err := validateAuthAndGetTeamID(authProvider, logger)
 	if err != nil {
 		logger.Fatal("Authentication failed - check your Slack tokens", zap.Error(err))
 	}
@@ -702,7 +735,7 @@ func newWithXOXC(transport string, authProvider auth.ValueAuth, logger *zap.Logg
 	if os.Getenv("SLACK_MCP_XOXP_TOKEN") == "demo" || (os.Getenv("SLACK_MCP_XOXC_TOKEN") == "demo" && os.Getenv("SLACK_MCP_XOXD_TOKEN") == "demo") {
 		logger.Info("Demo credentials are set, skip.")
 	} else {
-		client, err = NewMCPSlackClient(authProvider, logger)
+		client, err = NewMCPSlackClient(authProvider, logger, cachedAuth)
 		if err != nil {
 			logger.Fatal("Failed to create MCP Slack client", zap.Error(err))
 		}
@@ -868,7 +901,7 @@ func (ap *ApiProvider) refreshUsersInternal(ctx context.Context, force bool) err
 	if data, err := json.MarshalIndent(list, "", "  "); err != nil {
 		ap.logger.Error("Failed to marshal users for cache", zap.Error(err))
 	} else {
-		if err := os.WriteFile(ap.usersCachePath, data, 0644); err != nil {
+		if err := atomicWriteFile(ap.usersCachePath, data, 0644); err != nil {
 			ap.logger.Error("Failed to write cache file",
 				zap.String("cache_file", ap.usersCachePath),
 				zap.Error(err))
@@ -988,7 +1021,7 @@ func (ap *ApiProvider) refreshChannelsInternal(ctx context.Context, force bool) 
 	} else if data, err := json.MarshalIndent(channels, "", "  "); err != nil {
 		ap.logger.Error("Failed to marshal channels for cache", zap.Error(err))
 	} else {
-		if err := os.WriteFile(ap.channelsCachePath, data, 0644); err != nil {
+		if err := atomicWriteFile(ap.channelsCachePath, data, 0644); err != nil {
 			ap.logger.Error("Failed to write cache file",
 				zap.String("cache_file", ap.channelsCachePath),
 				zap.Error(err))


### PR DESCRIPTION
Fixes #254 and #255.

Two fixes for running multiple MCP server instances concurrently (e.g. Claude Code launching separate instances per workspace):

* Cache files are now written atomically via write-to-temp-then-rename. Previously `os.WriteFile` on 300-460MB JSON files could leave partial data visible to concurrent readers.

* `validateAuthAndGetTeamID` now returns the full `AuthTestResponse` which is passed into `NewMCPSlackClient`, eliminating a redundant `AuthTest` API call per startup (2 per instance down to 1). Reduces rate limit pressure when multiple instances start simultaneously.

No new dependencies. Backwards compatible — `NewMCPSlackClient` accepts `nil` for `cachedAuth` and falls back to calling `AuthTest` itself.