### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "slack-mcp-server",
+  "version": "0.1.0",
+  "description": "The most powerful MCP Slack Server with no permission requirements, Apps support, GovSlack, DMs, Group DMs and smart history fetch logic.",
+  "author": {
+    "name": "Alexander Korotovsky",
+    "url": "https://github.com/korotovsky"
+  },
+  "homepage": "https://github.com/korotovsky/slack-mcp-server",
+  "repository": "https://github.com/korotovsky/slack-mcp-server",
+  "keywords": ["mcp", "codex", "slack", "messaging", "communication"],
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Slack Messaging",
+    "shortDescription": "Powerful MCP Slack Server with Apps support",
+    "longDescription": "The most powerful MCP Slack Server with no permission requirements, Apps support, GovSlack, DMs, Group DMs and smart history fetch logic.",
+    "category": "Productivity",
+    "websiteURL": "https://github.com/korotovsky/slack-mcp-server"
+  }
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,22 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "slack": {
+      "command": "go",
+      "args": ["run", "github.com/korotovsky/slack-mcp-server"]
+    }
+  }
+}

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: slack
+description: Power MCP Slack Server with Apps support
+---
+
+# Slack Messaging
+
+The most powerful MCP Slack Server with no permission requirements, Apps support, GovSlack, DMs, Group DMs and smart history fetch logic.
+
+## When to use
+- When you need Slack messaging capabilities in your Codex workflow
+- When you want to integrate with Slack via MCP
+- See https://github.com/korotovsky/slack-mcp-server for full setup instructions


### PR DESCRIPTION
I opened this as a small metadata pass for the Codex plugin surface in the repo.

A couple of repo-specific details I checked first:
- The most powerful MCP Slack Server with no permission requirements, Apps support, GovSlack, DMs, Group DMs and smart history fetch logic
- Safe Message Posting: The conversations_add_message tool is disabled by default for safety. Enable it via an environment variable, with optional channel restrictions
- Note: This tool is not available when using bot tokens (xoxb-). Bot tokens cannot use the search.messages API

This PR adds the Codex plugin metadata, an `.mcp.json` starting point, and the scanner workflow.
If you want different command wiring or manifest metadata, I can adjust the branch.