### PR TITLE
fix(text): stop deleting punctuation, emoji, and quotes from messages

### DIFF
--- a/pkg/text/text_processor.go
+++ b/pkg/text/text_processor.go
@@ -236,8 +236,11 @@ func normalizeLinks(text string) string {
 }
 
 // stripUnsafeRunes removes runes that are display-corrupting or carry no
-// semantic content: C0/C1 controls (except \t \n \r), DEL, BOM, zero-width
-// joiners, and bidi overrides (a known prompt-injection vector in chat corpora).
+// semantic content: C0/C1 controls (except \t \n \r), DEL, BOM, ZWSP,
+// LRM/RLM, bidi overrides, and bidi isolates. Bidi overrides are a known
+// prompt-injection vector in chat corpora. U+200C (ZWNJ) and U+200D (ZWJ)
+// are preserved: they are required for Persian and Arabic letter joining
+// and for emoji ZWJ sequences such as family and flag emoji.
 func stripUnsafeRunes(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
@@ -251,7 +254,7 @@ func stripUnsafeRunes(s string) string {
 			continue
 		case r == 0xFEFF:
 			continue
-		case r >= 0x200B && r <= 0x200F:
+		case r == 0x200B, r == 0x200E, r == 0x200F: // ZWSP, LRM, RLM; U+200C ZWNJ and U+200D ZWJ preserved
 			continue
 		case r >= 0x202A && r <= 0x202E:
 			continue

--- a/pkg/text/text_processor.go
+++ b/pkg/text/text_processor.go
@@ -44,8 +44,6 @@ func AttachmentToText(att slack.Attachment) string {
 	result = strings.ReplaceAll(result, "\n", " ")
 	result = strings.ReplaceAll(result, "\r", " ")
 	result = strings.ReplaceAll(result, "\t", " ")
-	result = strings.ReplaceAll(result, "(", "[")
-	result = strings.ReplaceAll(result, ")", "]")
 	result = strings.TrimSpace(result)
 
 	return result
@@ -174,9 +172,11 @@ func TimestampToIsoRFC3339(slackTS string) (string, error) {
 }
 
 func ProcessText(s string) string {
-	s = filterSpecialChars(s)
+	s = normalizeLinks(s)
+	s = stripUnsafeRunes(s)
+	s = collapseInlineSpaces(s)
 
-	return s
+	return strings.TrimSpace(s)
 }
 
 func HumanizeCertificates(certs []*x509.Certificate) string {
@@ -192,28 +192,14 @@ func HumanizeCertificates(certs []*x509.Certificate) string {
 	return strings.Join(descriptions, ", ")
 }
 
-func filterSpecialChars(text string) string {
-	replaceWithCommaCheck := func(match []string, isLast bool) string {
-		var url, linkText string
+var (
+	slackLinkRegex    = regexp.MustCompile(`<(https?://[^>|]+)\|([^>]+)>`)
+	markdownLinkRegex = regexp.MustCompile(`\[([^\]]+)\]\((https?://[^)]+)\)`)
+	htmlLinkRegex     = regexp.MustCompile(`<a\s+href=["']([^"']+)["'][^>]*>([^<]+)</a>`)
+	inlineSpaceRegex  = regexp.MustCompile(`[ \t]+`)
+)
 
-		if len(match) == 3 && strings.Contains(match[0], "|") {
-			url = match[1]
-			linkText = match[2]
-		} else if len(match) == 3 {
-			linkText = match[1]
-			url = match[2]
-		}
-
-		replacement := url + " - " + linkText
-
-		if !isLast {
-			replacement += ","
-		}
-
-		return replacement
-	}
-
-	// Helper function to check if this is the last link/element
+func normalizeLinks(text string) string {
 	isLastInText := func(original string, currentText string) bool {
 		linkPos := strings.LastIndex(currentText, original)
 		if linkPos == -1 {
@@ -223,60 +209,61 @@ func filterSpecialChars(text string) string {
 		return afterLink == ""
 	}
 
-	// Handle Slack-style links: <URL|Description>
-	slackLinkRegex := regexp.MustCompile(`<(https?://[^>|]+)\|([^>]+)>`)
-	slackMatches := slackLinkRegex.FindAllStringSubmatch(text, -1)
-	for _, match := range slackMatches {
-		original := match[0]
-		isLast := isLastInText(original, text)
-		replacement := replaceWithCommaCheck(match, isLast)
-		text = strings.Replace(text, original, replacement, 1)
-	}
-
-	// Handle markdown links: [Description](URL)
-	markdownLinkRegex := regexp.MustCompile(`\[([^\]]+)\]\((https?://[^)]+)\)`)
-	markdownMatches := markdownLinkRegex.FindAllStringSubmatch(text, -1)
-	for _, match := range markdownMatches {
-		original := match[0]
-		isLast := isLastInText(original, text)
-		replacement := replaceWithCommaCheck(match, isLast)
-		text = strings.Replace(text, original, replacement, 1)
-	}
-
-	htmlLinkRegex := regexp.MustCompile(`<a\s+href=["']([^"']+)["'][^>]*>([^<]+)</a>`)
-	htmlMatches := htmlLinkRegex.FindAllStringSubmatch(text, -1)
-	for _, match := range htmlMatches {
-		original := match[0]
-		isLast := isLastInText(original, text)
-		url := match[1]
-		linkText := match[2]
-		replacement := url + " - " + linkText
+	render := func(url, linkText string, isLast bool) string {
+		out := url + " - " + linkText
 		if !isLast {
-			replacement += ","
+			out += ","
 		}
-		text = strings.Replace(text, original, replacement, 1)
+		return out
 	}
 
-	urlRegex := regexp.MustCompile(`https?://[^\s<>"{}|\\^` + "`" + `\[\]]+`)
-	urls := urlRegex.FindAllString(text, -1)
-
-	protected := text
-	for i, url := range urls {
-		placeholder := "___URL_PLACEHOLDER_" + string(rune(48+i)) + "___"
-		protected = strings.Replace(protected, url, placeholder, 1)
+	for _, match := range slackLinkRegex.FindAllStringSubmatch(text, -1) {
+		original := match[0]
+		text = strings.Replace(text, original, render(match[1], match[2], isLastInText(original, text)), 1)
 	}
 
-	cleanRegex := regexp.MustCompile(`[^0-9\p{L}\p{M}\s\.\,\-_:/\?=&%]`)
-	cleaned := cleanRegex.ReplaceAllString(protected, "")
-
-	// Restore the URLs
-	for i, url := range urls {
-		placeholder := "___URL_PLACEHOLDER_" + string(rune(48+i)) + "___"
-		cleaned = strings.Replace(cleaned, placeholder, url, 1)
+	for _, match := range markdownLinkRegex.FindAllStringSubmatch(text, -1) {
+		original := match[0]
+		text = strings.Replace(text, original, render(match[2], match[1], isLastInText(original, text)), 1)
 	}
 
-	spaceRegex := regexp.MustCompile(`[ \t]+`)
-	cleaned = spaceRegex.ReplaceAllString(cleaned, " ")
+	for _, match := range htmlLinkRegex.FindAllStringSubmatch(text, -1) {
+		original := match[0]
+		text = strings.Replace(text, original, render(match[1], match[2], isLastInText(original, text)), 1)
+	}
 
-	return strings.TrimSpace(cleaned)
+	return text
+}
+
+// stripUnsafeRunes removes runes that are display-corrupting or carry no
+// semantic content: C0/C1 controls (except \t \n \r), DEL, BOM, zero-width
+// joiners, and bidi overrides (a known prompt-injection vector in chat corpora).
+func stripUnsafeRunes(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\t' || r == '\n' || r == '\r':
+			b.WriteRune(r)
+		case r < 0x20 || r == 0x7F:
+			continue
+		case r >= 0x80 && r <= 0x9F:
+			continue
+		case r == 0xFEFF:
+			continue
+		case r >= 0x200B && r <= 0x200F:
+			continue
+		case r >= 0x202A && r <= 0x202E:
+			continue
+		case r >= 0x2066 && r <= 0x2069:
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func collapseInlineSpaces(s string) string {
+	return inlineSpaceRegex.ReplaceAllString(s, " ")
 }

--- a/pkg/text/text_processor_test.go
+++ b/pkg/text/text_processor_test.go
@@ -108,7 +108,7 @@ func TestIsUnfurlingEnabled(t *testing.T) {
 	}
 }
 
-func TestFilterSpecialCharsWithCommas(t *testing.T) {
+func TestProcessText_LinkNormalization(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -149,13 +149,122 @@ func TestFilterSpecialCharsWithCommas(t *testing.T) {
 			input:    "Check this [Google](https://google.com) out",
 			expected: "Check this https://google.com - Google, out",
 		},
+		{
+			name:     "HTML anchor at end",
+			input:    `Visit <a href="https://example.com">Example</a>`,
+			expected: "Visit https://example.com - Example",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := filterSpecialChars(tt.input)
+			result := ProcessText(tt.input)
 			if result != tt.expected {
-				t.Errorf("filterSpecialChars() = %q, expected %q", result, tt.expected)
+				t.Errorf("ProcessText() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProcessText_PreservesContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "apostrophes in contractions",
+			input:    "I'll let you know what didn't work, it's fine",
+			expected: "I'll let you know what didn't work, it's fine",
+		},
+		{
+			name:     "straight double quotes",
+			input:    `she said "hello" and left`,
+			expected: `she said "hello" and left`,
+		},
+		{
+			name:     "curly quotes from iOS",
+			input:    "\u2018don\u2019t\u2019 \u201csay\u201d that",
+			expected: "\u2018don\u2019t\u2019 \u201csay\u201d that",
+		},
+		{
+			name:     "exclamation and question marks",
+			input:    "wow! really?! amazing!!",
+			expected: "wow! really?! amazing!!",
+		},
+		{
+			name:     "parentheses and brackets",
+			input:    "see note (important) and [aside]",
+			expected: "see note (important) and [aside]",
+		},
+		{
+			name:     "blockquote marker",
+			input:    "> this was quoted",
+			expected: "> this was quoted",
+		},
+		{
+			name:     "currency and math",
+			input:    "costs $5.00 (2+2 = 4)",
+			expected: "costs $5.00 (2+2 = 4)",
+		},
+		{
+			name:     "markdown emphasis",
+			input:    "*bold* _italic_ ~strike~ `code`",
+			expected: "*bold* _italic_ ~strike~ `code`",
+		},
+		{
+			name:     "unicode emoji",
+			input:    "great work \U0001F389 \U0001F44D",
+			expected: "great work \U0001F389 \U0001F44D",
+		},
+		{
+			name:     "raw slack mention markup",
+			input:    "cc <@U0123ABC> in <#C0456DEF|general>",
+			expected: "cc <@U0123ABC> in <#C0456DEF|general>",
+		},
+		{
+			name:     "raw broadcast mention",
+			input:    "<!channel> please review",
+			expected: "<!channel> please review",
+		},
+		{
+			name:     "preserves newlines, collapses inline spaces",
+			input:    "first line\n\nsecond  line   with   gaps",
+			expected: "first line\n\nsecond line with gaps",
+		},
+		{
+			name:     "strips bidi override (prompt injection vector)",
+			input:    "safe\u202etext",
+			expected: "safetext",
+		},
+		{
+			name:     "strips zero-width joiner and BOM",
+			input:    "a\u200bb\ufeffc",
+			expected: "abc",
+		},
+		{
+			name:     "strips DEL and C0 controls; tabs collapse to space, newlines kept",
+			input:    "ok\x01\x7fmessage\twith\ntabs",
+			expected: "okmessage with\ntabs",
+		},
+		{
+			name: "twelve URLs in one message (regression for placeholder bug)",
+			input: "see https://a.example/1 and https://b.example/2 and https://c.example/3 " +
+				"and https://d.example/4 and https://e.example/5 and https://f.example/6 " +
+				"and https://g.example/7 and https://h.example/8 and https://i.example/9 " +
+				"and https://j.example/10 and https://k.example/11 and https://l.example/12",
+			expected: "see https://a.example/1 and https://b.example/2 and https://c.example/3 " +
+				"and https://d.example/4 and https://e.example/5 and https://f.example/6 " +
+				"and https://g.example/7 and https://h.example/8 and https://i.example/9 " +
+				"and https://j.example/10 and https://k.example/11 and https://l.example/12",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ProcessText(tt.input)
+			if result != tt.expected {
+				t.Errorf("ProcessText(%q)\n  got:  %q\n  want: %q", tt.input, result, tt.expected)
 			}
 		})
 	}

--- a/pkg/text/text_processor_test.go
+++ b/pkg/text/text_processor_test.go
@@ -238,9 +238,24 @@ func TestProcessText_PreservesContent(t *testing.T) {
 			expected: "safetext",
 		},
 		{
-			name:     "strips zero-width joiner and BOM",
+			name:     "strips ZWSP and BOM",
 			input:    "a\u200bb\ufeffc",
 			expected: "abc",
+		},
+		{
+			name:     "preserves ZWJ in family emoji sequence",
+			input:    "hi \U0001F468\u200D\U0001F469\u200D\U0001F467 bye",
+			expected: "hi \U0001F468\u200D\U0001F469\u200D\U0001F467 bye",
+		},
+		{
+			name:     "preserves ZWJ and VS16 in rainbow flag",
+			input:    "\U0001F3F3\uFE0F\u200D\U0001F308",
+			expected: "\U0001F3F3\uFE0F\u200D\U0001F308",
+		},
+		{
+			name:     "preserves ZWNJ in Persian text",
+			input:    "\u0645\u06CC\u200C\u062E\u0648\u0627\u0647\u0645",
+			expected: "\u0645\u06CC\u200C\u062E\u0648\u0627\u0647\u0645",
 		},
 		{
 			name:     "strips DEL and C0 controls; tabs collapse to space, newlines kept",

--- a/pkg/text/text_processor_test.go
+++ b/pkg/text/text_processor_test.go
@@ -248,15 +248,15 @@ func TestProcessText_PreservesContent(t *testing.T) {
 			expected: "okmessage with\ntabs",
 		},
 		{
-			name: "twelve URLs in one message (regression for placeholder bug)",
-			input: "see https://a.example/1 and https://b.example/2 and https://c.example/3 " +
-				"and https://d.example/4 and https://e.example/5 and https://f.example/6 " +
-				"and https://g.example/7 and https://h.example/8 and https://i.example/9 " +
-				"and https://j.example/10 and https://k.example/11 and https://l.example/12",
-			expected: "see https://a.example/1 and https://b.example/2 and https://c.example/3 " +
-				"and https://d.example/4 and https://e.example/5 and https://f.example/6 " +
-				"and https://g.example/7 and https://h.example/8 and https://i.example/9 " +
-				"and https://j.example/10 and https://k.example/11 and https://l.example/12",
+			name: "twelve Slack-style links in one message (regression for placeholder bug)",
+			input: "see <https://a.example/1|one> and <https://b.example/2|two> and <https://c.example/3|three> " +
+				"and <https://d.example/4|four> and <https://e.example/5|five> and <https://f.example/6|six> " +
+				"and <https://g.example/7|seven> and <https://h.example/8|eight> and <https://i.example/9|nine> " +
+				"and <https://j.example/10|ten> and <https://k.example/11|eleven> and <https://l.example/12|twelve>",
+			expected: "see https://a.example/1 - one, and https://b.example/2 - two, and https://c.example/3 - three, " +
+				"and https://d.example/4 - four, and https://e.example/5 - five, and https://f.example/6 - six, " +
+				"and https://g.example/7 - seven, and https://h.example/8 - eight, and https://i.example/9 - nine, " +
+				"and https://j.example/10 - ten, and https://k.example/11 - eleven, and https://l.example/12 - twelve",
 		},
 	}
 


### PR DESCRIPTION
## What's broken

The MCP runs every Slack message through a regex that only keeps a small whitelist of characters. Anything not on the list gets silently deleted before the message is handed back. In practice that means a lot of meaningful content disappears:

| Input | What comes back |
|---|---|
| `I'll, didn't, it's` | `Ill, didnt, its` |
| `she said "hello"` | `she said hello` |
| `wow! really?!` | `wow really?` |
| `*bold* _italic_ ~strike~` `` `code` `` | `bold italic strike code` |
| `(note) [aside]` | `note aside` |
| `> quoted` | `quoted` |
| `costs $5.00` | `costs 5.00` |
| `🎉 👍` | (deleted) |
| `'curly' "quotes"` (iOS keyboard) | `curly quotes` |
| `<@U123>` (user mention) | `U123` |
| `<#C456&#124;chan>` (channel mention) | `C456chan` |

The CSV layer (`gocsv`) already handles its own escaping for commas, quotes, and newlines, so this filter isn't protecting any output format. It's just throwing away message content.

There's also a related bug in the same function: when a single message has 12 or more Slack-style `<URL|text>` links, the 12th one comes back garbled. The cause is the URL-protection placeholder using `string(rune(48 + i))`, which produces `;` at i=11, which the same whitelist regex then strips.

And `AttachmentToText` has a leftover `(` to `[` and `)` to `]` substitution that only existed to survive the bracket-stripping. With the regex gone, it's a no-op that just confuses parens.

## Why the filter exists

Looking at the history:

- April 2025 (`6bfa56f`): `ProcessText` was a stopwords filter using `bbalet/stopwords`. The point was to shrink message text by dropping common English words like "the" and "is" before sending to an LLM.
- June 2025 (`4e7e96f`): The stopwords filter was replaced with link normalization, which is genuinely useful (Slack's `<URL|text>` syntax is hard to read). The whitelist regex was added in the same commit, but the commit message ("resolve html, markdown and slack links correctly") only talks about the link work. The regex looks like a leftover from the same "trim things down" instinct, not something that was ever actively justified.

The trade-off doesn't really hold up today: shaving a few characters of punctuation isn't worth losing apostrophes that change meaning (`we'll` vs `well`), quoted speech, currency, emoji, and so on. An MCP server's job is to give the LLM the source of truth and let the LLM decide what matters.

## What this PR changes

`ProcessText` now does three small, named passes:

1. `normalizeLinks` converts the three link forms (Slack `<URL|text>`, markdown `[text](url)`, HTML `<a>`) into `URL - text`. This keeps the existing comma-on-non-last-link behavior. The placeholder dance is gone, since there's no longer any cleanup step that could mangle URLs.
2. `stripUnsafeRunes` removes a small set of characters that are either invisible or dangerous: C0/C1 control characters (except tab, newline, carriage return), DEL, the byte-order mark, ZWSP, LRM/RLM, bidi overrides, and bidi isolates. Bidi overrides are worth calling out, they're a real prompt-injection vector in chat data. U+200C (ZWNJ) and U+200D (ZWJ) are deliberately preserved, since they're load-bearing for Persian/Arabic letter joining and for emoji ZWJ sequences (family emoji, rainbow flag, etc.).
3. `collapseInlineSpaces` turns runs of spaces and tabs into a single space, while leaving newlines alone (this matches the behavior introduced in `03cb013`).

`AttachmentToText` loses the dead `(` to `[` and `)` to `]` substitution.

## Tests

- Existing 7 link-conversion cases kept and renamed to `TestProcessText_LinkNormalization`. One new HTML-anchor case added. All pass.
- New `TestProcessText_PreservesContent` covers: apostrophes, straight and curly quotes, exclamations, parens and brackets, blockquote markers, currency, markdown emphasis, Unicode emoji, raw Slack mention syntax, newline preservation alongside inline-space collapsing, the bidi/BOM/ZWSP strip, control character handling, a 12-link regression case for the placeholder bug, and ZWNJ/ZWJ preservation for Persian text, family emoji, and rainbow-flag sequences.
- `go test ./...`, `gofmt`, and `go vet` are clean. Integration tests skip when `SLACK_MCP_XOXP_TOKEN` isn't set.

## What's not in this PR

- Resolving `<@U123>` to `@username`. Mentions pass through raw here. PR #233 already covers this and can layer on top once one of us merges.
- Block Kit text extraction (PRs #190 and #275).
- Bot/integration structured content (PR #272).

## Heads up on conflicts

Several open PRs touch this file: #233, #190, #272, #259, #192, #188, #195, #166. PR #272 in particular rewrites the test file, so whichever of us merges second will need to rebase. Happy to do that whichever direction works.
