### PR TITLE
fix(text): preserve full-width ASCII characters (zenkaku)

### DIFF
--- a/pkg/text/text_processor.go
+++ b/pkg/text/text_processor.go
@@ -266,7 +266,7 @@ func filterSpecialChars(text string) string {
 		protected = strings.Replace(protected, url, placeholder, 1)
 	}
 
-	cleanRegex := regexp.MustCompile(`[^0-9\p{L}\p{M}\s\.\,\-_:/\?=&%]`)
+	cleanRegex := regexp.MustCompile(`[^0-9\p{L}\p{M}\p{Zs}\s\.\,\-_:/\?=&%！-～]`)
 	cleaned := cleanRegex.ReplaceAllString(protected, "")
 
 	// Restore the URLs


### PR DESCRIPTION
## Summary

The `filterSpecialChars` function was stripping full-width ASCII characters (zenkaku) from text output. Characters like ：(U+FF1A), ０-９(U+FF10-FF19), （）(U+FF08-FF09), 　(U+3000 ideographic space), and 〜(U+FF5E) were being removed.

## Problem

Example from issue #282:
- Input: `時間：５月１日　15時頃〜`
- Expected output: `時間：５月１日　15時頃〜`
- Actual output: `時間月日15時頃`

## Changes

Modified the `cleanRegex` in `filterSpecialChars` to preserve:
- `\p{Zs}` - Space separators (includes ideographic space U+3000)
- `！-～` - Full-width ASCII range (U+FF01-U+FF5E)

## Fixes

Fixes #282