### PR TITLE
Include file names in AttachmentIDs for message responses

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -1507,9 +1507,13 @@ func (ch *ConversationsHandler) convertMessagesFromHistory(slackMessages []slack
 
 		var attachmentIDs []string
 		for _, f := range msg.Files {
-			attachmentIDs = append(attachmentIDs, f.ID)
+			if f.Name != "" {
+				attachmentIDs = append(attachmentIDs, fmt.Sprintf("%s (%s)", f.ID, f.Name))
+			} else {
+				attachmentIDs = append(attachmentIDs, f.ID)
+			}
 		}
-		attachmentIDsStr := strings.Join(attachmentIDs, ",")
+		attachmentIDsStr := strings.Join(attachmentIDs, ", ")
 
 		messages = append(messages, Message{
 			MsgID:         msg.Timestamp,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -231,7 +231,7 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithString("file_id",
 				mcp.Required(),
-				mcp.Description("The ID of the attachment to download, in format Fxxxxxxxxxx. Attachment IDs can be found in message metadata when HasMedia is true or AttachmentCount > 0."),
+				mcp.Description("The ID of the attachment to download, in format Fxxxxxxxxxx. Attachment IDs (with filenames) can be found in the AttachmentIDs field of message metadata when FileCount > 0."),
 			),
 		), conversationsHandler.FilesGetHandler)
 	}


### PR DESCRIPTION
## Summary

Fixes #260

- Include file names alongside file IDs in the `AttachmentIDs` field of message responses from `slack_read_thread` and `slack_read_channel`
- Previously: `F08ABC1234,F08XYZ5678` — raw IDs with no way to identify which file is which
- Now: `F08ABC1234 (contract.pdf), F08XYZ5678 (report.xlsx)` — IDs with filenames so consumers can selectively download relevant attachments via `attachment_get_data`
- Updated `attachment_get_data` tool description to reference the new format

## Notes

- `convertMessagesFromSearch` is not updated because the upstream `slack-go` `SearchMessage` struct does not include a `Files` field — the Slack search API may return file data but it's silently dropped during unmarshalling. This would need an upstream fix in `slack-go/slack`.
- Falls back to ID-only format if a file has no name set.

## Test plan

- [ ] Read a channel/thread containing messages with file attachments
- [ ] Verify `AttachmentIDs` field now shows `F... (filename)` format
- [ ] Verify `attachment_get_data` still works when called with the file ID extracted from the new format
- [ ] Verify messages without attachments are unaffected