### PR TITLE
fix(text): remove parentheses replacement that broke markdown links

### DIFF
--- a/pkg/text/text_processor.go
+++ b/pkg/text/text_processor.go
@@ -44,8 +44,6 @@ func AttachmentToText(att slack.Attachment) string {
 	result = strings.ReplaceAll(result, "\n", " ")
 	result = strings.ReplaceAll(result, "\r", " ")
 	result = strings.ReplaceAll(result, "\t", " ")
-	result = strings.ReplaceAll(result, "(", "[")
-	result = strings.ReplaceAll(result, ")", "]")
 	result = strings.TrimSpace(result)
 
 	return result


### PR DESCRIPTION
## Summary
- Remove unconditional replacement of `(` → `[` and `)` → `]` in `AttachmentToText`
- This was breaking standard markdown link syntax `[text](url)` turning it into `[text][url]`
- The original CSV-safety intent is no longer needed with the current semicolon-delimited output format

## Test plan
- [x] Build passes (`go build ./pkg/text/...`)
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)