### PR TITLE
feat(conversations_add_message): add reply_broadcast option for threaded replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Add a message to a public channel, private channel, or direct message (DM, or IM
   - `thread_ts` (string, optional): Unique identifier of either a thread’s parent message or a message in the thread_ts must be the timestamp in format `1234567890.123456` of an existing message with 0 or more replies. Optional, if not provided the message will be added to the channel itself, otherwise it will be added to the thread.
   - `payload` (string, required): Message payload in specified content_type format. Example: 'Hello, world!' for text/plain or '# Hello, world!' for text/markdown.
   - `content_type` (string, default: "text/markdown"): Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'.
+  - `reply_broadcast` (boolean, default: false): When posting a threaded reply (`thread_ts` is set), also make the reply visible in the channel ("also send to channel"). Has no effect on top-level messages.
 
 ### 4. conversations_search_messages
 Search messages in a public channel, private channel, or direct message (DM, or IM) conversation using filters. All filters are optional, if not provided then search_query is required.

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -94,11 +94,12 @@ type searchParams struct {
 }
 
 type addMessageParams struct {
-	channel     string
-	threadTs    string
-	text        string
-	contentType string
-	blocks      []slack.Block
+	channel        string
+	threadTs       string
+	text           string
+	contentType    string
+	blocks         []slack.Block
+	replyBroadcast bool
 }
 
 type addReactionParams struct {
@@ -222,6 +223,11 @@ func (ch *ConversationsHandler) ConversationsAddMessageHandler(ctx context.Conte
 	var options []slack.MsgOption
 	if params.threadTs != "" {
 		options = append(options, slack.MsgOptionTS(params.threadTs))
+		// reply_broadcast only applies to threaded replies; Slack ignores it for
+		// top-level messages, so gate it on thread_ts being set.
+		if params.replyBroadcast {
+			options = append(options, slack.MsgOptionBroadcast())
+		}
 	}
 
 	if params.blocks != nil {
@@ -262,6 +268,7 @@ func (ch *ConversationsHandler) ConversationsAddMessageHandler(ctx context.Conte
 		zap.String("channel", params.channel),
 		zap.String("thread_ts", params.threadTs),
 		zap.String("content_type", params.contentType),
+		zap.Bool("reply_broadcast", params.replyBroadcast),
 	)
 	respChannel, respTimestamp, err := ch.apiProvider.Slack().PostMessageContext(ctx, params.channel, options...)
 	if err != nil {
@@ -1783,6 +1790,8 @@ func (ch *ConversationsHandler) parseParamsToolAddMessage(ctx context.Context, r
 		return nil, errors.New("thread_ts must be a valid timestamp in format 1234567890.123456")
 	}
 
+	replyBroadcast := request.GetBool("reply_broadcast", false)
+
 	msgText := request.GetString("text", "")
 	if msgText == "" {
 		// Backward compatibility with "payload" parameter
@@ -1833,11 +1842,12 @@ func (ch *ConversationsHandler) parseParamsToolAddMessage(ctx context.Context, r
 	}
 
 	return &addMessageParams{
-		channel:     channel,
-		threadTs:    threadTs,
-		text:        msgText,
-		contentType: contentType,
-		blocks:      blocks,
+		channel:        channel,
+		threadTs:       threadTs,
+		text:           msgText,
+		contentType:    contentType,
+		blocks:         blocks,
+		replyBroadcast: replyBroadcast,
 	}, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -198,6 +198,9 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 			mcp.WithString("blocks",
 				mcp.Description("Raw Slack Block Kit JSON array for rich message formatting (rich_text lists, code blocks, etc.). When provided, this takes precedence over text/content_type for rendering. The text parameter becomes the notification fallback text."),
 			),
+			mcp.WithBoolean("reply_broadcast",
+				mcp.Description("When posting a threaded reply (thread_ts is set), also make the reply visible in the channel ('also send to channel'). Has no effect on top-level messages. Default is boolean false."),
+			),
 		), conversationsHandler.ConversationsAddMessageHandler)
 	}
 


### PR DESCRIPTION
## Summary

Adds an optional `reply_broadcast` boolean parameter to the `conversations_add_message` tool. When posting a threaded reply (`thread_ts` is set), `reply_broadcast: true` also surfaces the reply in the channel — Slack's "Also send to channel" behavior — via `slack.MsgOptionBroadcast()`.

Today the tool can post threaded replies but offers no way to broadcast them to the channel, which forces callers to drop down to the raw Slack web API. This exposes a capability the underlying `slack-go` client already supports.

## Behavior

- Defaults to `false`, so existing callers are unaffected.
- Applied only when `thread_ts` is set; Slack ignores `reply_broadcast` for top-level messages, so it is gated to avoid sending a meaningless flag.

## Changes

- `pkg/server/server.go`: register the `reply_broadcast` boolean parameter on the tool.
- `pkg/handler/conversations.go`: parse it via `request.GetBool`, thread it through `addMessageParams`, and append `slack.MsgOptionBroadcast()` when set within a thread.
- `README.md`: document the new parameter.

## Testing

- `go build ./...`, `go vet ./...`, and `gofmt` are clean.
- `make test` (unit suite) passes. `make test-integration` is gated on `SLACK_MCP_OPENAI_API` and was not run.
