### PR TITLE
feat(tools): add files_list tool for listing Slack channel files

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -111,6 +111,28 @@ type filesGetParams struct {
 	fileID string
 }
 
+type filesListParams struct {
+	channel string
+	user    string
+	types   string
+	limit   int
+	cursor  string
+}
+
+type FileListResult struct {
+	FileID     string `csv:"FileID"`
+	Name       string `csv:"Name"`
+	Title      string `csv:"Title"`
+	Mimetype   string `csv:"Mimetype"`
+	Filetype   string `csv:"Filetype"`
+	PrettyType string `csv:"PrettyType"`
+	Size       int    `csv:"Size"`
+	UserID     string `csv:"UserID"`
+	Created    string `csv:"Created"`
+	Permalink  string `csv:"Permalink"`
+	Cursor     string `csv:"Cursor"`
+}
+
 type usersSearchParams struct {
 	query string
 	limit int
@@ -497,6 +519,91 @@ func (ch *ConversationsHandler) FilesGetHandler(ctx context.Context, request mcp
 
 func isImageMimetype(mimetype string) bool {
 	return strings.HasPrefix(mimetype, "image/")
+}
+
+func (ch *ConversationsHandler) parseParamsToolFilesList(request mcp.CallToolRequest) (*filesListParams, error) {
+	params := &filesListParams{
+		channel: request.GetString("channel_id", ""),
+		user:    request.GetString("user_id", ""),
+		types:   request.GetString("types", ""),
+		cursor:  request.GetString("cursor", ""),
+		limit:   50,
+	}
+
+	if limitStr := request.GetString("limit", ""); limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil && v > 0 {
+			params.limit = v
+		}
+	}
+
+	return params, nil
+}
+
+func (ch *ConversationsHandler) FilesListHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("FilesListHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	params, err := ch.parseParamsToolFilesList(request)
+	if err != nil {
+		ch.logger.Error("Failed to parse files_list params", zap.Error(err))
+		return nil, err
+	}
+
+	listParams := slack.ListFilesParameters{
+		Channel: params.channel,
+		User:    params.user,
+		Types:   params.types,
+		Limit:   params.limit,
+		Cursor:  params.cursor,
+	}
+
+	files, nextPage, err := ch.apiProvider.Slack().ListFilesContext(ctx, listParams)
+	if err != nil {
+		ch.logger.Error("Slack ListFilesContext failed", zap.Error(err))
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		return mcp.NewToolResultText("No files found."), nil
+	}
+
+	nextCursor := ""
+	if nextPage != nil {
+		nextCursor = nextPage.Cursor
+	}
+
+	results := make([]FileListResult, 0, len(files))
+	for i, f := range files {
+		cursor := ""
+		if i == len(files)-1 {
+			cursor = nextCursor
+		}
+		results = append(results, FileListResult{
+			FileID:     f.ID,
+			Name:       f.Name,
+			Title:      f.Title,
+			Mimetype:   f.Mimetype,
+			Filetype:   f.Filetype,
+			PrettyType: f.PrettyType,
+			Size:       f.Size,
+			UserID:     f.User,
+			Created:    f.Created.Time().Format(time.RFC3339),
+			Permalink:  f.Permalink,
+			Cursor:     cursor,
+		})
+	}
+
+	csvBytes, err := gocsv.MarshalBytes(&results)
+	if err != nil {
+		ch.logger.Error("Failed to marshal files to CSV", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(csvBytes)), nil
 }
 
 func isTextMimetype(mimetype string) bool {

--- a/pkg/handler/files_list_test.go
+++ b/pkg/handler/files_list_test.go
@@ -1,0 +1,107 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestUnitParseParamsToolFilesList(t *testing.T) {
+	ch := &ConversationsHandler{}
+
+	tests := []struct {
+		name    string
+		args    map[string]any
+		want    filesListParams
+		wantErr bool
+	}{
+		{
+			name: "defaults when no args provided",
+			args: map[string]any{},
+			want: filesListParams{limit: 50},
+		},
+		{
+			name: "channel_id and user_id set",
+			args: map[string]any{"channel_id": "C0123456789", "user_id": "U0123456789"},
+			want: filesListParams{channel: "C0123456789", user: "U0123456789", limit: 50},
+		},
+		{
+			name: "types and cursor set",
+			args: map[string]any{"types": "images,pdfs", "cursor": "dXNlcjpXMDYxTkZU"},
+			want: filesListParams{types: "images,pdfs", cursor: "dXNlcjpXMDYxTkZU", limit: 50},
+		},
+		{
+			name: "custom valid limit",
+			args: map[string]any{"limit": "10"},
+			want: filesListParams{limit: 10},
+		},
+		{
+			name: "limit at max boundary",
+			args: map[string]any{"limit": "200"},
+			want: filesListParams{limit: 200},
+		},
+		{
+			name: "non-numeric limit falls back to default",
+			args: map[string]any{"limit": "abc"},
+			want: filesListParams{limit: 50},
+		},
+		{
+			name: "zero limit ignored, falls back to default",
+			args: map[string]any{"limit": "0"},
+			want: filesListParams{limit: 50},
+		},
+		{
+			name: "negative limit ignored, falls back to default",
+			args: map[string]any{"limit": "-1"},
+			want: filesListParams{limit: 50},
+		},
+		{
+			name: "all params set",
+			args: map[string]any{
+				"channel_id": "C0123456789",
+				"user_id":    "U0123456789",
+				"types":      "images",
+				"limit":      "25",
+				"cursor":     "abc123",
+			},
+			want: filesListParams{
+				channel: "C0123456789",
+				user:    "U0123456789",
+				types:   "images",
+				limit:   25,
+				cursor:  "abc123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := mcp.CallToolRequest{}
+			req.Params.Arguments = tt.args
+
+			got, err := ch.parseParamsToolFilesList(req)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseParamsToolFilesList() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if got.channel != tt.want.channel {
+				t.Errorf("channel: got %q, want %q", got.channel, tt.want.channel)
+			}
+			if got.user != tt.want.user {
+				t.Errorf("user: got %q, want %q", got.user, tt.want.user)
+			}
+			if got.types != tt.want.types {
+				t.Errorf("types: got %q, want %q", got.types, tt.want.types)
+			}
+			if got.cursor != tt.want.cursor {
+				t.Errorf("cursor: got %q, want %q", got.cursor, tt.want.cursor)
+			}
+			if got.limit != tt.want.limit {
+				t.Errorf("limit: got %d, want %d", got.limit, tt.want.limit)
+			}
+		})
+	}
+}

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -230,6 +230,7 @@ type SlackAPI interface {
 	// Used to get files
 	GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*slack.File, []slack.Comment, *slack.Paging, error)
 	GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error
+	ListFilesContext(ctx context.Context, params slack.ListFilesParameters) ([]slack.File, *slack.ListFilesParameters, error)
 
 	// Used to get channel info (for unread counts with xoxp tokens)
 	GetConversationInfoContext(ctx context.Context, input *slack.GetConversationInfoInput) (*slack.Channel, error)
@@ -547,6 +548,10 @@ func (c *MCPSlackClient) GetFileInfoContext(ctx context.Context, fileID string, 
 
 func (c *MCPSlackClient) GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error {
 	return c.slackClient.GetFileContext(ctx, downloadURL, writer)
+}
+
+func (c *MCPSlackClient) ListFilesContext(ctx context.Context, params slack.ListFilesParameters) ([]slack.File, *slack.ListFilesParameters, error) {
+	return c.slackClient.ListFilesContext(ctx, params)
 }
 
 func (c *MCPSlackClient) GetConversationInfoContext(ctx context.Context, input *slack.GetConversationInfoInput) (*slack.Channel, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -47,6 +47,7 @@ const (
 	ToolSavedList                   = "saved_list"
 	ToolSavedUpdate                 = "saved_update"
 	ToolSavedClearCompleted         = "saved_clear_completed"
+	ToolFilesList                   = "files_list"
 )
 
 var ValidToolNames = []string{
@@ -72,6 +73,7 @@ var ValidToolNames = []string{
 	ToolSavedList,
 	ToolSavedUpdate,
 	ToolSavedClearCompleted,
+	ToolFilesList,
 }
 
 func ValidateEnabledTools(tools []string) error {
@@ -313,6 +315,31 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Maximum number of results to return (1-100). Default is 10."),
 			),
 		), conversationsHandler.UsersSearchHandler)
+	}
+
+	if shouldAddTool(ToolFilesList, enabledTools, "SLACK_MCP_FILES_LIST_TOOL") {
+		s.AddTool(mcp.NewTool(ToolFilesList,
+			mcp.WithDescription("List files shared in a Slack channel or workspace. Returns file metadata including ID, name, type, size, uploader, and permalink. Use the file_id from results with attachment_get_data to download file content. The last row cursor column is used for pagination."),
+			mcp.WithTitleAnnotation("List Files"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Description("Filter files by channel ID (format Cxxxxxxxxxx) or channel name (e.g. #general). If omitted, lists files across all channels."),
+			),
+			mcp.WithString("user_id",
+				mcp.Description("Filter files uploaded by a specific user ID (format Uxxxxxxxxxx)."),
+			),
+			mcp.WithString("types",
+				mcp.DefaultString("all"),
+				mcp.Description("Filter by file type. Comma-separated values: all, spaces, snippets, images, gdocs, zips, pdfs. Default is all."),
+			),
+			mcp.WithString("limit",
+				mcp.DefaultString("50"),
+				mcp.Description("Maximum number of files to return (1-200). Default is 50."),
+			),
+			mcp.WithString("cursor",
+				mcp.Description("Cursor for pagination. Use the value from the last row cursor column returned by the previous request."),
+			),
+		), conversationsHandler.FilesListHandler)
 	}
 
 	// Register unreads tool - gets all unread messages across channels efficiently.


### PR DESCRIPTION
## Summary

Adds a `files_list` MCP tool that lists files shared in a Slack channel or workspace, returning metadata as CSV (matching the format of other handlers).

- New tool `files_list` registered in `server.go` behind `SLACK_MCP_FILES_LIST_TOOL` env flag
- `FilesListHandler` in `conversations.go` with cursor-based pagination support
- `ListFilesContext` added to the `SlackAPI` interface and `MCPSlackClient` in `provider/api.go`
- `TestUnitParseParamsToolFilesList` unit tests covering all params, defaults, limit boundary/invalid cases

## Changes

**`pkg/handler/conversations.go`**
- Added `filesListParams` and `FileListResult` (CSV-tagged) structs
- Added `parseParamsToolFilesList` and `FilesListHandler` methods
- Returns CSV with columns: FileID, Name, Title, Mimetype, Filetype, PrettyType, Size, UserID, Created, Permalink, Cursor

**`pkg/provider/api.go`**
- Added `ListFilesContext` to `SlackAPI` interface and `MCPSlackClient`

**`pkg/server/server.go`**
- Added `ToolFilesList = "files_list"` constant
- Registered tool with channel/user/types/limit/cursor parameters

**`pkg/handler/files_list_test.go`** *(new)*
- `TestUnitParseParamsToolFilesList`: 9 table-driven unit tests (no external services required)

## Test plan

- [x] `go test ./pkg/handler/ -run TestUnitParseParamsToolFilesList -v` — all 9 cases pass
- [x] All existing `TestUnit*` tests continue to pass
- [ ] Integration test with a live Slack workspace to verify `ListFilesContext` response shape

## Notes

This PR addresses the three points from the [maintainer review on #261](https://github.com/korotovsky/slack-mcp-server/pull/261#issuecomment-4454699040):
1. Unit tests added (`TestUnitParseParamsToolFilesList`)
2. Rebased on `v1.2.3` (`b24b1b0`)
3. Scoped to listing only; aware of the broader file-tooling discussion in #247 — happy to adapt if the interface there settles on a different shape