### PR TITLE
fix: non-blocking stdio startup and --no-cache flag

### DIFF
--- a/cmd/slack-mcp-server/main.go
+++ b/cmd/slack-mcp-server/main.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/korotovsky/slack-mcp-server/pkg/provider"
 	"github.com/korotovsky/slack-mcp-server/pkg/server"
@@ -23,10 +22,12 @@ var defaultSsePort = 13080
 func main() {
 	var transport string
 	var enabledToolsFlag string
+	var noCache bool
 	flag.StringVar(&transport, "t", "stdio", "Transport type (stdio, sse or http)")
 	flag.StringVar(&transport, "transport", "stdio", "Transport type (stdio, sse or http)")
 	flag.StringVar(&enabledToolsFlag, "e", "", "Comma-separated list of enabled tools (empty = all tools)")
 	flag.StringVar(&enabledToolsFlag, "enabled-tools", "", "Comma-separated list of enabled tools (empty = all tools)")
+	flag.BoolVar(&noCache, "no-cache", false, "Skip user/channel cache loading on startup for faster initialization. Lookups by #channel-name or @username will not work; use channel/user IDs instead.")
 	flag.Parse()
 
 	if enabledToolsFlag == "" {
@@ -69,20 +70,26 @@ func main() {
 	p := provider.New(transport, logger)
 	s := server.NewMCPServer(p, logger, enabledTools)
 
-	go func() {
-		var once sync.Once
+	if noCache {
+		p.SkipCache()
+		logger.Info("Cache loading disabled via --no-cache flag",
+			zap.String("context", "console"),
+		)
+	} else {
+		go func() {
+			var once sync.Once
 
-		newUsersWatcher(p, &once, logger)()
-		newChannelsWatcher(p, &once, logger)()
-	}()
+			newUsersWatcher(p, &once, logger)()
+			newChannelsWatcher(p, &once, logger)()
+		}()
+	}
 
 	switch transport {
 	case "stdio":
-		for {
-			if ready, _ := p.IsReady(); ready {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
+		if ready, _ := p.IsReady(); !ready && !noCache {
+			logger.Info("Slack MCP Server is still warming up caches, starting server anyway",
+				zap.String("context", "console"),
+			)
 		}
 		if err := s.ServeStdio(); err != nil {
 			logger.Fatal("Server error",

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -228,11 +228,11 @@ type MCPSlackClient struct {
 	authResponse *slack.AuthTestResponse
 	authProvider auth.Provider
 
-	isEnterprise  bool
-	isOAuth       bool
-	isBotToken    bool
-	edgeFailed    bool // set when edge API fails; subsequent calls skip straight to standard API
-	teamEndpoint  string
+	isEnterprise bool
+	isOAuth      bool
+	isBotToken   bool
+	edgeFailed   bool // set when edge API fails; subsequent calls skip straight to standard API
+	teamEndpoint string
 }
 
 type ApiProvider struct {
@@ -1165,6 +1165,19 @@ func (ap *ApiProvider) IsReady() (bool, error) {
 		return false, ErrChannelsNotReady
 	}
 	return true, nil
+}
+
+// SkipCache marks both users and channels caches as ready without loading
+// any data. Lookups by #channel-name or @username will not work; callers
+// must use channel/user IDs instead.
+func (ap *ApiProvider) SkipCache() {
+	ap.usersMu.Lock()
+	ap.usersReady = true
+	ap.usersMu.Unlock()
+
+	ap.channelsMu.Lock()
+	ap.channelsReady = true
+	ap.channelsMu.Unlock()
 }
 
 func (ap *ApiProvider) ServerTransport() string {


### PR DESCRIPTION
## Summary

Fixes #271 — the stdio transport blocks the MCP `initialize` response until users/channels caches are fully loaded. On large workspaces (12k+ users, 43k+ channels) this takes 3-5 minutes, causing MCP clients with connection timeouts to drop the server.

## Changes

### 1. Non-blocking stdio startup (default behavior change)

Removed the busy-wait loop in `main.go` that blocked stdio from starting until `IsReady()` returned true:

```go
// BEFORE — blocks until caches are loaded
case "stdio":
    for {
        if ready, _ := p.IsReady(); ready {
            break
        }
        time.Sleep(100 * time.Millisecond)
    }
    s.ServeStdio()
```

```go
// AFTER — starts immediately, caches load in background
case "stdio":
    if ready, _ := p.IsReady(); !ready && !noCache {
        logger.Info("Slack MCP Server is still warming up caches, starting server anyway")
    }
    s.ServeStdio()
```

This matches the existing SSE/HTTP behavior, which already starts serving before caches are ready. Tool calls made before caches load return a graceful "not ready" error via the existing `buildErrorRecoveryMiddleware`, allowing the LLM to retry.

### 2. `--no-cache` CLI flag (opt-in)

For environments that only use channel/user IDs (never `#channel-name` or `@username` lookups), the `--no-cache` flag skips cache loading entirely:

```
slack-mcp-server --no-cache --transport stdio
```

This marks both `usersReady` and `channelsReady` as true immediately via a new `SkipCache()` method on `ApiProvider`, without loading any data. Startup is instant regardless of workspace size.

### Files changed

| File | Change |
|------|--------|
| `cmd/slack-mcp-server/main.go` | Add `--no-cache` flag, remove stdio busy-wait loop, add warm-up log message |
| `pkg/provider/api.go` | Add `SkipCache()` method |

## Testing

Tested on a workspace with 823 users and 1,418 channels:

| Mode | Startup time | Notes |
|------|-------------|-------|
| `--no-cache` | <1s | Instant, no cache loading |
| Default (no flag) | <1s | MCP handshake immediate, caches load in background |
| Original (upstream) | 30s+ timeout | Blocked on channel cache refresh |