### PR TITLE
Include channel ID and permalink in search results

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -52,6 +52,7 @@ type Message struct {
 	ThreadTs      string `json:"ThreadTs"`
 	Text          string `json:"text"`
 	Time          string `json:"time"`
+	Permalink     string `json:"permalink,omitempty"`
 	Reactions     string `json:"reactions,omitempty"`
 	BotName       string `json:"botName,omitempty"`
 	FileCount     int    `json:"fileCount,omitempty"`
@@ -1571,9 +1572,10 @@ func (ch *ConversationsHandler) convertMessagesFromSearch(slackMessages []slack.
 			UserName:  userName,
 			RealName:  realName,
 			Text:      text.ProcessText(msgText),
-			Channel:   fmt.Sprintf("#%s", msg.Channel.Name),
+			Channel:   fmt.Sprintf("%s (#%s)", msg.Channel.ID, msg.Channel.Name),
 			ThreadTs:  threadTs,
 			Time:      timestamp,
+			Permalink: msg.Permalink,
 			Reactions: "",
 			HasMedia:  hasMedia,
 		})


### PR DESCRIPTION
Addresses #100.

Search results from conversations_search_messages only includes the channel display name, like #general. The Slack search API returns both Channel.ID and Permalink on every SearchMessage, but they are not included in convertMessagesFromSearch.

I often want permalinks to the message to add to docs or to open the thread myself, but I can't reliably get the LLM agent to reconstruct the link. This makes it possible.

Changes:
- Channel column now includes the ID: `C0515UGHR0R (#general)`
- New `Permalink` column passes through `msg.Permalink` from the API response

This is similar to #133, but I think worthwhile on its own. Instead of adding a new tool to construct permalinks (which is still useful!) this passes permalinks through when available.