### PR TITLE
feat: render Slack Block Kit content in message text

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -1489,7 +1489,7 @@ func (ch *ConversationsHandler) convertMessagesFromHistory(slackMessages []slack
 			continue
 		}
 
-		msgText := msg.Text + text.AttachmentsTo2CSV(msg.Text, msg.Attachments)
+		msgText := text.MergeBlocksWithText(msg.Text, msg.Blocks) + text.AttachmentsTo2CSV(msg.Text, msg.Attachments)
 
 		var reactionParts []string
 		for _, r := range msg.Reactions {
@@ -1561,7 +1561,7 @@ func (ch *ConversationsHandler) convertMessagesFromSearch(slackMessages []slack.
 			continue
 		}
 
-		msgText := msg.Text + text.AttachmentsTo2CSV(msg.Text, msg.Attachments)
+		msgText := text.MergeBlocksWithText(msg.Text, msg.Blocks) + text.AttachmentsTo2CSV(msg.Text, msg.Attachments)
 
 		hasMedia := hasImageBlocks(msg.Blocks)
 

--- a/pkg/text/blocks.go
+++ b/pkg/text/blocks.go
@@ -1,0 +1,194 @@
+package text
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+// BlocksToText converts Slack block kit structures into plain text.
+// Returns empty string if no text content is found in blocks.
+func BlocksToText(blocks slack.Blocks) string {
+	if len(blocks.BlockSet) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, block := range blocks.BlockSet {
+		t := blockToText(block)
+		if t != "" {
+			parts = append(parts, t)
+		}
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+func blockToText(block slack.Block) string {
+	switch b := block.(type) {
+	case *slack.SectionBlock:
+		return sectionBlockToText(b)
+	case *slack.HeaderBlock:
+		return headerBlockToText(b)
+	case *slack.RichTextBlock:
+		return richTextBlockToText(b)
+	case *slack.ContextBlock:
+		return contextBlockToText(b)
+	case *slack.DividerBlock:
+		return ""
+	default:
+		return ""
+	}
+}
+
+func sectionBlockToText(b *slack.SectionBlock) string {
+	var parts []string
+
+	if b.Text != nil && b.Text.Text != "" {
+		parts = append(parts, b.Text.Text)
+	}
+
+	for _, field := range b.Fields {
+		if field != nil && field.Text != "" {
+			parts = append(parts, field.Text)
+		}
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+func headerBlockToText(b *slack.HeaderBlock) string {
+	if b.Text != nil && b.Text.Text != "" {
+		return b.Text.Text
+	}
+	return ""
+}
+
+func contextBlockToText(b *slack.ContextBlock) string {
+	var parts []string
+	for _, elem := range b.ContextElements.Elements {
+		switch e := elem.(type) {
+		case *slack.TextBlockObject:
+			if e.Text != "" {
+				parts = append(parts, e.Text)
+			}
+		case *slack.ImageBlockElement:
+			if e.AltText != "" {
+				parts = append(parts, e.AltText)
+			}
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func richTextBlockToText(b *slack.RichTextBlock) string {
+	var parts []string
+	for _, elem := range b.Elements {
+		t := richTextElementToText(elem)
+		if t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func richTextElementToText(elem slack.RichTextElement) string {
+	switch e := elem.(type) {
+	case *slack.RichTextSection:
+		return richTextSectionToText(e.Elements)
+	case *slack.RichTextList:
+		return richTextListToText(e)
+	case *slack.RichTextQuote:
+		section := slack.RichTextSection(*e)
+		t := richTextSectionToText(section.Elements)
+		if t != "" {
+			return "> " + strings.ReplaceAll(t, "\n", "\n> ")
+		}
+		return ""
+	case *slack.RichTextPreformatted:
+		t := richTextSectionToText(e.RichTextSection.Elements)
+		if t != "" {
+			return "```\n" + t + "\n```"
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+func richTextSectionToText(elements []slack.RichTextSectionElement) string {
+	var parts []string
+	for _, elem := range elements {
+		t := richTextSectionElementToText(elem)
+		if t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func richTextSectionElementToText(elem slack.RichTextSectionElement) string {
+	switch e := elem.(type) {
+	case *slack.RichTextSectionTextElement:
+		return e.Text
+	case *slack.RichTextSectionLinkElement:
+		if e.Text != "" {
+			return fmt.Sprintf("%s (%s)", e.Text, e.URL)
+		}
+		return e.URL
+	case *slack.RichTextSectionEmojiElement:
+		return fmt.Sprintf(":%s:", e.Name)
+	case *slack.RichTextSectionChannelElement:
+		return fmt.Sprintf("#%s", e.ChannelID)
+	case *slack.RichTextSectionUserElement:
+		return fmt.Sprintf("@%s", e.UserID)
+	case *slack.RichTextSectionBroadcastElement:
+		return fmt.Sprintf("@%s", e.Range)
+	case *slack.RichTextSectionDateElement:
+		if e.Fallback != nil {
+			return *e.Fallback
+		}
+		return ""
+	case *slack.RichTextSectionColorElement:
+		return e.Value
+	case *slack.RichTextSectionUserGroupElement:
+		return fmt.Sprintf("@%s", e.UsergroupID)
+	default:
+		return ""
+	}
+}
+
+func richTextListToText(list *slack.RichTextList) string {
+	var lines []string
+	for i, elem := range list.Elements {
+		t := richTextElementToText(elem)
+		if t == "" {
+			continue
+		}
+		prefix := "- "
+		if list.Style == slack.RTEListOrdered {
+			prefix = fmt.Sprintf("%d. ", i+list.Offset+1)
+		}
+		indent := strings.Repeat("  ", list.Indent)
+		lines = append(lines, indent+prefix+t)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// MergeBlocksWithText appends block-derived text to the message text
+// when blocks contain content not already present in the text field.
+func MergeBlocksWithText(msgText string, blocks slack.Blocks) string {
+	blockText := BlocksToText(blocks)
+	if blockText == "" {
+		return msgText
+	}
+	if msgText == "" {
+		return blockText
+	}
+	// If the text field already contains the block content, skip
+	if strings.Contains(msgText, blockText) {
+		return msgText
+	}
+	return msgText + "\n" + blockText
+}


### PR DESCRIPTION
## Summary

Bot messages (workflow automations, monitoring bots, etc.) often store their content exclusively in the `blocks` array rather than the `text` field. Previously this content was silently dropped, causing these messages to appear empty or with only a summary line in the CSV output.

This PR adds block content rendering so the full message data is available to MCP clients.

### Changes

- **New file `pkg/text/blocks.go`**: `BlocksToText()` function that traverses Block Kit structures and converts them to plain text. Supports:
  - `section` blocks (text + fields)
  - `header` blocks
  - `rich_text` blocks (sections, lists, quotes, preformatted)
  - `context` blocks (text + image alt text)
  - Rich text section elements: text, links, emoji, channels, users, broadcasts, dates, colors, user groups

- **`pkg/handler/conversations.go`**: Both `convertMessagesFromHistory` and `convertMessagesFromSearch` now call `MergeBlocksWithText()` to include block content in the text output. `MergeBlocksWithText` avoids duplication when both `text` and `blocks` contain the same content.

### Affected tools

- `conversations_history`
- `conversations_replies`
- `conversations_unreads`
- `conversations_search_messages`

### Example

Before (bot message with block-only content):
```
Text: "Details page 1 10 rows"
```

After:
```
Text: "Details page 1 10 rows\ncluster_id: abc123\nalert_types: Low Memory\nauto_upgrade: yes\n..."
```