### PR TITLE
Add recommended security policies for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,50 @@ npx @modelcontextprotocol/inspector go run mcp/mcp-server.go --transport stdio
 tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
 ```
 
+## Tool-level policy enforcement
+
+The server's built-in `SLACK_MCP_ADD_MESSAGE_TOOL` and `SLACK_MCP_ENABLED_TOOLS` controls determine which tools are available. For rate limiting, daily caps, and audit logging on individual tool calls, you can wrap the server with [PolicyLayer Intercept](https://github.com/policylayer/intercept), an open-source MCP proxy.
+
+Three policy presets are included in [`/policies`](/policies):
+
+| Policy | Description |
+|--------|-------------|
+| `recommended.yaml` | Rate limits on message sending, daily caps, reads allowed freely |
+| `strict.yaml` | Default deny — only read and list tools are allowed |
+| `permissive.yaml` | Everything allowed, rate limits on sends and user group writes |
+
+### Usage
+
+```sh
+npx -y @policylayer/intercept \
+  --policy policies/recommended.yaml \
+  -- go run mcp/mcp-server.go --transport stdio
+```
+
+Or in your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "slack": {
+      "command": "npx",
+      "args": [
+        "-y", "@policylayer/intercept",
+        "--policy", "policies/recommended.yaml",
+        "--", "/path/to/slack-mcp-server",
+        "--transport", "stdio"
+      ],
+      "env": {
+        "SLACK_MCP_XOXP_TOKEN": "<your-token>",
+        "SLACK_MCP_ADD_MESSAGE_TOOL": "true"
+      }
+    }
+  }
+}
+```
+
+Policies are YAML files you can customise. See the [Intercept docs](https://github.com/policylayer/intercept) for the full reference.
+
 ## Security
 
 - Never share API tokens

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -1,0 +1,47 @@
+version: "1"
+description: "Slack MCP — permissive policy. All tools allowed. Rate limits on message sending and user group writes."
+default: allow
+
+tools:
+  # Message sending — rate limited even in permissive mode
+  conversations_add_message:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "10/minute"
+        on_deny: "Slow down — max 10 messages per minute"
+      - name: "daily-cap"
+        rate_limit: "500/day"
+        on_deny: "Daily message limit (500) reached"
+
+  # Reactions — light limits
+  reactions_add:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/minute"
+        on_deny: "Max 20 reactions per minute"
+
+  reactions_remove:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/minute"
+        on_deny: "Max 20 reaction removals per minute"
+
+  # User group management — rate limited
+  usergroups_create:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 user group creations per hour"
+
+  usergroups_users_update:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/hour"
+        on_deny: "Max 30 membership updates per hour"
+
+  # Global safety net
+  "*":
+    rules:
+      - name: "global-rate-limit"
+        rate_limit: "120/minute"
+        on_deny: "Global rate limit — max 120 tool calls per minute"

--- a/policies/recommended.yaml
+++ b/policies/recommended.yaml
@@ -1,0 +1,94 @@
+version: "1"
+description: "Slack MCP — recommended policy. Rate limits on message sending, caps on bulk operations, reads allowed freely."
+default: allow
+
+tools:
+  # Message sending — highest risk, tightest limits
+  conversations_add_message:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "5/minute"
+        on_deny: "Slow down — max 5 messages per minute"
+      - name: "hourly-cap"
+        rate_limit: "30/hour"
+        on_deny: "Hourly message limit (30) reached"
+      - name: "daily-cap"
+        rate_limit: "200/day"
+        on_deny: "Daily message limit (200) reached — prevents bulk messaging"
+
+  # Reactions — moderate limits
+  reactions_add:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "10/minute"
+        on_deny: "Slow down — max 10 reactions per minute"
+      - name: "hourly-cap"
+        rate_limit: "60/hour"
+        on_deny: "Hourly reaction limit (60) reached"
+
+  reactions_remove:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/minute"
+        on_deny: "Max 10 reaction removals per minute"
+
+  # Mark as read — moderate limits
+  conversations_mark:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/minute"
+        on_deny: "Max 30 mark-as-read operations per minute"
+
+  # User group management — write operations, limited
+  usergroups_create:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "5/hour"
+        on_deny: "Max 5 user group creations per hour"
+
+  usergroups_update:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 user group updates per hour"
+
+  usergroups_users_update:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "3/minute"
+        on_deny: "Slow down — max 3 membership changes per minute"
+      - name: "hourly-cap"
+        rate_limit: "20/hour"
+        on_deny: "Hourly user group membership update limit (20) reached"
+
+  # Read tools — generous limits
+  conversations_history:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/minute"
+        on_deny: "Max 30 history fetches per minute"
+
+  conversations_replies:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/minute"
+        on_deny: "Max 30 thread fetches per minute"
+
+  conversations_search_messages:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "20/minute"
+        on_deny: "Max 20 searches per minute"
+
+  conversations_unreads:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/minute"
+        on_deny: "Max 10 unread fetches per minute"
+
+  # Global safety net
+  "*":
+    rules:
+      - name: "global-rate-limit"
+        rate_limit: "60/minute"
+        on_deny: "Global rate limit — max 60 tool calls per minute across all Slack tools"

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -1,0 +1,54 @@
+version: "1"
+description: "Slack MCP — strict policy. Default deny. Only read and list tools are allowed."
+default: deny
+
+tools:
+  # Read-only tools — explicitly allowed
+  conversations_history:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  conversations_replies:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  conversations_search_messages:
+    rules:
+      - action: allow
+        rate_limit: "20/minute"
+
+  conversations_unreads:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  channels_list:
+    rules:
+      - action: allow
+        rate_limit: "20/minute"
+
+  users_search:
+    rules:
+      - action: allow
+        rate_limit: "20/minute"
+
+  usergroups_list:
+    rules:
+      - action: allow
+        rate_limit: "20/minute"
+
+  usergroups_me:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  # All write tools blocked by default deny:
+  # - conversations_add_message
+  # - reactions_add
+  # - reactions_remove
+  # - conversations_mark
+  # - usergroups_create
+  # - usergroups_update
+  # - usergroups_users_update


### PR DESCRIPTION
## Summary

Adds three YAML policy files for use with [PolicyLayer Intercept](https://github.com/policylayer/intercept), an open-source MCP proxy that enforces rate limits, daily caps, and access control on individual tool calls.

The Slack MCP server exposes 15 tools — including `conversations_add_message`, `usergroups_create`, and `usergroups_users_update` — which can send messages to any channel, any user, at any volume, and modify workspace group membership. The server's built-in `SLACK_MCP_ADD_MESSAGE_TOOL` and `SLACK_MCP_ENABLED_TOOLS` controls determine which tools are available, but there's no rate limiting or daily capping on how those tools are used once enabled.

These policies add that layer without any changes to the server itself.

## What's included

```
policies/
├── recommended.yaml   # Rate limits on sends, daily caps, reads allowed freely
├── strict.yaml        # Default deny — only read/list tools allowed
└── permissive.yaml    # Everything allowed, rate limits on sends and group writes
```

**recommended.yaml** — good starting point:
- `conversations_add_message`: 5/min burst, 30/hour, 200/day cap
- `reactions_add`: 10/min burst, 60/hour cap
- `usergroups_users_update`: 3/min burst, 20/hour cap
- `usergroups_create`: 5/hour
- Read tools: allowed, 20-30/minute limits
- Global safety net: 60/minute across all tools

**strict.yaml** — for production/compliance:
- Default deny — only read and list tools are allowed
- All writes (messages, reactions, mark-as-read, group management) blocked unless explicitly opted in

**permissive.yaml** — for development:
- Everything allowed, rate limits on `conversations_add_message` (10/min, 500/day) and user group writes

## Usage

Wrap the MCP server with Intercept (one line):

```bash
npx -y @policylayer/intercept \
  --policy policies/recommended.yaml \
  -- /path/to/slack-mcp-server --transport stdio
```

Or in Claude Desktop config:

```json
{
  "mcpServers": {
    "slack": {
      "command": "npx",
      "args": [
        "-y", "@policylayer/intercept",
        "--policy", "policies/recommended.yaml",
        "--", "/path/to/slack-mcp-server",
        "--transport", "stdio"
      ],
      "env": {
        "SLACK_MCP_XOXP_TOKEN": "<your-token>",
        "SLACK_MCP_ADD_MESSAGE_TOOL": "true"
      }
    }
  }
}
```

## Why this matters

`SLACK_MCP_ADD_MESSAGE_TOOL` and `SLACK_MCP_ENABLED_TOOLS` control access but not behaviour. An agent with messaging enabled can send unlimited messages to any channel at any rate, with no daily cap and no audit trail. These policies add deterministic, transport-layer enforcement that complements the server's built-in controls.

## About PolicyLayer Intercept

- Open source (MIT): [github.com/policylayer/intercept](https://github.com/policylayer/intercept)
- npm: `@policylayer/intercept`
- Sub-millisecond evaluation, fail-closed, deterministic (not prompt-based)
- Supports all MCP clients: Claude Desktop, Claude Code, Cursor, VS Code, Windsurf, etc.
- Zero changes to the MCP server — wraps the command transparently
- Structured JSON audit logs for every tool call decision