### PR TITLE
Add docker-compose override template and document .env usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@
 /npm/slack-mcp-server/.npmrc
 /npm/slack-mcp-server/LICENSE
 /npm/slack-mcp-server/README.md
+# Personal docker-compose override (auto-merged by compose, local-only)
+docker-compose.override.yml
 docker-compose.release.yml

--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ Fetches a CSV directory of all users in the workspace.
 
 *You need one of: `xoxp` (user), `xoxb` (bot), or both `xoxc`/`xoxd` tokens for authentication.
 
+#### Personal Docker Compose override
+
+Docker Compose auto-merges a `docker-compose.override.yml` next to the base file (no `-f` needed). A template is shipped as `docker-compose.override.yml.dist` — copy it, fill your `.env` with real tokens, and `docker compose up -d` picks it up. Both `docker-compose.override.yml` and `.env` are gitignored, so secrets stay local. See [Configuration and Usage](docs/03-configuration-and-usage.md#personal-override-via-docker-composeoverrideyml) for details.
+
 ### Limitations matrix & Cache
 
 | Users Cache        | Channels Cache     | Limitations                                                                                                                                                                                                                                                                                                                  |

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,0 +1,18 @@
+# Personal override — copy to docker-compose.override.yml and fill .env.
+# docker-compose.override.yml is gitignored and auto-merged by `docker compose up`,
+# so `docker compose up -d` picks it up automatically without `-f`.
+#
+# Put your real Slack tokens in a local .env file (already gitignored):
+#   SLACK_MCP_XOXP_TOKEN=xoxp-...
+#   SLACK_MCP_XOXB_TOKEN=xoxb-...
+# See docs/01-authentication-setup.md for how to obtain tokens.
+services:
+  mcp-server:
+    env_file:
+      - .env
+    environment:
+      SLACK_MCP_HOST: "0.0.0.0"
+      SLACK_MCP_PORT: "3001"
+      SLACK_MCP_ADD_MESSAGE_TOOL: "true"
+    ports:
+      - "3001:3001"

--- a/docs/03-configuration-and-usage.md
+++ b/docs/03-configuration-and-usage.md
@@ -246,6 +246,27 @@ docker network create app-tier
 docker-compose up -d
 ```
 
+#### Personal override via `docker-compose.override.yml`
+
+Docker Compose automatically merges a `docker-compose.override.yml` next to the base `docker-compose.yml` — no `-f` flag needed. This is the recommended way to personalise the deployment (tokens, host, port, feature flags) without editing the base file or committing secrets.
+
+A template is shipped as `docker-compose.override.yml.dist`. To use it:
+
+```bash
+cp docker-compose.override.yml.dist docker-compose.override.yml
+cp .env.dist .env          # if you don't already have one
+nano .env                  # add your real Slack tokens (see docs/01-authentication-setup.md)
+docker compose up -d
+```
+
+`docker-compose.override.yml` is listed in `.gitignore`, and `.env` is already gitignored, so your tokens never end up in version control.
+
+The override template references `env_file: .env`, so the same variables documented in [Environment Variables](#environment-variables) (`SLACK_MCP_XOXP_TOKEN`, `SLACK_MCP_XOXB_TOKEN`, etc.) are loaded from your local `.env`. Override `SLACK_MCP_HOST`, `SLACK_MCP_PORT`, and feature flags like `SLACK_MCP_ADD_MESSAGE_TOOL` directly in the override file when needed.
+
+> **Note on port merging:** Compose *appends* `ports` from the base file and the override, so with the template above both `3001:3001` (base) and `3001:3001` (override) are published. To suppress the base ports, set `ports: []` in your local override.
+
+> **Security:** Never commit real tokens. Keep them in `.env` (gitignored) or in your local `docker-compose.override.yml` (gitignored). See [SECURITY.md](../SECURITY.md).
+
 ### Console Arguments
 
 | Argument                    | Required ? | Description                                                                                                                                                                                                         |


### PR DESCRIPTION
## What

Adds a personalisation mechanism for Docker Compose deployments via a `docker-compose.override.yml` template, and documents how to use it together with the existing `.env` file.

## Why

The base `docker-compose.yml` is shipped as-is and should not hold personal tokens, host/port overrides, or feature flags. Docker Compose automatically merges a `docker-compose.override.yml` placed next to it (no `-f` needed), which makes it the natural place for local/personal configuration. This PR ships a ready-to-copy template and gitignores the resulting local override so secrets never enter version control.

## Changes

- **`docker-compose.override.yml.dist`** (new): template referencing `env_file: .env` with neutral defaults (`0.0.0.0:3001`, `SLACK_MCP_ADD_MESSAGE_TOOL=true`). Users copy it to `docker-compose.override.yml` and fill `.env` with real tokens.
- **`.gitignore`**: adds `docker-compose.override.yml` so the local override (and any secrets embedded in it) stays out of git. `.env` is already gitignored.
- **`docs/03-configuration-and-usage.md`**: new "Personal override via `docker-compose.override.yml`" subsection under "Using Docker" — explains the auto-merge mechanism, the `cp` / `nano .env` / `up -d` flow, port-merge behaviour, and a security note.
- **`README.md`**: short pointer in the Setup Guide next to the Environment Variables quick reference.

## Security

- No real tokens are committed. The template contains only placeholders / neutral defaults.
- Both `docker-compose.override.yml` and `.env` are gitignored, so tokens belong only in local, untracked files.

## Setup flow (end user)

```bash
cp docker-compose.override.yml.dist docker-compose.override.yml
cp .env.dist .env
nano .env                  # SLACK_MCP_XOXP_TOKEN=xoxp-... (see docs/01-authentication-setup.md)
docker compose up -d
```
