### PR TITLE
fix(main): serve stdio immediately without waiting for cache warmup

### DIFF
--- a/cmd/slack-mcp-server/main.go
+++ b/cmd/slack-mcp-server/main.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/korotovsky/slack-mcp-server/pkg/provider"
 	"github.com/korotovsky/slack-mcp-server/pkg/server"
@@ -76,14 +75,11 @@ func main() {
 		newChannelsWatcher(p, &once, logger)()
 	}()
 
-	switch transport {
+switch transport {
 	case "stdio":
-		for {
-			if ready, _ := p.IsReady(); ready {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
+		// Start serving immediately without waiting for cache warmup.
+		// This allows MCP initialize and tools/list to respond immediately
+		// while caching happens in the background.
 		if err := s.ServeStdio(); err != nil {
 			logger.Fatal("Server error",
 				zap.String("context", "console"),


### PR DESCRIPTION
## Summary
- Remove blocking wait for cache warmup on stdio transport
- Server now responds to MCP `initialize` and `tools/list` immediately
- Caching continues in the background (via goroutines started at startup)
- Tool calls that need cached data will wait or return appropriate errors

## Problem
On large Slack workspaces (~12.8k users, ~43k channels), the server cached users (~11s) and channels (3-5 min) BEFORE responding to the MCP initialize request. This caused MCP clients with 60-second timeouts (like Claude Code) to drop the server.

## Solution
The stdio transport now calls `s.ServeStdio()` immediately without waiting for `p.IsReady()`. Background goroutines (started at lines 72-77) handle caching asynchronously.

## Test plan
- [x] Build passes
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)