### PR TITLE
fix: add rate limiting and retry to SearchContext

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -602,7 +602,12 @@ func (ch *ConversationsHandler) ConversationsSearchHandler(ctx context.Context, 
 		Count:         params.limit,
 		Page:          params.page,
 	}
-	messagesRes, _, err := ch.apiProvider.Slack().SearchContext(ctx, params.query, searchParams)
+
+	rl := limiter.Tier2.Limiter()
+	messagesRes, err := limiter.CallWithRetry(ctx, rl, 2, slackRetryAfter, func() (*slack.SearchMessages, error) {
+		msgs, _, err := ch.apiProvider.Slack().SearchContext(ctx, params.query, searchParams)
+		return msgs, err
+	})
 	if err != nil {
 		ch.logger.Error("Slack SearchContext failed", zap.Error(err))
 		return nil, err


### PR DESCRIPTION
## Summary
- `SearchContext` was the only Slack API call in `conversations.go` without rate limiting or retry logic
- Under concurrent load (e.g. three parallel workspace searches), this caused immediate failures when hitting Slack's Tier 2 rate limits
- Wraps the call with `limiter.CallWithRetry` using a `Tier2` rate limiter, matching the established pattern used by `GetConversationHistoryContext` and `GetConversationInfoContext` in the same file

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./pkg/handler/...` passes
- [x] `pkg/limiter` tests pass
- [x] Manual validation with three concurrent workspace searches
- [ ] Upstream CI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>