### PR TITLE
fix(provider): add PatchUser for O(1) cache miss recovery

### DIFF
--- a/cmd/slack-mcp-server/main.go
+++ b/cmd/slack-mcp-server/main.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/korotovsky/slack-mcp-server/pkg/provider"
 	"github.com/korotovsky/slack-mcp-server/pkg/server"
@@ -76,14 +75,11 @@ func main() {
 		newChannelsWatcher(p, &once, logger)()
 	}()
 
-	switch transport {
+switch transport {
 	case "stdio":
-		for {
-			if ready, _ := p.IsReady(); ready {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
+		// Start serving immediately without waiting for cache warmup.
+		// This allows MCP initialize and tools/list to respond immediately
+		// while caching happens in the background.
 		if err := s.ServeStdio(); err != nil {
 			logger.Fatal("Server error",
 				zap.String("context", "console"),

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -1473,7 +1473,7 @@ func (ch *ConversationsHandler) convertMessagesFromHistory(slackMessages []slack
 			continue
 		}
 
-		userName, realName, ok := getUserInfo(msg.User, usersMap.Users)
+		userName, realName, ok := getUserInfo(ch, msg.User, usersMap.Users)
 
 		if !ok && msg.SubType == "bot_message" {
 			userName, realName, ok = getBotInfo(msg.Username)
@@ -1545,7 +1545,7 @@ func (ch *ConversationsHandler) convertMessagesFromSearch(slackMessages []slack.
 	warn := false
 
 	for _, msg := range slackMessages {
-		userName, realName, ok := getUserInfo(msg.User, usersMap.Users)
+		userName, realName, ok := getUserInfo(ch, msg.User, usersMap.Users)
 
 		if !ok && msg.User == "" && msg.Username != "" {
 			userName, realName, ok = getBotInfo(msg.Username)
@@ -1971,6 +1971,13 @@ func (ch *ConversationsHandler) paramFormatUser(raw string) (string, error) {
 	if isSlackUserIDPrefix(raw) {
 		u, ok := users.Users[raw]
 		if !ok {
+			// Attempt to recover from cache miss by fetching user via users.info
+			if err := ch.apiProvider.PatchUser(context.Background(), raw); err == nil {
+				users = ch.apiProvider.ProvideUsersMap()
+				if u, ok = users.Users[raw]; ok {
+					return fmt.Sprintf("<@%s>", u.ID), nil
+				}
+			}
 			return "", fmt.Errorf("user %q not found", raw)
 		}
 		return fmt.Sprintf("<@%s>", u.ID), nil
@@ -2015,9 +2022,16 @@ func marshalMessagesToCSV(messages []Message) (*mcp.CallToolResult, error) {
 	return mcp.NewToolResultText(string(csvBytes)), nil
 }
 
-func getUserInfo(userID string, usersMap map[string]slack.User) (userName, realName string, ok bool) {
+func getUserInfo(ch *ConversationsHandler, userID string, usersMap map[string]slack.User) (userName, realName string, ok bool) {
 	if u, ok := usersMap[userID]; ok {
 		return u.Name, u.RealName, true
+	}
+	// Attempt to recover from cache miss by fetching user via users.info
+	if err := ch.apiProvider.PatchUser(context.Background(), userID); err == nil {
+		usersMap = ch.apiProvider.ProvideUsersMap().Users
+		if u, ok := usersMap[userID]; ok {
+			return u.Name, u.RealName, true
+		}
 	}
 	return userID, userID, false
 }

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -1150,6 +1151,55 @@ func (ap *ApiProvider) GetChannels(ctx context.Context, channelTypes []string) [
 func (ap *ApiProvider) ProvideUsersMap() *UsersCache {
 	// Atomic load - no lock needed, snapshot is immutable
 	return ap.usersSnapshot.Load()
+}
+
+// PatchUser fetches a single user via users.info API and patches the in-memory cache.
+// This enables O(1) recovery for cache misses without triggering a full cache rebuild.
+func (ap *ApiProvider) PatchUser(ctx context.Context, userID string) error {
+	if userID == "" {
+		return fmt.Errorf("user ID is required")
+	}
+
+	// Fetch fresh user data from Slack API
+	usersInfo, err := ap.client.GetUsersInfo(userID)
+	if err != nil {
+		ap.logger.Debug("Failed to fetch user info",
+			zap.String("user_id", userID),
+			zap.Error(err))
+		return err
+	}
+	if len(*usersInfo) == 0 {
+		return fmt.Errorf("user %q not found", userID)
+	}
+	user := (*usersInfo)[0]
+
+	// Load current snapshot
+	currentSnapshot := ap.usersSnapshot.Load()
+
+	// Create new snapshot with patched user
+	newSnapshot := &UsersCache{
+		Users:    make(map[string]slack.User, len(currentSnapshot.Users)+1),
+		UsersInv: make(map[string]string, len(currentSnapshot.UsersInv)+1),
+	}
+	for k, v := range currentSnapshot.Users {
+		newSnapshot.Users[k] = v
+	}
+	for k, v := range currentSnapshot.UsersInv {
+		newSnapshot.UsersInv[k] = v
+	}
+
+	// Apply patch
+	newSnapshot.Users[user.ID] = user
+	newSnapshot.UsersInv[user.Name] = user.ID
+
+	// Atomically replace snapshot
+	ap.usersSnapshot.Store(newSnapshot)
+
+	ap.logger.Debug("Patched user cache",
+		zap.String("user_id", userID),
+		zap.String("user_name", user.Name))
+
+	return nil
 }
 
 func (ap *ApiProvider) ProvideChannelsMaps() *ChannelsCache {


### PR DESCRIPTION
When a user ID isn't in the cache, PatchUser fetches via users.info and patches the snapshot atomically. Fixes #268.