### PR TITLE
feat: add conversations_update_message tool for editing existing messages

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -101,6 +101,14 @@ type addMessageParams struct {
 	blocks      []slack.Block
 }
 
+type updateMessageParams struct {
+	channel     string
+	ts          string
+	text        string
+	contentType string
+	blocks      []slack.Block
+}
+
 type addReactionParams struct {
 	channel   string
 	timestamp string
@@ -282,6 +290,62 @@ func (ch *ConversationsHandler) ConversationsAddMessageHandler(ctx context.Conte
 		return mcp.NewToolResultText(fmt.Sprintf("Successfully posted message to channel %s in thread %s (ts=%s)", respChannel, params.threadTs, respTimestamp)), nil
 	}
 	return mcp.NewToolResultText(fmt.Sprintf("Successfully posted message to channel %s (ts=%s)", respChannel, respTimestamp)), nil
+}
+
+// ConversationsUpdateMessageHandler edits an existing message and returns it as CSV
+func (ch *ConversationsHandler) ConversationsUpdateMessageHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsUpdateMessageHandler called", zap.Any("params", request.Params))
+
+	// provider readiness
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	params, err := ch.parseParamsToolUpdateMessage(ctx, request)
+	if err != nil {
+		ch.logger.Error("Failed to parse update-message params", zap.Error(err))
+		return nil, err
+	}
+
+	var options []slack.MsgOption
+
+	if params.blocks != nil {
+		options = append(options, slack.MsgOptionBlocks(params.blocks...))
+		if params.text != "" {
+			options = append(options, slack.MsgOptionText(params.text, false))
+		}
+	} else {
+		switch params.contentType {
+		case "text/plain":
+			options = append(options, slack.MsgOptionDisableMarkdown())
+			options = append(options, slack.MsgOptionText(params.text, false))
+		case "text/markdown":
+			blocks, err := slackGoUtil.ConvertMarkdownTextToBlocks(params.text)
+			if err != nil {
+				ch.logger.Warn("Markdown parsing error", zap.Error(err))
+				options = append(options, slack.MsgOptionDisableMarkdown())
+				options = append(options, slack.MsgOptionText(params.text, false))
+			} else {
+				options = append(options, slack.MsgOptionBlocks(blocks...))
+			}
+		default:
+			return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")
+		}
+	}
+
+	ch.logger.Debug("Updating Slack message",
+		zap.String("channel", params.channel),
+		zap.String("ts", params.ts),
+		zap.String("content_type", params.contentType),
+	)
+	respChannel, respTimestamp, _, err := ch.apiProvider.Slack().UpdateMessageContext(ctx, params.channel, params.ts, options...)
+	if err != nil {
+		ch.logger.Error("Slack UpdateMessageContext failed", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Successfully updated message in channel %s (ts=%s)", respChannel, respTimestamp)), nil
 }
 
 // ReactionsAddHandler adds an emoji reaction to a message
@@ -1835,6 +1899,96 @@ func (ch *ConversationsHandler) parseParamsToolAddMessage(ctx context.Context, r
 	return &addMessageParams{
 		channel:     channel,
 		threadTs:    threadTs,
+		text:        msgText,
+		contentType: contentType,
+		blocks:      blocks,
+	}, nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolUpdateMessage(ctx context.Context, request mcp.CallToolRequest) (*updateMessageParams, error) {
+	toolConfig := os.Getenv("SLACK_MCP_ADD_MESSAGE_TOOL")
+	enabledTools := os.Getenv("SLACK_MCP_ENABLED_TOOLS")
+
+	if toolConfig == "" {
+		if !strings.Contains(enabledTools, "conversations_update_message") && !strings.Contains(enabledTools, "conversations_add_message") {
+			ch.logger.Error("Update-message tool disabled by default")
+			return nil, errors.New(
+				"by default, the conversations_update_message tool is disabled to guard Slack workspaces against accidental edits. " +
+					"It is gated by the same SLACK_MCP_ADD_MESSAGE_TOOL environment variable as conversations_add_message.",
+			)
+		}
+		toolConfig = "true"
+	}
+
+	channel := request.GetString("channel_id", "")
+	if channel == "" {
+		ch.logger.Error("channel_id missing in update-message params")
+		return nil, errors.New("channel_id must be a string")
+	}
+	channel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		ch.logger.Error("Channel not found", zap.String("channel", channel), zap.Error(err))
+		return nil, err
+	}
+	if !isChannelAllowed(channel) {
+		ch.logger.Warn("Update-message tool not allowed for channel", zap.String("channel", channel), zap.String("policy", toolConfig))
+		return nil, fmt.Errorf("conversations_update_message tool is not allowed for channel %q, applied policy: %s", channel, toolConfig)
+	}
+
+	ts := request.GetString("ts", "")
+	if ts == "" {
+		ch.logger.Error("ts missing in update-message params")
+		return nil, errors.New("ts must be a string")
+	}
+	if !strings.Contains(ts, ".") {
+		ch.logger.Error("Invalid ts format", zap.String("ts", ts))
+		return nil, errors.New("ts must be a valid timestamp in format 1234567890.123456")
+	}
+
+	msgText := request.GetString("text", "")
+
+	contentType := request.GetString("content_type", "text/markdown")
+	if contentType != "text/plain" && contentType != "text/markdown" {
+		ch.logger.Error("Invalid content_type", zap.String("content_type", contentType))
+		return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")
+	}
+
+	// Parse optional raw blocks JSON (same logic as parseParamsToolAddMessage)
+	var blocks []slack.Block
+	args := request.GetArguments()
+	if rawBlocks, ok := args["blocks"]; ok && rawBlocks != nil {
+		var blocksJSON []byte
+		switch v := rawBlocks.(type) {
+		case string:
+			if v != "" {
+				blocksJSON = []byte(v)
+			}
+		default:
+			var err error
+			blocksJSON, err = json.Marshal(v)
+			if err != nil {
+				ch.logger.Error("Failed to marshal blocks argument", zap.Error(err))
+				return nil, fmt.Errorf("blocks must be valid Slack Block Kit JSON: %w", err)
+			}
+		}
+		if blocksJSON != nil {
+			var slackBlocks slack.Blocks
+			if err := json.Unmarshal(blocksJSON, &slackBlocks); err != nil {
+				ch.logger.Error("Failed to parse blocks JSON", zap.Error(err))
+				return nil, fmt.Errorf("blocks must be valid Slack Block Kit JSON: %w", err)
+			}
+			blocks = slackBlocks.BlockSet
+		}
+	}
+
+	if msgText == "" && blocks == nil {
+		ch.logger.Error("Message text and blocks both missing")
+		return nil, errors.New("either text or blocks must be provided")
+	}
+
+	return &updateMessageParams{
+		channel:     channel,
+		ts:          ts,
 		text:        msgText,
 		contentType: contentType,
 		blocks:      blocks,

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -216,6 +216,7 @@ type SlackAPI interface {
 	GetUsersContext(ctx context.Context, options ...slack.GetUsersOption) ([]slack.User, error)
 	GetUsersInfo(users ...string) (*[]slack.User, error)
 	PostMessageContext(ctx context.Context, channel string, options ...slack.MsgOption) (string, string, error)
+	UpdateMessageContext(ctx context.Context, channel, timestamp string, options ...slack.MsgOption) (string, string, string, error)
 	MarkConversationContext(ctx context.Context, channel, ts string) error
 	AddReactionContext(ctx context.Context, name string, item slack.ItemRef) error
 	RemoveReactionContext(ctx context.Context, name string, item slack.ItemRef) error
@@ -531,6 +532,10 @@ func (c *MCPSlackClient) SearchContext(ctx context.Context, query string, params
 
 func (c *MCPSlackClient) PostMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error) {
 	return c.slackClient.PostMessageContext(ctx, channelID, options...)
+}
+
+func (c *MCPSlackClient) UpdateMessageContext(ctx context.Context, channelID, timestamp string, options ...slack.MsgOption) (string, string, string, error) {
+	return c.slackClient.UpdateMessageContext(ctx, channelID, timestamp, options...)
 }
 
 func (c *MCPSlackClient) AddReactionContext(ctx context.Context, name string, item slack.ItemRef) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,6 +28,7 @@ const (
 	ToolConversationsHistory        = "conversations_history"
 	ToolConversationsReplies        = "conversations_replies"
 	ToolConversationsAddMessage     = "conversations_add_message"
+	ToolConversationsUpdateMessage  = "conversations_update_message"
 	ToolReactionsAdd                = "reactions_add"
 	ToolReactionsRemove             = "reactions_remove"
 	ToolAttachmentGetData           = "attachment_get_data"
@@ -53,6 +54,7 @@ var ValidToolNames = []string{
 	ToolConversationsHistory,
 	ToolConversationsReplies,
 	ToolConversationsAddMessage,
+	ToolConversationsUpdateMessage,
 	ToolReactionsAdd,
 	ToolReactionsRemove,
 	ToolAttachmentGetData,
@@ -199,6 +201,32 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Raw Slack Block Kit JSON array for rich message formatting (rich_text lists, code blocks, etc.). When provided, this takes precedence over text/content_type for rendering. The text parameter becomes the notification fallback text."),
 			),
 		), conversationsHandler.ConversationsAddMessageHandler)
+	}
+
+	if shouldAddTool(ToolConversationsUpdateMessage, enabledTools, "SLACK_MCP_ADD_MESSAGE_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsUpdateMessage,
+			mcp.WithDescription("Edit an existing message you sent in a public channel, private channel, or direct message. Identify the message by channel_id and ts (original timestamp). Same formatting options as conversations_add_message."),
+			mcp.WithTitleAnnotation("Update Message"),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
+			),
+			mcp.WithString("ts",
+				mcp.Required(),
+				mcp.Description("Timestamp of the message to edit, in format 1234567890.123456. This is the ts of the message returned when it was originally posted."),
+			),
+			mcp.WithString("text",
+				mcp.Description("New message text in specified content_type format."),
+			),
+			mcp.WithString("content_type",
+				mcp.DefaultString("text/markdown"),
+				mcp.Description("Content type of the new message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'. Ignored when blocks is provided."),
+			),
+			mcp.WithString("blocks",
+				mcp.Description("Raw Slack Block Kit JSON array for rich message formatting. When provided, this takes precedence over text/content_type for rendering. The text parameter becomes the notification fallback text."),
+			),
+		), conversationsHandler.ConversationsUpdateMessageHandler)
 	}
 
 	if shouldAddTool(ToolReactionsAdd, enabledTools, "SLACK_MCP_REACTION_TOOL") {


### PR DESCRIPTION
## Summary

This PR adds a new `conversations_update_message` tool that edits an existing message in a channel, private channel, or DM. It mirrors the formatting options of `conversations_add_message` (`text`, `content_type`, `blocks`) but operates on an existing message identified by `channel_id` and `ts`.

### Why

`conversations_add_message` allows MCP clients to post messages, but there's no way to fix typos, update status messages, or correct mistakes after posting. Editing is a core Slack workflow and a natural complement to posting.

### Behavior

- Accepts `channel_id` (required), `ts` (required, in `1234567890.123456` format), and any of `text`, `content_type`, `blocks`.
- Same content-type handling as `conversations_add_message`: `text/markdown` (default) is converted via slack-go-util, `text/plain` posts as-is, and raw `blocks` JSON takes precedence when provided.
- Returns a plain confirmation (`Successfully updated message in channel C... (ts=...)`), matching the convention introduced in #284.
- Marked with `WithDestructiveHintAnnotation(true)` so MCP clients can prompt before editing.

### Gating

Gated by the same `SLACK_MCP_ADD_MESSAGE_TOOL` environment variable as `conversations_add_message`. Workspaces that have opted into the existing add-message tool get update-message automatically. The same channel-allowlist policy is applied.

This avoids introducing a new env var for a closely related capability. If you'd prefer a separate \`SLACK_MCP_UPDATE_MESSAGE_TOOL\` gate, happy to split it out.

## Test plan

- [ ] Verify update with \`text/markdown\` rebuilds the message as native rich_text blocks
- [ ] Verify update with \`text/plain\` posts plain text without markdown processing
- [ ] Verify update with raw \`blocks\` JSON renders correctly (lists, code, links)
- [ ] Verify \`blocks\` accepts both JSON string and raw JSON array forms (matches add-message behavior)
- [ ] Verify error when neither \`text\` nor \`blocks\` is provided
- [ ] Verify error when \`ts\` is missing or malformed (must contain \`.\`)
- [ ] Verify channel allowlist policy is enforced
- [ ] Verify tool is disabled by default and only registered when \`SLACK_MCP_ADD_MESSAGE_TOOL\` is set
- [ ] Verify response is a plain confirmation string, not a CSV history fetch