### PR TITLE
fix: overwrite entrypoint in docker-compose to make dlv work

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,6 +4,7 @@ services:
         context: .
         target: dev
         dockerfile: Dockerfile
+    entrypoint: []
     command: /dlv debug /app/cmd/slack-mcp-server/main.go --accept-multiclient --headless --listen=:40000 --api-version=2 --log -- --transport sse
     restart: unless-stopped
     networks:

--- a/docker-compose.toolkit.yml
+++ b/docker-compose.toolkit.yml
@@ -4,7 +4,8 @@ services:
         context: .
         target: production
         dockerfile: Dockerfile
-    # Uncomment to have delve debug on port 40000
+    # Uncomment below to have delve debug on port 40000
+    # entrypoint: []
     # command: /dlv debug /app/cmd/slack-mcp-server/main.go --headless --listen=:40000 --api-version=2 --log -- --transport sse
     restart: unless-stopped
     networks:


### PR DESCRIPTION
# Summary (Close #299)
Clear inherited `ENTRYPOINT` in `docker-compose.dev.yml`

# Implementations
The entrypoint: `[]` clears the inherited`ENTRYPOINT` so command: becomes the actual exec: 
```
/dlv debug /app/cmd/slack-mcp-server/main.go --accept-multiclient ...
```
# Result
debugger successfully launches for `mcp-server` in `docker-compose.dev.yml`
<img width="2430" height="1165" alt="Screenshot from 2026-05-14 19-17-01" src="https://github.com/user-attachments/assets/56875312-0456-4cef-9367-8abeda61b20d" />
