### PR TITLE
feat: support raw Block Kit blocks in message posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ Add a message to a public channel, private channel, or direct message (DM, or IM
 - **Parameters:**
   - `channel_id` (string, required): ID of the channel in format `Cxxxxxxxxxx` or its name starting with `#...` or `@...` aka `#general` or `@username_dm`.
   - `thread_ts` (string, optional): Unique identifier of either a thread’s parent message or a message in the thread_ts must be the timestamp in format `1234567890.123456` of an existing message with 0 or more replies. Optional, if not provided the message will be added to the channel itself, otherwise it will be added to the thread.
-  - `payload` (string, required): Message payload in specified content_type format. Example: 'Hello, world!' for text/plain or '# Hello, world!' for text/markdown.
+  - `text` (string, optional): Message text in specified content_type format. Example: 'Hello, world!' for text/plain or '# Hello, world!' for text/markdown. `payload` is still accepted as a backward-compatible alias.
   - `content_type` (string, default: "text/markdown"): Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'.
+  - `blocks` (array, optional): Raw Slack Block Kit blocks. When provided, blocks are sent directly to Slack and `text`/`payload` is used only as fallback text. Use this for native Slack table blocks.
 
 ### 4. conversations_search_messages
 Search messages in a public channel, private channel, or direct message (DM, or IM) conversation using filters. All filters are optional, if not provided then search_query is required.

--- a/pkg/handler/block_posting_test.go
+++ b/pkg/handler/block_posting_test.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRawBlocksAcceptsSlackTableBlock(t *testing.T) {
+	blocks, err := parseRawBlocks(mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]any{
+				"blocks": []any{
+					map[string]any{
+						"type": "table",
+						"rows": []any{
+							[]any{
+								map[string]any{"type": "raw_text", "text": "Header"},
+							},
+							[]any{
+								map[string]any{"type": "raw_text", "text": "Value"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, "table", string(blocks[0].BlockType()))
+}
+
+func TestParseRawBlocksRejectsBlockWithoutType(t *testing.T) {
+	_, err := parseRawBlocks(mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]any{
+				"blocks": []any{map[string]any{"text": "missing type"}},
+			},
+		},
+	})
+
+	require.ErrorContains(t, err, "blocks[0].type is required")
+}

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -96,6 +97,27 @@ type addMessageParams struct {
 	threadTs    string
 	text        string
 	contentType string
+	blocks      []slack.Block
+}
+
+type rawSlackBlock map[string]any
+
+func (b rawSlackBlock) BlockType() slack.MessageBlockType {
+	if blockType, ok := b["type"].(string); ok {
+		return slack.MessageBlockType(blockType)
+	}
+	return ""
+}
+
+func (b rawSlackBlock) ID() string {
+	if id, ok := b["block_id"].(string); ok {
+		return id
+	}
+	return ""
+}
+
+func (b rawSlackBlock) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any(b))
 }
 
 type addReactionParams struct {
@@ -221,21 +243,28 @@ func (ch *ConversationsHandler) ConversationsAddMessageHandler(ctx context.Conte
 		options = append(options, slack.MsgOptionTS(params.threadTs))
 	}
 
-	switch params.contentType {
-	case "text/plain":
-		options = append(options, slack.MsgOptionDisableMarkdown())
-		options = append(options, slack.MsgOptionText(params.text, false))
-	case "text/markdown":
-		blocks, err := slackGoUtil.ConvertMarkdownTextToBlocks(params.text)
-		if err != nil {
-			ch.logger.Warn("Markdown parsing error", zap.Error(err))
+	if len(params.blocks) > 0 {
+		if params.text != "" {
+			options = append(options, slack.MsgOptionText(params.text, false))
+		}
+		options = append(options, slack.MsgOptionBlocks(params.blocks...))
+	} else {
+		switch params.contentType {
+		case "text/plain":
 			options = append(options, slack.MsgOptionDisableMarkdown())
 			options = append(options, slack.MsgOptionText(params.text, false))
-		} else {
-			options = append(options, slack.MsgOptionBlocks(blocks...))
+		case "text/markdown":
+			blocks, err := slackGoUtil.ConvertMarkdownTextToBlocks(params.text)
+			if err != nil {
+				ch.logger.Warn("Markdown parsing error", zap.Error(err))
+				options = append(options, slack.MsgOptionDisableMarkdown())
+				options = append(options, slack.MsgOptionText(params.text, false))
+			} else {
+				options = append(options, slack.MsgOptionBlocks(blocks...))
+			}
+		default:
+			return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")
 		}
-	default:
-		return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")
 	}
 
 	unfurlOpt := os.Getenv("SLACK_MCP_ADD_MESSAGE_UNFURLING")
@@ -1698,9 +1727,14 @@ func (ch *ConversationsHandler) parseParamsToolAddMessage(ctx context.Context, r
 		// Backward compatibility with "payload" parameter
 		msgText = request.GetString("payload", "")
 	}
-	if msgText == "" {
-		ch.logger.Error("Message text missing")
-		return nil, errors.New("text must be a string")
+	blocks, err := parseRawBlocks(request)
+	if err != nil {
+		ch.logger.Error("Invalid blocks", zap.Error(err))
+		return nil, err
+	}
+	if msgText == "" && len(blocks) == 0 {
+		ch.logger.Error("Message text and blocks missing")
+		return nil, errors.New("text or blocks must be provided")
 	}
 
 	contentType := request.GetString("content_type", "text/markdown")
@@ -1714,7 +1748,41 @@ func (ch *ConversationsHandler) parseParamsToolAddMessage(ctx context.Context, r
 		threadTs:    threadTs,
 		text:        msgText,
 		contentType: contentType,
+		blocks:      blocks,
 	}, nil
+}
+
+func parseRawBlocks(request mcp.CallToolRequest) ([]slack.Block, error) {
+	args := request.GetArguments()
+	if args == nil {
+		return nil, nil
+	}
+	blocksArg, ok := args["blocks"]
+	if !ok || blocksArg == nil {
+		return nil, nil
+	}
+
+	blocksJSON, err := json.Marshal(blocksArg)
+	if err != nil {
+		return nil, fmt.Errorf("blocks must be valid JSON: %w", err)
+	}
+
+	var rawBlocks []rawSlackBlock
+	if err := json.Unmarshal(blocksJSON, &rawBlocks); err != nil {
+		return nil, fmt.Errorf("blocks must be an array of Slack Block Kit block objects: %w", err)
+	}
+	if len(rawBlocks) == 0 {
+		return nil, errors.New("blocks must not be empty when provided")
+	}
+
+	blocks := make([]slack.Block, 0, len(rawBlocks))
+	for i, block := range rawBlocks {
+		if block.BlockType() == "" {
+			return nil, fmt.Errorf("blocks[%d].type is required", i)
+		}
+		blocks = append(blocks, block)
+	}
+	return blocks, nil
 }
 
 func (ch *ConversationsHandler) parseParamsToolReaction(ctx context.Context, request mcp.CallToolRequest) (*addReactionParams, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -183,6 +183,13 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.DefaultString("text/markdown"),
 				mcp.Description("Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'."),
 			),
+			mcp.WithArray("blocks",
+				mcp.Description("Optional raw Slack Block Kit blocks array. When provided, blocks are sent directly to Slack and text/payload is used only as fallback text."),
+				mcp.Items(map[string]any{
+					"type":                 "object",
+					"additionalProperties": true,
+				}),
+			),
 		), conversationsHandler.ConversationsAddMessageHandler)
 	}
 


### PR DESCRIPTION
## Summary

- Add optional raw Slack Block Kit `blocks` support to `conversations_add_message`.
- Preserve the existing `text` / backward-compatible `payload` behavior for plain and markdown messages.
- Add a focused unit test for accepting Slack `table` blocks.
- Document the new `blocks` parameter in the README.

## Why

The existing message-posting tool only accepts text and converts markdown into Slack blocks internally. That works for simple messages, but it cannot produce Slack-native structures that are only available through raw Block Kit, especially `type: "table"` blocks. Markdown tables, TSV, and HTML text are rendered as plain text by Slack rather than real Slack tables.

This change lets MCP clients post richer Slack messages through the same existing safety gates (`SLACK_MCP_ADD_MESSAGE_TOOL` / `SLACK_MCP_ENABLED_TOOLS`). It enables native table blocks for report-style output, and also allows other Slack-supported Block Kit layouts when a client needs structured formatting beyond markdown.

## Testing

- `go build -o slack-mcp-server ./cmd/slack-mcp-server`
- `go test ./pkg/handler -run 'TestParseRawBlocks'`
- `go test ./pkg/server ./pkg/text ./pkg/limiter ./pkg/provider ./pkg/provider/edge ./pkg/provider/edge/fasttime ./pkg/transport`

Note: full `go test ./...` requires integration env such as `SLACK_MCP_XOXP_TOKEN` and `SLACK_MCP_OPENAI_API` in current upstream tests.
