### PR TITLE
feat(tools): add files_list tool for listing Slack channel files

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -108,6 +108,28 @@ type filesGetParams struct {
 	fileID string
 }
 
+type filesListParams struct {
+	channel string
+	user    string
+	types   string
+	limit   int
+	cursor  string
+}
+
+type FileListResult struct {
+	FileID     string `csv:"FileID"`
+	Name       string `csv:"Name"`
+	Title      string `csv:"Title"`
+	Mimetype   string `csv:"Mimetype"`
+	Filetype   string `csv:"Filetype"`
+	PrettyType string `csv:"PrettyType"`
+	Size       int    `csv:"Size"`
+	UserID     string `csv:"UserID"`
+	Created    string `csv:"Created"`
+	Permalink  string `csv:"Permalink"`
+	Cursor     string `csv:"Cursor"`
+}
+
 type usersSearchParams struct {
 	query string
 	limit int
@@ -481,6 +503,91 @@ func (ch *ConversationsHandler) FilesGetHandler(ctx context.Context, request mcp
 		escapeJSON(contentStr))
 
 	return mcp.NewToolResultText(result), nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolFilesList(request mcp.CallToolRequest) (*filesListParams, error) {
+	params := &filesListParams{
+		channel: request.GetString("channel_id", ""),
+		user:    request.GetString("user_id", ""),
+		types:   request.GetString("types", ""),
+		cursor:  request.GetString("cursor", ""),
+		limit:   50,
+	}
+
+	if limitStr := request.GetString("limit", ""); limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil && v > 0 {
+			params.limit = v
+		}
+	}
+
+	return params, nil
+}
+
+func (ch *ConversationsHandler) FilesListHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("FilesListHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	params, err := ch.parseParamsToolFilesList(request)
+	if err != nil {
+		ch.logger.Error("Failed to parse files_list params", zap.Error(err))
+		return nil, err
+	}
+
+	listParams := slack.ListFilesParameters{
+		Channel: params.channel,
+		User:    params.user,
+		Types:   params.types,
+		Limit:   params.limit,
+		Cursor:  params.cursor,
+	}
+
+	files, nextPage, err := ch.apiProvider.Slack().ListFilesContext(ctx, listParams)
+	if err != nil {
+		ch.logger.Error("Slack ListFilesContext failed", zap.Error(err))
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		return mcp.NewToolResultText("No files found."), nil
+	}
+
+	nextCursor := ""
+	if nextPage != nil {
+		nextCursor = nextPage.Cursor
+	}
+
+	results := make([]FileListResult, 0, len(files))
+	for i, f := range files {
+		cursor := ""
+		if i == len(files)-1 {
+			cursor = nextCursor
+		}
+		results = append(results, FileListResult{
+			FileID:     f.ID,
+			Name:       f.Name,
+			Title:      f.Title,
+			Mimetype:   f.Mimetype,
+			Filetype:   f.Filetype,
+			PrettyType: f.PrettyType,
+			Size:       f.Size,
+			UserID:     f.User,
+			Created:    f.Created.Time().Format(time.RFC3339),
+			Permalink:  f.Permalink,
+			Cursor:     cursor,
+		})
+	}
+
+	csvBytes, err := gocsv.MarshalBytes(&results)
+	if err != nil {
+		ch.logger.Error("Failed to marshal files to CSV", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(csvBytes)), nil
 }
 
 func isTextMimetype(mimetype string) bool {

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -195,6 +195,7 @@ type SlackAPI interface {
 	// Used to get files
 	GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*slack.File, []slack.Comment, *slack.Paging, error)
 	GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error
+	ListFilesContext(ctx context.Context, params slack.ListFilesParameters) ([]slack.File, *slack.ListFilesParameters, error)
 
 	// Used to get channel info (for unread counts with xoxp tokens)
 	GetConversationInfoContext(ctx context.Context, input *slack.GetConversationInfoInput) (*slack.Channel, error)
@@ -487,6 +488,10 @@ func (c *MCPSlackClient) GetFileInfoContext(ctx context.Context, fileID string, 
 
 func (c *MCPSlackClient) GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error {
 	return c.slackClient.GetFileContext(ctx, downloadURL, writer)
+}
+
+func (c *MCPSlackClient) ListFilesContext(ctx context.Context, params slack.ListFilesParameters) ([]slack.File, *slack.ListFilesParameters, error) {
+	return c.slackClient.ListFilesContext(ctx, params)
 }
 
 func (c *MCPSlackClient) GetConversationInfoContext(ctx context.Context, input *slack.GetConversationInfoInput) (*slack.Channel, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -41,6 +41,7 @@ const (
 	ToolUsergroupsUpdate            = "usergroups_update"
 	ToolUsergroupsUsersUpdate       = "usergroups_users_update"
 	ToolUsersSearch                 = "users_search"
+	ToolFilesList                   = "files_list"
 )
 
 var ValidToolNames = []string{
@@ -60,6 +61,7 @@ var ValidToolNames = []string{
 	ToolUsergroupsUpdate,
 	ToolUsergroupsUsersUpdate,
 	ToolUsersSearch,
+	ToolFilesList,
 }
 
 func ValidateEnabledTools(tools []string) error {
@@ -298,6 +300,31 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Maximum number of results to return (1-100). Default is 10."),
 			),
 		), conversationsHandler.UsersSearchHandler)
+	}
+
+	if shouldAddTool(ToolFilesList, enabledTools, "SLACK_MCP_FILES_LIST_TOOL") {
+		s.AddTool(mcp.NewTool(ToolFilesList,
+			mcp.WithDescription("List files shared in a Slack channel or workspace. Returns file metadata including ID, name, type, size, uploader, and permalink. Use the file_id from results with attachment_get_data to download file content. The last row cursor column is used for pagination."),
+			mcp.WithTitleAnnotation("List Files"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Description("Filter files by channel ID (format Cxxxxxxxxxx) or channel name (e.g. #general). If omitted, lists files across all channels."),
+			),
+			mcp.WithString("user_id",
+				mcp.Description("Filter files uploaded by a specific user ID (format Uxxxxxxxxxx)."),
+			),
+			mcp.WithString("types",
+				mcp.DefaultString("all"),
+				mcp.Description("Filter by file type. Comma-separated values: all, spaces, snippets, images, gdocs, zips, pdfs. Default is all."),
+			),
+			mcp.WithString("limit",
+				mcp.DefaultString("50"),
+				mcp.Description("Maximum number of files to return (1-200). Default is 50."),
+			),
+			mcp.WithString("cursor",
+				mcp.Description("Cursor for pagination. Use the value from the last row cursor column returned by the previous request."),
+			),
+		), conversationsHandler.FilesListHandler)
 	}
 
 	// Register unreads tool - gets all unread messages across channels efficiently.


### PR DESCRIPTION
## Summary

Adds a new `files_list` tool that lists files shared in a Slack channel or workspace, completing the file workflow alongside the existing `attachment_get_data` tool.

### Motivation

`attachment_get_data` downloads a file by ID, but there was no way to **discover** files shared in a channel. An AI agent can now call `files_list` to find files, then use the returned `FileID` with `attachment_get_data` to read the content.

### Changes

**`pkg/provider/api.go`**
- Added `ListFilesContext(ctx, params)` to the `SlackAPI` interface
- Implemented `MCPSlackClient.ListFilesContext` delegating to `slack.Client.ListFilesContext`

**`pkg/handler/conversations.go`**
- Added `filesListParams` struct
- Added `FileListResult` CSV struct (`FileID, Name, Title, Mimetype, Filetype, PrettyType, Size, UserID, Created, Permalink, Curso\`)
- Added `parseParamsToolFilesList` using `request.GetString` (consistent with existing parsers)
- Added `FilesListHandler\` returning CSV output with cursor on the last row

**`pkg/server/server.go`**
- Added `ToolFilesList = "files_list"` constant
- Added to `ValidToolNames`
- Registered in `NewMCPServer` guarded by `SLACK_MCP_FILES_LIST_TOOL` env var (same pattern as `attachment_get_data`)

### Design Decisions

- **Disabled by default** — same pattern as `attachment_get_data`, requires explicit opt-in via env var
- **`ListFilesContext` over `GetFilesContext`** — cursor-based pagination is preferred over page/count
- **CSV output** — consistent with all other tools in the project
- **No new dependencies** — uses only the existing `github.com/slack-go/slack` client