### PR TITLE
fix: handle Slack refresh token format (xoxe)

### DIFF
--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -301,8 +301,9 @@ func NewMCPSlackClient(authProvider auth.Provider, logger *zap.Logger) (*MCPSlac
 	// Token type detection
 	// isOAuth: Official OAuth tokens (xoxp or xoxb) - uses Standard API
 	// isBotToken: Bot token - determines feature availability (e.g., search)
-	isOAuth := strings.HasPrefix(token, "xoxp-") || strings.HasPrefix(token, "xoxb-")
-	isBotToken := strings.HasPrefix(token, "xoxb-")
+	// xoxe.xoxp- and xoxe.xoxb- are token-rotation variants of xoxp/xoxb (same scopes, 12h expiry)
+	isOAuth := strings.HasPrefix(token, "xoxp-") || strings.HasPrefix(token, "xoxb-") || strings.HasPrefix(token, "xoxe.xoxp-") || strings.HasPrefix(token, "xoxe.xoxb-")
+	isBotToken := strings.HasPrefix(token, "xoxb-") || strings.HasPrefix(token, "xoxe.xoxb-")
 
 	return &MCPSlackClient{
 		slackClient:  slackClient,


### PR DESCRIPTION
re https://github.com/korotovsky/slack-mcp-server/issues/115

Slack's docs https://api.slack.com/authentication/rotation and oauth.v2.access https://api.slack.com/methods/oauth.v2.access, xoxe.xoxp tokens carry have the same scopes/permissions to the regular ones. Slack apps with token rotation enabled seem to issue these instead of xoxp- tokens.