### PR TITLE
fix(provider): change SsoSyncWithProvider to json.RawMessage to handle numeric value

### DIFF
--- a/pkg/provider/edge/client_boot.go
+++ b/pkg/provider/edge/client_boot.go
@@ -541,7 +541,7 @@ type Prefs struct {
 	SsoDisableEmails                                               bool                           `json:"sso_disable_emails"`
 	SsoOptional                                                    bool                           `json:"sso_optional"`
 	SsoSignupRestrictions                                          int64                          `json:"sso_signup_restrictions"`
-	SsoSyncWithProvider                                            bool                           `json:"sso_sync_with_provider"`
+	SsoSyncWithProvider                                            json.RawMessage `json:"sso_sync_with_provider"`
 	StatsOnlyAdmins                                                bool                           `json:"stats_only_admins"`
 	SubteamsAutoCreateAdmin                                        bool                           `json:"subteams_auto_create_admin"`
 	SubteamsAutoCreateOwner                                        bool                           `json:"subteams_auto_create_owner"`


### PR DESCRIPTION
## Summary
- Fix #250 - Fatal crash on startup: `cannot unmarshal number into sso_sync_with_provider (type bool)`
- Change `SsoSyncWithProvider` field type from `bool` to `json.RawMessage` to handle both bool and numeric values from Slack API

## Problem
The server authenticates successfully but crashes during user cache warmup with a JSON unmarshal error. The Slack API returns a number for `Prefs.team.prefs.sso_sync_with_provider` where the Go struct expects a `bool`.

## Solution
Use `json.RawMessage` for flexible type handling - the field value is stored but not parsed, avoiding the unmarshal error. If the value is needed later, proper type handling can be added.

## Test plan
- [ ] Verify server starts without crash on affected workspaces
- [ ] Verify existing functionality with standard bool values still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)