### PR TITLE
Add optional oldest timestamp to conversations_history and conversations_replies

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -1711,6 +1711,17 @@ func (ch *ConversationsHandler) parseParamsToolConversations(ctx context.Context
 		}
 	}
 
+	// An explicit `oldest` timestamp takes precedence over the window derived
+	// from a duration `limit`, letting a client fetch messages strictly after a
+	// known marker (e.g. a channel's last_read).
+	if oldest := request.GetString("oldest", ""); oldest != "" {
+		if !isValidSlackTimestamp(oldest) {
+			ch.logger.Error("Invalid oldest timestamp", zap.String("oldest", oldest))
+			return nil, fmt.Errorf("invalid oldest timestamp %q: expected a Slack ts like 1234567890.123456", oldest)
+		}
+		paramOldest = oldest
+	}
+
 	if strings.HasPrefix(channel, "#") || strings.HasPrefix(channel, "@") {
 		if ready, err := ch.apiProvider.IsReady(); !ready {
 			if errors.Is(err, provider.ErrUsersNotReady) {
@@ -2235,6 +2246,16 @@ func limitByExpression(limit, defaultLimit string) (slackLimit int, oldest, late
 	latest = fmt.Sprintf("%d.000000", now.Unix())
 	oldest = fmt.Sprintf("%d.000000", oldestTime.Unix())
 	return 100, oldest, latest, nil
+}
+
+// slackTimestampRegex matches a Slack message timestamp: unix seconds with an
+// optional fractional part, e.g. "1234567890.123456".
+var slackTimestampRegex = regexp.MustCompile(`^\d+(\.\d+)?$`)
+
+// isValidSlackTimestamp reports whether s is a Slack timestamp usable as an
+// `oldest` bound (unix seconds, optionally with a fractional part).
+func isValidSlackTimestamp(s string) bool {
+	return slackTimestampRegex.MatchString(s)
 }
 
 func extractThreadTS(rawurl string) (string, error) {

--- a/pkg/handler/conversations_test.go
+++ b/pkg/handler/conversations_test.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/korotovsky/slack-mcp-server/pkg/test/util"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/responses"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestIntegrationConversations(t *testing.T) {
@@ -652,4 +654,107 @@ func TestUnitIsSlackUserIDPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnitIsValidSlackTimestamp(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   string
+		want bool
+	}{
+		{"canonical last_read", "1234567890.123456", true},
+		{"bare unix seconds", "1700000000", true},
+		{"zero sentinel", "0000000000.000000", true},
+		{"empty", "", false},
+		{"non-numeric", "not-a-ts", false},
+		{"channel name", "#general", false},
+		{"trailing dot", "123.", false},
+		{"leading dot", ".123", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidSlackTimestamp(tt.ts); got != tt.want {
+				t.Errorf("isValidSlackTimestamp(%q) = %v, want %v", tt.ts, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnitParseParamsToolConversationsOldest covers the client-settable absolute
+// `oldest` param on conversations_history: it is used when provided, overrides the
+// window derived from a duration `limit`, and is validated as a Slack timestamp.
+func TestUnitParseParamsToolConversationsOldest(t *testing.T) {
+	ch := &ConversationsHandler{logger: zap.NewNop()}
+	ctx := context.Background()
+
+	newReq := func(args map[string]any) mcp.CallToolRequest {
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = args
+		return req
+	}
+
+	t.Run("explicit oldest is used", func(t *testing.T) {
+		params, err := ch.parseParamsToolConversations(ctx, newReq(map[string]any{
+			"channel_id": "C123",
+			"oldest":     "1700000000.000100",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1700000000.000100", params.oldest)
+	})
+
+	t.Run("explicit oldest overrides duration-derived oldest, latest preserved", func(t *testing.T) {
+		params, err := ch.parseParamsToolConversations(ctx, newReq(map[string]any{
+			"channel_id": "C123",
+			"limit":      "1d",
+			"oldest":     "1700000000.000100",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1700000000.000100", params.oldest)
+		assert.NotEmpty(t, params.latest, "duration-derived latest upper bound should survive the oldest override")
+	})
+
+	t.Run("numeric limit with oldest sets both, no latest bound", func(t *testing.T) {
+		params, err := ch.parseParamsToolConversations(ctx, newReq(map[string]any{
+			"channel_id": "C123",
+			"limit":      "50",
+			"oldest":     "1700000000.000100",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1700000000.000100", params.oldest)
+		assert.Equal(t, 50, params.limit)
+		assert.Empty(t, params.latest, "numeric limit should not set a latest upper bound")
+	})
+
+	t.Run("no oldest keeps duration-derived oldest", func(t *testing.T) {
+		params, err := ch.parseParamsToolConversations(ctx, newReq(map[string]any{
+			"channel_id": "C123",
+			"limit":      "1d",
+		}))
+		require.NoError(t, err)
+		assert.NotEmpty(t, params.oldest)
+		assert.True(t, strings.HasSuffix(params.oldest, ".000000"),
+			"duration-derived oldest should be a whole-second ts, got %q", params.oldest)
+	})
+
+	t.Run("invalid oldest returns error", func(t *testing.T) {
+		_, err := ch.parseParamsToolConversations(ctx, newReq(map[string]any{
+			"channel_id": "C123",
+			"oldest":     "not-a-ts",
+		}))
+		require.Error(t, err)
+	})
+
+	// Bounded pagination requires oldest to survive alongside a cursor: Slack's
+	// cursor encodes only a position, not the oldest floor, so a client must
+	// re-send oldest on each page or the lower bound is lost.
+	t.Run("oldest is kept alongside a cursor", func(t *testing.T) {
+		params, err := ch.parseParamsToolConversations(ctx, newReq(map[string]any{
+			"channel_id": "C123",
+			"cursor":     "bmV4dF90czoxNzgz",
+			"oldest":     "1700000000.000100",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1700000000.000100", params.oldest)
+		assert.Equal(t, "bmV4dF90czoxNzgz", params.cursor)
+	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -146,6 +146,9 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.DefaultString("1d"),
 				mcp.Description("Limit of messages to fetch in format of maximum ranges of time (e.g. 1d - 1 day, 1w - 1 week, 30d - 30 days, 90d - 90 days which is a default limit for free tier history) or number of messages (e.g. 50). Must be empty when 'cursor' is provided."),
 			),
+			mcp.WithString("oldest",
+				mcp.Description("Only include messages after this Slack timestamp (e.g. '1234567890.123456'), exclusive (a message whose ts equals 'oldest' is excluded). Useful to fetch only what is new since a known point, such as a channel's last_read marker. When more messages match than fit in one page, Slack returns the earliest ones first; keep 'oldest' set on each request and follow the returned 'cursor' to page through the rest (dropping 'oldest' while paging loses the lower bound)."),
+			),
 		), conversationsHandler.ConversationsHistoryHandler)
 	}
 
@@ -172,6 +175,9 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 			mcp.WithString("limit",
 				mcp.DefaultString("1d"),
 				mcp.Description("Limit of messages to fetch in format of maximum ranges of time (e.g. 1d - 1 day, 30d - 30 days, 90d - 90 days which is a default limit for free tier history) or number of messages (e.g. 50). Must be empty when 'cursor' is provided."),
+			),
+			mcp.WithString("oldest",
+				mcp.Description("Only include replies after this Slack timestamp (e.g. '1234567890.123456'), exclusive (a reply whose ts equals 'oldest' is excluded). The thread's parent message is always returned. When more replies match than fit in one page, Slack returns the earliest ones first; keep 'oldest' set on each request and follow the returned 'cursor' to page through the rest (dropping 'oldest' while paging loses the lower bound)."),
 			),
 		), conversationsHandler.ConversationsRepliesHandler)
 	}


### PR DESCRIPTION
## Summary

Adds an optional `oldest` parameter (an absolute Slack timestamp) to the `conversations_history` and `conversations_replies` tools. When provided, only messages after that timestamp are returned, fully paginated, so a client can fetch exactly what arrived in a channel or thread since a known point: a checkpoint it recorded, a thread's replies since it was last seen, or a channel's `last_read` marker.

Today these tools bound results only by a relative window (`limit=1d`), a message count, or a `cursor`; there is no absolute lower-bound timestamp. (`conversations_unreads` discovers unreads across channels but is a per-channel-capped cross-channel summary, not a way to page one channel's or thread's messages after an arbitrary timestamp.)

## Behavior

- `oldest` is a Slack ts (e.g. `1234567890.123456`), validated before use; an invalid value returns a clear error.
- It is exclusive (a message whose ts equals `oldest` is excluded), matching the tools' existing `Inclusive: false` behavior. This is correct for a `last_read` marker, which points at an already-read message.
- When set, it takes precedence over the lower bound derived from a duration `limit`; the upper bound and page size are unaffected.
- Additive and backward-compatible: omitting `oldest` leaves existing behavior unchanged.

The parameter passes through to the Slack Web API's existing `oldest` field, which this server already populated internally from the duration limit; this exposes it to callers.

## Tests

- Unit tests for timestamp validation, and for parser precedence: explicit `oldest` used; overrides the duration-derived value with the upper bound preserved; numeric `limit` + `oldest`; the default path (no `oldest`) unchanged; invalid `oldest` errors; and `oldest` retained alongside a `cursor` (so bounded pagination keeps its lower bound).

## Test plan

- `make test` (unit) passes.
- Manually verified against a live workspace with a user token: `conversations_history` and `conversations_replies` each return exactly the messages/replies after the supplied `oldest`, and the full set without it.

Fixes #320
