### PR TITLE
feat: support direct user ID lookup in users_search

### DIFF
--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -1185,10 +1185,26 @@ func (ap *ApiProvider) IsOAuth() bool {
 	return ok && client != nil && client.IsOAuth()
 }
 
+// slackUserIDPattern matches Slack user IDs (e.g., U07VCEPP4N5, W0123456789).
+var slackUserIDPattern = regexp.MustCompile(`^[UW][A-Z0-9]{2,}$`)
+
 // SearchUsers searches for users by name, email, or display name.
+// If the query matches a Slack user ID pattern (e.g., U07VCEPP4N5), it looks up the user
+// directly via the users.info API instead of searching.
 // For OAuth tokens (xoxp/xoxb), it searches the local users cache using regex matching.
 // For browser tokens (xoxc/xoxd), it uses the edge API's UsersSearch method.
 func (ap *ApiProvider) SearchUsers(ctx context.Context, query string, limit int) ([]slack.User, error) {
+	if slackUserIDPattern.MatchString(query) {
+		users, err := ap.client.GetUsersInfo(query)
+		if err != nil {
+			return nil, err
+		}
+		if users != nil {
+			return *users, nil
+		}
+		return nil, nil
+	}
+
 	if ap.IsOAuth() {
 		return ap.searchUsersInCache(query, limit)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -286,12 +286,12 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 
 	if shouldAddTool(ToolUsersSearch, enabledTools, "") {
 		s.AddTool(mcp.NewTool(ToolUsersSearch,
-			mcp.WithDescription("Search for users by name, email, or display name. Returns user details and DM channel ID if available."),
+			mcp.WithDescription("Search for users by name, email, display name, or Slack user ID. If a Slack user ID is provided (e.g. U07VCEPP4N5), the user is looked up directly. Returns user details and DM channel ID if available."),
 			mcp.WithTitleAnnotation("Search Users"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithString("query",
 				mcp.Required(),
-				mcp.Description("Search query - matches against real name, display name, username, or email."),
+				mcp.Description("Search query - matches against real name, display name, username, email, or a Slack user ID (e.g. U07VCEPP4N5)."),
 			),
 			mcp.WithNumber("limit",
 				mcp.DefaultNumber(10),


### PR DESCRIPTION
## Summary
- When the `users_search` query matches a Slack user ID pattern (starts with `U` or `W`, followed by alphanumeric characters, e.g. `U07VCEPP4N5`), the tool now calls the `users.info` API directly instead of performing a name/email search
- Falls back to existing search behavior for non-ID queries
- Updated tool description and parameter description to document user ID support

## Motivation
When working with Slack data, user IDs appear frequently in message metadata, mentions (`<@U07VCEPP4N5>`), and API responses. Currently, resolving a user ID to a name/profile requires workarounds. This change lets you pass a user ID directly to `users_search` for an exact lookup.

Related: #205

## Changes
- `pkg/provider/api.go`: Added `slackUserIDPattern` regex and a user ID detection branch in `SearchUsers()` that calls the existing `GetUsersInfo` method (which wraps the Slack `users.info` API)
- `pkg/server/server.go`: Updated tool and parameter descriptions to mention user ID support

## Test plan
- [ ] Query with a valid Slack user ID (e.g. `U07VCEPP4N5`) returns that user profile
- [ ] Query with a name/email still uses the existing search path
- [ ] Query with an invalid user ID format (e.g. `hello`, `u07vcepp4n5`) falls through to search
- [ ] Works with both browser tokens (xoxc/xoxd) and OAuth tokens (xoxp/xoxb)