### PR TITLE
feat: support granular Slack User OAuth search

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This feature-rich Slack MCP Server has:
 - **Channel and Thread Support with `#Name` `@Lookup`**: Fetch messages from channels and threads, including activity messages, and retrieve channels using their names (e.g., #general) as well as their IDs.
 - **Smart History**: Fetch messages with pagination by date (d1, 7d, 1m) or message count.
 - **Unread Messages**: Get all unread messages across channels efficiently with priority sorting (DMs > partner channels > internal), @mention filtering, and mark-as-read support.
-- **Search Messages**: Search messages in channels, threads, and DMs using various filters like date, user, and content.
+- **Search Messages**: With User OAuth, search messages in public/private channels and MPIMs using filters such as date, author, and content.
 - **Safe Message Posting**: The `conversations_add_message` tool is disabled by default for safety. Enable it via an environment variable, with optional channel restrictions.
 - **DM and Group DM support**: Retrieve direct messages and group direct messages.
 - **Embedded user information**: Embed user information in messages, for better context.
@@ -60,14 +60,13 @@ Add a message to a public channel, private channel, or direct message (DM, or IM
   - `content_type` (string, default: "text/markdown"): Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'.
 
 ### 4. conversations_search_messages
-Search messages in a public channel, private channel, or direct message (DM, or IM) conversation using filters. All filters are optional, if not provided then search_query is required.
+Search messages in public channels, private channels, and multi-person direct messages (MPIMs) using Slack's `assistant.search.context` Real-time Search API. All filters are optional; if none are provided, `search_query` is required.
 
-> **Note**: This tool is not available when using bot tokens (`xoxb-*`). Bot tokens cannot use the `search.messages` API.
+> **Note**: This tool is registered only for User OAuth tokens (`xoxp-*` or rotating `xoxe.xoxp-*`). Bot calls require an event `action_token`, which a standalone stdio server does not have, and browser-session tokens are not supported by this endpoint.
 - **Parameters:**
-  - `search_query` (string, optional): Search query to filter messages. Example: 'marketing report' or full URL of Slack message e.g. 'https://slack.com/archives/C1234567890/p1234567890123456', then the tool will return a single message matching given URL, herewith all other parameters will be ignored.
-  - `filter_in_channel` (string, optional): Filter messages in a specific channel by its ID or name. Example: `C1234567890` or `#general`. If not provided, all channels will be searched.
-  - `filter_in_im_or_mpim` (string, optional): Filter messages in a direct message (DM) or multi-person direct message (MPIM) conversation by its ID or name. Example: `D1234567890` or `@username_dm`. If not provided, all DMs and MPIMs will be searched.
-  - `filter_users_with` (string, optional): Filter messages with a specific user by their ID or display name in threads and DMs. Example: `U1234567890` or `@username`. If not provided, all threads and DMs will be searched.
+  - `search_query` (string, optional): Free-text query with optional Slack modifiers such as `in:#general` or `from:@alice`. Structured filters are combined with this query.
+  - `filter_in_channel` (string, optional): Filter a public or private channel by stable ID or cached name. Example: `C1234567890`, `G1234567890`, or `#general`.
+  - `filter_in_im_or_mpim` (string, optional): Filter a cached MPIM by stable ID or name. One-to-one DM search is unavailable because `search:read.im` is not part of the documented search configuration.
   - `filter_users_from` (string, optional): Filter messages from a specific user by their ID or display name. Example: `U1234567890` or `@username`. If not provided, all users will be searched.
   - `filter_date_before` (string, optional): Filter messages sent before a specific date in format `YYYY-MM-DD`. Example: `2023-10-01`, `July`, `Yesterday` or `Today`. If not provided, all dates will be searched.
   - `filter_date_after` (string, optional): Filter messages sent after a specific date in format `YYYY-MM-DD`. Example: `2023-10-01`, `July`, `Yesterday` or `Today`. If not provided, all dates will be searched.
@@ -75,7 +74,9 @@ Search messages in a public channel, private channel, or direct message (DM, or 
   - `filter_date_during` (string, optional): Filter messages sent during a specific period in format `YYYY-MM-DD`. Example: `July`, `Yesterday` or `Today`. If not provided, all dates will be searched.
   - `filter_threads_only` (boolean, default: false): If true, the response will include only messages from threads. Default is boolean false.
   - `cursor` (string, default: ""): Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request.
-  - `limit` (number, default: 20): The maximum number of items to return. Must be an integer between 1 and 100.
+  - `limit` (integer, default: 20): The maximum number of items to return. Must be between 1 and 100.
+
+Raw `with:` modifiers and `filter_users_with` are rejected because Slack's Real-time Search response does not provide enough participant data for the server to verify that scope locally.
 
 ### 5. channels_list:
 Get list of channels

--- a/docs/01-authentication-setup.md
+++ b/docs/01-authentication-setup.md
@@ -46,7 +46,9 @@ Instead of using browser-based tokens (`xoxc`/`xoxd`), you can use a User OAuth 
     - `mpim:write` - Start group direct messages with people on a user’s behalf (new since `v1.1.18`)
     - `users:read` - View people in a workspace.
     - `chat:write` - Send messages on a user's behalf. (new since `v1.1.18`)
-    - `search:read` - Search a workspace's content. (new since `v1.1.18`)
+    - `search:read.public` - Search messages in public channels with Real-time Search.
+    - `search:read.private` - Search messages in private channels with Real-time Search.
+    - `search:read.mpim` - Search messages in multi-person direct messages with Real-time Search.
     - `usergroups:read` - View user groups in a workspace.
     - `usergroups:write` - Create and manage user groups.
     - `channels:write` - Join and leave public channels.
@@ -77,7 +79,9 @@ To create the app from a manifest with permissions preconfigured, use the follow
                 "mpim:write",
                 "users:read",
                 "chat:write",
-                "search:read",
+                "search:read.public",
+                "search:read.private",
+                "search:read.mpim",
                 "usergroups:read",
                 "usergroups:write",
                 "channels:write"
@@ -97,12 +101,12 @@ To create the app from a manifest with permissions preconfigured, use the follow
 You can also use a Bot token instead of a User token:
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app
-2. Under "OAuth & Permissions", add Bot Token Scopes (same as User scopes above, except replace `search:read` with `search:read.public` and replace `channels:write` with `channels:join` + `channels:manage`)
+2. Under "OAuth & Permissions", add the corresponding Bot Token Scopes and replace `channels:write` with `channels:join` + `channels:manage`.
 3. Install the app to your workspace
 4. Copy the "Bot User OAuth Token" (starts with `xoxb-`)
 5. **Important**: Bot must be invited to channels for access
 
-> **Note**: Bot tokens cannot use `search.messages` API, so `conversations_search_messages` tool will not be available.
+> **Note**: `conversations_search_messages` is not registered for bot tokens. Slack requires an event `action_token` for bot calls to `assistant.search.context`, and a standalone stdio server does not receive one. Browser-session tokens also do not expose this tool.
 
 
 See next: [Installation](02-installation.md)

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -139,8 +139,22 @@ type markParams struct {
 	channel string
 	ts      string
 }
+
+type conversationsProvider interface {
+	ServerTransport() string
+	IsReady() (bool, error)
+	Slack() provider.SlackAPI
+	ProvideUsersMap() *provider.UsersCache
+	ProvideChannelsMaps() *provider.ChannelsCache
+	SearchUsers(context.Context, string, int) ([]slack.User, error)
+	IsBotToken() bool
+	IsOAuth() bool
+	ForceRefreshChannels(context.Context) error
+	PatchUser(context.Context, string) (*slack.User, error)
+}
+
 type ConversationsHandler struct {
-	apiProvider *provider.ApiProvider
+	apiProvider conversationsProvider
 	logger      *zap.Logger
 }
 
@@ -612,6 +626,11 @@ func (ch *ConversationsHandler) ConversationsRepliesHandler(ctx context.Context,
 func (ch *ConversationsHandler) ConversationsSearchHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	ch.logger.Debug("ConversationsSearchHandler called", zap.Any("params", request.Params))
 
+	if err := validateAssistantSearchToken(ch.apiProvider.IsOAuth(), ch.apiProvider.IsBotToken()); err != nil {
+		ch.logger.Error("Assistant search requires a user token", zap.Error(err))
+		return nil, err
+	}
+
 	params, err := ch.parseParamsToolSearch(ctx, request)
 	if err != nil {
 		ch.logger.Error("Failed to parse search params", zap.Error(err))
@@ -619,24 +638,21 @@ func (ch *ConversationsHandler) ConversationsSearchHandler(ctx context.Context, 
 	}
 	ch.logger.Debug("Search params parsed", zap.String("query", params.query), zap.Int("limit", params.limit), zap.String("cursor", params.cursor))
 
-	limit := params.limit
-	if limit > 20 {
-		limit = 20 // Slack assistant.search.context has a hard 20-result maximum.
-	}
-
-	// Author filtering is performed against the structured author_user_id returned
-	// by assistant.search.context. Slack accepts from: modifiers on this endpoint
-	// but currently does not enforce them, so relying on the modifier returns mixed
-	// authors. Scan a bounded number of pages to avoid returning a false empty first
-	// page when the requested historical author is not among the first 20 results.
-	maxPages := 1
-	if params.authorFilter != nil {
-		maxPages = 10
-	}
-
 	cursor := params.cursor
+	seenCursors := make(map[string]struct{})
+	if cursor != "" {
+		seenCursors[cursor] = struct{}{}
+	}
+	matches := make([]assistantSearchMessage, 0, params.limit)
+	nextCursor := ""
 	rl := limiter.Tier2.Limiter()
-	for page := 0; page < maxPages; page++ {
+	const maxAssistantSearchPages = 10
+	pagesScanned := 0
+	for len(matches) < params.limit {
+		pageLimit := params.limit - len(matches)
+		if pageLimit > 20 {
+			pageLimit = 20
+		}
 		result, callErr := limiter.CallWithRetry(ctx, rl, 2, slackRetryAfter, func() (json.RawMessage, error) {
 			return ch.apiProvider.Slack().AssistantSearchContext(ctx, provider.AssistantSearchContextRequest{
 				Query:                  params.query,
@@ -644,7 +660,7 @@ func (ch *ConversationsHandler) ConversationsSearchHandler(ctx context.Context, 
 				ContentTypes:           []string{"messages"},
 				ContextChannelID:       params.contextChannelID,
 				Cursor:                 cursor,
-				Limit:                  limit,
+				Limit:                  pageLimit,
 				IncludeContextMessages: true,
 				DisableSemanticSearch:  true,
 			})
@@ -653,22 +669,140 @@ func (ch *ConversationsHandler) ConversationsSearchHandler(ctx context.Context, 
 			ch.logger.Error("Slack AssistantSearchContext failed", zap.Error(callErr))
 			return nil, callErr
 		}
-		if params.authorFilter == nil {
-			return mcp.NewToolResultText(string(result)), nil
+		pagesScanned++
+
+		page, decodeErr := decodeAssistantSearchMessagePage(result)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		for _, message := range page.Messages {
+			if params.authorFilter != nil && message.AuthorUserID != params.authorFilter.UserID {
+				continue
+			}
+			if params.contextChannelID != "" && message.ChannelID != params.contextChannelID {
+				continue
+			}
+			matches = append(matches, message)
+			if len(matches) == params.limit {
+				break
+			}
 		}
 
-		filtered, matchCount, nextCursor, filterErr := filterAssistantSearchPage(result, params.authorFilter)
-		if filterErr != nil {
-			ch.logger.Error("Failed to filter assistant search response", zap.Error(filterErr))
-			return nil, filterErr
+		nextCursor = page.NextCursor
+		if nextCursor != "" {
+			if _, repeated := seenCursors[nextCursor]; repeated {
+				return nil, fmt.Errorf("assistant search returned repeated cursor %q", nextCursor)
+			}
 		}
-		if matchCount > 0 || nextCursor == "" || page == maxPages-1 {
-			return mcp.NewToolResultText(string(filtered)), nil
+		if nextCursor == "" || len(matches) == params.limit {
+			break
 		}
+		if pagesScanned >= maxAssistantSearchPages {
+			return nil, fmt.Errorf("assistant search pagination truncated after %d pages before reaching the requested limit", maxAssistantSearchPages)
+		}
+		seenCursors[nextCursor] = struct{}{}
 		cursor = nextCursor
 	}
 
-	return nil, errors.New("assistant search pagination ended unexpectedly")
+	messages := ch.convertMessagesFromAssistantSearch(ctx, matches)
+	if len(messages) > 0 && nextCursor != "" {
+		messages[len(messages)-1].Cursor = nextCursor
+	}
+	return marshalMessagesToCSV(messages)
+}
+
+type assistantSearchMessage struct {
+	AuthorName   string `json:"author_name"`
+	AuthorUserID string `json:"author_user_id"`
+	ChannelID    string `json:"channel_id"`
+	ChannelName  string `json:"channel_name"`
+	Content      string `json:"content"`
+	IsAuthorBot  bool   `json:"is_author_bot"`
+	MessageTS    string `json:"message_ts"`
+	Permalink    string `json:"permalink"`
+}
+
+type assistantSearchMessagePage struct {
+	Messages   []assistantSearchMessage
+	NextCursor string
+}
+
+func decodeAssistantSearchMessagePage(raw json.RawMessage) (assistantSearchMessagePage, error) {
+	var response struct {
+		OK               bool            `json:"ok"`
+		APIError         string          `json:"error"`
+		Results          json.RawMessage `json:"results"`
+		ResponseMetadata struct {
+			NextCursor string `json:"next_cursor"`
+		} `json:"response_metadata"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return assistantSearchMessagePage{}, fmt.Errorf("decode assistant search response: %w", err)
+	}
+	if !response.OK {
+		if response.APIError == "" {
+			response.APIError = "unknown_error"
+		}
+		return assistantSearchMessagePage{}, fmt.Errorf("assistant search failed: %s", response.APIError)
+	}
+	if len(response.Results) == 0 || string(response.Results) == "null" {
+		return assistantSearchMessagePage{}, errors.New("assistant search response is missing results.messages")
+	}
+	var results struct {
+		Messages json.RawMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(response.Results, &results); err != nil {
+		return assistantSearchMessagePage{}, fmt.Errorf("decode assistant search results: %w", err)
+	}
+	if len(results.Messages) == 0 || string(results.Messages) == "null" {
+		return assistantSearchMessagePage{}, errors.New("assistant search response is missing results.messages")
+	}
+	var messages []assistantSearchMessage
+	if err := json.Unmarshal(results.Messages, &messages); err != nil {
+		return assistantSearchMessagePage{}, fmt.Errorf("decode assistant search messages: %w", err)
+	}
+	return assistantSearchMessagePage{Messages: messages, NextCursor: response.ResponseMetadata.NextCursor}, nil
+}
+
+func (ch *ConversationsHandler) convertMessagesFromAssistantSearch(ctx context.Context, source []assistantSearchMessage) []Message {
+	resolver := ch.newUserResolver(ctx)
+	messages := make([]Message, 0, len(source))
+	for _, item := range source {
+		timestamp, err := text.TimestampToIsoRFC3339(item.MessageTS)
+		if err != nil {
+			ch.logger.Warn("Skipping assistant search result with invalid timestamp", zap.Error(err))
+			continue
+		}
+		userName, realName, resolved := resolver.resolve(item.AuthorUserID)
+		if !resolved || realName == "" {
+			realName = item.AuthorName
+		}
+		channel := item.ChannelID
+		if name := strings.TrimPrefix(strings.TrimSpace(item.ChannelName), "#"); name != "" {
+			channel = fmt.Sprintf("%s (#%s)", item.ChannelID, name)
+		}
+		threadTS, _ := extractThreadTS(item.Permalink)
+		botName := ""
+		if item.IsAuthorBot {
+			botName = item.AuthorName
+		}
+		messages = append(messages, Message{
+			MsgID: item.MessageTS, UserID: item.AuthorUserID, UserName: userName, RealName: realName,
+			Channel: channel, ThreadTs: threadTS, Text: text.ProcessText(item.Content), Time: timestamp,
+			Permalink: item.Permalink, BotName: botName,
+		})
+	}
+	return messages
+}
+
+func validateAssistantSearchToken(isOAuth, isBotToken bool) error {
+	if isBotToken {
+		return errors.New("assistant search requires a Slack user token; bot tokens require an action_token that is unavailable to the stdio handler")
+	}
+	if !isOAuth {
+		return errors.New("assistant search requires a Slack User OAuth token (xoxp); browser session tokens are not supported by the Real-time Search API")
+	}
+	return nil
 }
 
 func newSearchAuthorFilter(raw string, usersInv map[string]string) *searchAuthorFilter {
@@ -693,7 +827,12 @@ func newSearchAuthorFilter(raw string, usersInv map[string]string) *searchAuthor
 	return &searchAuthorFilter{Name: raw}
 }
 
-func searchAuthorFromUsersResponse(raw json.RawMessage, requestedName string) (*searchAuthorFilter, error) {
+type historicalUserCandidates struct {
+	ByPriority [3]map[string]struct{}
+	NextCursor string
+}
+
+func decodeHistoricalUserCandidates(raw json.RawMessage, requestedName string) (*historicalUserCandidates, error) {
 	var response struct {
 		OK       bool   `json:"ok"`
 		APIError string `json:"error"`
@@ -704,6 +843,9 @@ func searchAuthorFromUsersResponse(raw json.RawMessage, requestedName string) (*
 				Email    string `json:"email"`
 			} `json:"users"`
 		} `json:"results"`
+		ResponseMetadata struct {
+			NextCursor string `json:"next_cursor"`
+		} `json:"response_metadata"`
 	}
 	if err := json.Unmarshal(raw, &response); err != nil {
 		return nil, fmt.Errorf("decode historical user search response: %w", err)
@@ -715,27 +857,129 @@ func searchAuthorFromUsersResponse(raw json.RawMessage, requestedName string) (*
 		return nil, fmt.Errorf("historical user search failed: %s", response.APIError)
 	}
 
+	result := &historicalUserCandidates{NextCursor: response.ResponseMetadata.NextCursor}
+	for i := range result.ByPriority {
+		result.ByPriority[i] = make(map[string]struct{})
+	}
 	requested := strings.TrimSpace(strings.TrimPrefix(requestedName, "@"))
 	for _, user := range response.Results.Users {
-		emailName := user.Email
+		email := strings.TrimSpace(user.Email)
+		emailName := email
 		if at := strings.IndexByte(emailName, '@'); at >= 0 {
 			emailName = emailName[:at]
 		}
-		if strings.EqualFold(user.UserID, requested) ||
-			strings.EqualFold(strings.TrimSpace(user.FullName), requested) ||
-			strings.EqualFold(strings.TrimSpace(user.Email), requested) ||
-			strings.EqualFold(strings.TrimSpace(emailName), requested) {
-			return &searchAuthorFilter{UserID: user.UserID}, nil
+
+		priority := -1
+		switch {
+		case strings.EqualFold(strings.TrimSpace(user.UserID), requested):
+			priority = 0
+		case strings.EqualFold(email, requested):
+			priority = 1
+		case strings.EqualFold(strings.TrimSpace(user.FullName), requested),
+			strings.EqualFold(strings.TrimSpace(emailName), requested):
+			priority = 2
 		}
+		if priority < 0 {
+			continue
+		}
+		if !provider.IsValidSlackUserID(user.UserID) {
+			return nil, fmt.Errorf("historical user match for %q has no valid stable user ID", requestedName)
+		}
+		result.ByPriority[priority][user.UserID] = struct{}{}
 	}
-	if len(response.Results.Users) == 1 && response.Results.Users[0].UserID != "" {
-		return &searchAuthorFilter{UserID: response.Results.Users[0].UserID}, nil
+	return result, nil
+}
+
+func selectHistoricalUser(candidates [3]map[string]struct{}, requestedName string) (*searchAuthorFilter, error) {
+	for _, matches := range candidates {
+		if len(matches) == 0 {
+			continue
+		}
+		if len(matches) > 1 {
+			return nil, fmt.Errorf("historical user %q is ambiguous", requestedName)
+		}
+		for userID := range matches {
+			return &searchAuthorFilter{UserID: userID}, nil
+		}
 	}
 	return nil, nil
 }
 
+func searchAuthorFromUsersResponse(raw json.RawMessage, requestedName string) (*searchAuthorFilter, error) {
+	page, err := decodeHistoricalUserCandidates(raw, requestedName)
+	if err != nil {
+		return nil, err
+	}
+	return selectHistoricalUser(page.ByPriority, requestedName)
+}
+
+func assistantSearchNextCursor(raw json.RawMessage) (string, error) {
+	var response struct {
+		ResponseMetadata struct {
+			NextCursor string `json:"next_cursor"`
+		} `json:"response_metadata"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return "", fmt.Errorf("decode historical user search cursor: %w", err)
+	}
+	return response.ResponseMetadata.NextCursor, nil
+}
+
+func searchHistoricalAuthorPages(
+	ctx context.Context,
+	requestedName string,
+	fetchPage func(context.Context, string) (json.RawMessage, error),
+) (*searchAuthorFilter, error) {
+	const maxPages = 10
+
+	var collected [3]map[string]struct{}
+	for i := range collected {
+		collected[i] = make(map[string]struct{})
+	}
+	cursor := ""
+	seenCursors := map[string]struct{}{cursor: {}}
+	for pageNumber := 0; pageNumber < maxPages; pageNumber++ {
+		result, err := fetchPage(ctx, cursor)
+		if err != nil {
+			return nil, err
+		}
+		page, err := decodeHistoricalUserCandidates(result, requestedName)
+		if err != nil {
+			return nil, err
+		}
+		for priority, matches := range page.ByPriority {
+			for userID := range matches {
+				collected[priority][userID] = struct{}{}
+			}
+		}
+		if page.NextCursor == "" {
+			resolved, err := selectHistoricalUser(collected, requestedName)
+			if err != nil {
+				return nil, err
+			}
+			if resolved == nil {
+				return nil, fmt.Errorf("user %q not found", requestedName)
+			}
+			return resolved, nil
+		}
+		if _, repeated := seenCursors[page.NextCursor]; repeated {
+			return nil, fmt.Errorf("historical user pagination returned repeated cursor %q", page.NextCursor)
+		}
+		if pageNumber == maxPages-1 {
+			return nil, fmt.Errorf("historical user pagination truncated after %d pages", maxPages)
+		}
+		seenCursors[page.NextCursor] = struct{}{}
+		cursor = page.NextCursor
+	}
+	return nil, fmt.Errorf("historical user pagination truncated after %d pages", maxPages)
+}
+
 func (ch *ConversationsHandler) resolveSearchAuthorFilter(ctx context.Context, raw string) (*searchAuthorFilter, error) {
-	filter := newSearchAuthorFilter(raw, ch.apiProvider.ProvideUsersMap().UsersInv)
+	users := ch.apiProvider.ProvideUsersMap()
+	if users == nil {
+		return nil, errors.New("user cache is unavailable")
+	}
+	filter := newSearchAuthorFilter(raw, users.UsersInv)
 	if filter == nil {
 		return nil, errors.New("filter_users_from must not be empty")
 	}
@@ -747,98 +991,18 @@ func (ch *ConversationsHandler) resolveSearchAuthorFilter(ctx context.Context, r
 	// while their historical messages remain searchable. The assistant search API
 	// can include deleted users and returns the stable historical user ID.
 	rl := limiter.Tier2.Limiter()
-	result, err := limiter.CallWithRetry(ctx, rl, 2, slackRetryAfter, func() (json.RawMessage, error) {
-		return ch.apiProvider.Slack().AssistantSearchContext(ctx, provider.AssistantSearchContextRequest{
-			Query:                 filter.Name,
-			ContentTypes:          []string{"users"},
-			Limit:                 20,
-			IncludeDeletedUsers:   true,
-			DisableSemanticSearch: true,
+	return searchHistoricalAuthorPages(ctx, filter.Name, func(ctx context.Context, cursor string) (json.RawMessage, error) {
+		return limiter.CallWithRetry(ctx, rl, 2, slackRetryAfter, func() (json.RawMessage, error) {
+			return ch.apiProvider.Slack().AssistantSearchContext(ctx, provider.AssistantSearchContextRequest{
+				Query:                 filter.Name,
+				ContentTypes:          []string{"users"},
+				Cursor:                cursor,
+				Limit:                 20,
+				IncludeDeletedUsers:   true,
+				DisableSemanticSearch: true,
+			})
 		})
 	})
-	if err != nil {
-		ch.logger.Warn("Historical user lookup unavailable; falling back to returned author name",
-			zap.String("author", filter.Name), zap.Error(err))
-		return filter, nil
-	}
-	resolved, err := searchAuthorFromUsersResponse(result, filter.Name)
-	if err != nil {
-		ch.logger.Warn("Historical user lookup could not be decoded; falling back to returned author name",
-			zap.String("author", filter.Name), zap.Error(err))
-		return filter, nil
-	}
-	if resolved != nil {
-		return resolved, nil
-	}
-	return filter, nil
-}
-
-func filterAssistantSearchPage(raw json.RawMessage, author *searchAuthorFilter) (json.RawMessage, int, string, error) {
-	var envelope map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return nil, 0, "", fmt.Errorf("decode assistant search response: %w", err)
-	}
-
-	var metadata struct {
-		NextCursor string `json:"next_cursor"`
-	}
-	if metadataRaw, ok := envelope["response_metadata"]; ok {
-		if err := json.Unmarshal(metadataRaw, &metadata); err != nil {
-			return nil, 0, "", fmt.Errorf("decode assistant search cursor: %w", err)
-		}
-	}
-
-	var results map[string]json.RawMessage
-	if resultsRaw, ok := envelope["results"]; ok {
-		if err := json.Unmarshal(resultsRaw, &results); err != nil {
-			return nil, 0, "", fmt.Errorf("decode assistant search results: %w", err)
-		}
-	} else {
-		return raw, 0, metadata.NextCursor, nil
-	}
-
-	var messages []json.RawMessage
-	if messagesRaw, ok := results["messages"]; ok {
-		if err := json.Unmarshal(messagesRaw, &messages); err != nil {
-			return nil, 0, "", fmt.Errorf("decode assistant search messages: %w", err)
-		}
-	}
-
-	filtered := make([]json.RawMessage, 0, len(messages))
-	for _, message := range messages {
-		var identity struct {
-			AuthorUserID string `json:"author_user_id"`
-			AuthorName   string `json:"author_name"`
-		}
-		if err := json.Unmarshal(message, &identity); err != nil {
-			return nil, 0, "", fmt.Errorf("decode assistant search message author: %w", err)
-		}
-		matches := author == nil
-		if author != nil && author.UserID != "" {
-			matches = identity.AuthorUserID == author.UserID
-		} else if author != nil && author.Name != "" {
-			matches = strings.EqualFold(strings.TrimSpace(identity.AuthorName), strings.TrimSpace(author.Name))
-		}
-		if matches {
-			filtered = append(filtered, message)
-		}
-	}
-
-	filteredJSON, err := json.Marshal(filtered)
-	if err != nil {
-		return nil, 0, "", fmt.Errorf("encode filtered assistant search messages: %w", err)
-	}
-	results["messages"] = filteredJSON
-	resultsJSON, err := json.Marshal(results)
-	if err != nil {
-		return nil, 0, "", fmt.Errorf("encode filtered assistant search results: %w", err)
-	}
-	envelope["results"] = resultsJSON
-	responseJSON, err := json.Marshal(envelope)
-	if err != nil {
-		return nil, 0, "", fmt.Errorf("encode filtered assistant search response: %w", err)
-	}
-	return responseJSON, len(filtered), metadata.NextCursor, nil
 }
 
 // UnreadChannel represents a channel with unread messages
@@ -2197,53 +2361,75 @@ func (ch *ConversationsHandler) parseParamsToolMark(request mcp.CallToolRequest)
 func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req mcp.CallToolRequest) (*searchParams, error) {
 	rawQuery := strings.TrimSpace(req.GetString("search_query", ""))
 	freeTextParts, filters := splitQuery(rawQuery)
-	freeText := strings.Join(freeTextParts, " ")
 	channelTypes := []string{"public_channel", "private_channel", "mpim"}
 	contextChannelID := ""
+	resolvedChannelName := ""
 	var authorFilter *searchAuthorFilter
 
 	if req.GetBool("filter_threads_only", false) {
 		addFilter(filters, "is", "thread")
 	}
-	if chName := req.GetString("filter_in_channel", ""); chName != "" {
-		f, err := ch.paramFormatChannel(chName)
+	mergeChannelScope := func(raw string, requireMPIM, rejectMPIM bool) error {
+		channel, err := ch.resolveSearchChannel(ctx, raw, requireMPIM)
 		if err != nil {
+			return err
+		}
+		if rejectMPIM && channel.IsMpIM {
+			return errors.New("MPIM search requires filter_in_im_or_mpim; filter_in_channel supports public and private channels only")
+		}
+		if contextChannelID != "" && contextChannelID != channel.ID {
+			return fmt.Errorf("conflicting channel filters resolve to %q and %q", contextChannelID, channel.ID)
+		}
+		contextChannelID = channel.ID
+		resolvedChannelName = channel.Name
+		channelTypes = searchChannelTypesForCachedChannel(channel)
+		return nil
+	}
+
+	for _, rawIn := range filters["in"] {
+		if err := mergeChannelScope(rawIn, false, false); err != nil {
+			ch.logger.Error("Invalid in-channel modifier", zap.String("filter", rawIn), zap.Error(err))
+			return nil, err
+		}
+	}
+	if chName := strings.TrimSpace(req.GetString("filter_in_channel", "")); chName != "" {
+		if err := mergeChannelScope(chName, false, true); err != nil {
 			ch.logger.Error("Invalid channel filter", zap.String("filter", chName), zap.Error(err))
 			return nil, err
 		}
-		addFilter(filters, "in", f)
-		contextChannelID, err = ch.resolveChannelID(ctx, chName)
-		if err != nil {
+	}
+	if im := strings.TrimSpace(req.GetString("filter_in_im_or_mpim", "")); im != "" {
+		if err := mergeChannelScope(im, true, false); err != nil {
+			ch.logger.Error("Invalid MPIM filter", zap.String("filter", im), zap.Error(err))
 			return nil, err
 		}
-		if cached, ok := ch.apiProvider.ProvideChannelsMaps().Channels[contextChannelID]; ok && cached.IsPrivate {
-			channelTypes = []string{"private_channel"}
-		} else {
-			channelTypes = []string{"public_channel"}
-		}
-	} else if im := req.GetString("filter_in_im_or_mpim", ""); im != "" {
-		return nil, fmt.Errorf("DM-specific search is unavailable because this Slack app cannot obtain im:read; search public/private channels or MPIMs instead")
 	}
-	if with := req.GetString("filter_users_with", ""); with != "" {
-		f, err := ch.paramFormatUser(ctx, with)
-		if err != nil {
-			ch.logger.Error("Invalid with-user filter", zap.String("filter", with), zap.Error(err))
-			return nil, err
-		}
-		addFilter(filters, "with", f)
+	if contextChannelID != "" {
+		filters["in"] = []string{resolvedChannelName}
 	}
-	if from := req.GetString("filter_users_from", ""); from != "" {
+	if len(filters["with"]) > 0 || strings.TrimSpace(req.GetString("filter_users_with", "")) != "" {
+		return nil, errors.New("with: and filter_users_with are unsupported by Slack Real-time Search because participant scope cannot be verified from the response")
+	}
+	rawFrom := filters["from"]
+	if len(rawFrom) > 1 {
+		return nil, errors.New("multiple from: modifiers are unsupported; provide exactly one author filter")
+	}
+	explicitFrom := strings.TrimSpace(req.GetString("filter_users_from", ""))
+	if explicitFrom != "" && len(rawFrom) > 0 {
+		return nil, errors.New("filter_users_from cannot be combined with a from: modifier in search_query")
+	}
+	from := explicitFrom
+	if len(rawFrom) == 1 {
+		from = rawFrom[0]
+	}
+	if from != "" {
 		f, err := ch.resolveSearchAuthorFilter(ctx, from)
 		if err != nil {
 			ch.logger.Error("Invalid from-user filter", zap.String("filter", from), zap.Error(err))
 			return nil, err
 		}
 		authorFilter = f
-		if f.UserID != "" {
-			addFilter(filters, "from", fmt.Sprintf("<@%s>", f.UserID))
-		} else {
-			addFilter(filters, "from", f.Name)
-		}
+		filters["from"] = []string{fmt.Sprintf("<@%s>", f.UserID)}
 	}
 
 	dateMap, err := buildDateFilters(
@@ -2261,22 +2447,25 @@ func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req m
 	}
 
 	finalQuery := buildQuery(freeTextParts, filters)
-	if freeText == "" {
-		return nil, errors.New("search_query must include search text")
+	if finalQuery == "" {
+		return nil, errors.New("search_query or at least one filter is required")
 	}
-	limit := req.GetInt("limit", 20)
-	if limit < 1 {
-		return nil, errors.New("limit must be at least 1")
+	limit := 20
+	arguments, _ := req.Params.Arguments.(map[string]any)
+	if rawLimit, ok := arguments["limit"]; ok {
+		limit, err = parseSearchLimit(rawLimit)
+		if err != nil {
+			return nil, err
+		}
 	}
 	cursor := req.GetString("cursor", "")
 
 	ch.logger.Debug("Search parameters built",
-		zap.String("query", freeText),
-		zap.String("legacy_query", finalQuery),
+		zap.String("query", finalQuery),
 		zap.Int("limit", limit),
 	)
 	return &searchParams{
-		query:            freeText,
+		query:            finalQuery,
 		limit:            limit,
 		cursor:           cursor,
 		contextChannelID: contextChannelID,
@@ -2285,9 +2474,151 @@ func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req m
 	}, nil
 }
 
-// Slack user IDs may begin with U or W: https://docs.slack.dev/changelog/2016/08/11/user-id-format-changes
+func parseSearchLimit(raw any) (int, error) {
+	var limit int
+	switch value := raw.(type) {
+	case int:
+		limit = value
+	case int32:
+		limit = int(value)
+	case int64:
+		limit = int(value)
+	case float64:
+		limit = int(value)
+		if value != float64(limit) {
+			return 0, errors.New("limit must be an integer between 1 and 100")
+		}
+	case json.Number:
+		parsed, err := strconv.Atoi(value.String())
+		if err != nil {
+			return 0, errors.New("limit must be an integer between 1 and 100")
+		}
+		limit = parsed
+	default:
+		return 0, errors.New("limit must be an integer between 1 and 100")
+	}
+	if limit < 1 || limit > 100 {
+		return 0, errors.New("limit must be between 1 and 100")
+	}
+	return limit, nil
+}
+
+func searchChannelTypesForCachedChannel(channel provider.Channel) []string {
+	if channel.IsIM {
+		return nil
+	}
+	if channel.IsMpIM {
+		return []string{"mpim"}
+	}
+	if channel.IsPrivate {
+		return []string{"private_channel"}
+	}
+	return []string{"public_channel"}
+}
+
+func resolveCachedMPIM(raw string, channels *provider.ChannelsCache) (provider.Channel, error) {
+	raw = strings.TrimSpace(raw)
+	channelID := raw
+	if id, ok := channels.ChannelsInv[raw]; ok {
+		channelID = id
+	}
+	channel, ok := channels.Channels[channelID]
+	if !ok {
+		if strings.HasPrefix(raw, "D") || strings.HasSuffix(raw, "_dm") {
+			return provider.Channel{}, fmt.Errorf("one-to-one DM search is unavailable because this Slack app cannot obtain im:read; filter_in_im_or_mpim supports cached MPIMs only")
+		}
+		return provider.Channel{}, fmt.Errorf("MPIM %q not found in the channel cache", raw)
+	}
+	if channel.IsIM {
+		return provider.Channel{}, fmt.Errorf("one-to-one DM search is unavailable because this Slack app cannot obtain im:read; filter_in_im_or_mpim supports cached MPIMs only")
+	}
+	if !channel.IsMpIM {
+		return provider.Channel{}, fmt.Errorf("channel %q is not an MPIM", raw)
+	}
+	return channel, nil
+}
+
+var slackSearchChannelIDPattern = regexp.MustCompile(`^[CG][A-Z0-9]+$`)
+
+func (ch *ConversationsHandler) resolveSearchChannel(ctx context.Context, raw string, requireMPIM bool) (provider.Channel, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return provider.Channel{}, errors.New("channel filter must not be empty")
+	}
+	if strings.HasPrefix(raw, "D") {
+		return provider.Channel{}, errors.New("one-to-one DM search is unavailable because this Slack app cannot obtain im:read")
+	}
+
+	channels := ch.apiProvider.ProvideChannelsMaps()
+	if channels == nil {
+		return provider.Channel{}, errors.New("channel cache is unavailable")
+	}
+
+	channelID := ""
+	lookupName := ""
+	if strings.HasPrefix(raw, "C") || strings.HasPrefix(raw, "G") {
+		if !slackSearchChannelIDPattern.MatchString(raw) {
+			return provider.Channel{}, fmt.Errorf("invalid Slack channel ID %q", raw)
+		}
+		channelID = raw
+	} else {
+		candidates := []string{raw}
+		if !strings.HasPrefix(raw, "#") && !strings.HasPrefix(raw, "@") {
+			candidates = append(candidates, "#"+raw)
+		}
+		for _, candidate := range candidates {
+			if id, ok := channels.ChannelsInv[candidate]; ok {
+				lookupName = candidate
+				channelID = id
+				break
+			}
+		}
+		if channelID == "" {
+			lookupName = raw
+			if !strings.HasPrefix(lookupName, "#") && !strings.HasPrefix(lookupName, "@") {
+				lookupName = "#" + lookupName
+			}
+			resolved, err := ch.resolveChannelID(ctx, lookupName)
+			if err != nil {
+				return provider.Channel{}, err
+			}
+			channelID = resolved
+			channels = ch.apiProvider.ProvideChannelsMaps()
+			if channels == nil {
+				return provider.Channel{}, errors.New("channel cache is unavailable after refresh")
+			}
+		}
+	}
+
+	if !slackSearchChannelIDPattern.MatchString(channelID) {
+		return provider.Channel{}, fmt.Errorf("invalid Slack channel ID %q in channel cache", channelID)
+	}
+	channel, ok := channels.Channels[channelID]
+	if !ok {
+		return provider.Channel{}, fmt.Errorf("channel %q not found in the channel cache", raw)
+	}
+	if channel.ID != channelID {
+		return provider.Channel{}, fmt.Errorf("channel cache record for %q has inconsistent Slack channel ID %q", channelID, channel.ID)
+	}
+	if lookupName != "" {
+		if mappedID, ok := channels.ChannelsInv[lookupName]; !ok || mappedID != channelID {
+			return provider.Channel{}, fmt.Errorf("channel cache inverse entry for %q is inconsistent", lookupName)
+		}
+	}
+	if channel.Name == "" {
+		return provider.Channel{}, fmt.Errorf("channel cache record for %q has no search name", channelID)
+	}
+	if channel.IsIM {
+		return provider.Channel{}, errors.New("one-to-one DM search is unavailable because this Slack app cannot obtain im:read")
+	}
+	if requireMPIM && !channel.IsMpIM {
+		return provider.Channel{}, fmt.Errorf("channel %q is not an MPIM", raw)
+	}
+	return channel, nil
+}
+
 func isSlackUserIDPrefix(s string) bool {
-	return strings.HasPrefix(s, "U") || strings.HasPrefix(s, "W")
+	return provider.IsValidSlackUserID(s)
 }
 
 func (ch *ConversationsHandler) paramFormatUser(ctx context.Context, raw string) (string, error) {
@@ -2359,7 +2690,7 @@ func getUserInfo(userID string, usersMap map[string]slack.User) (userName, realN
 // it already tried to fetch, so a user that doesn't exist in Slack is only
 // looked up once per batch rather than once per message.
 type userResolver struct {
-	apiProvider  *provider.ApiProvider
+	apiProvider  conversationsProvider
 	ctx          context.Context
 	usersMap     *provider.UsersCache
 	attemptedIDs map[string]bool

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -88,9 +88,17 @@ type conversationParams struct {
 }
 
 type searchParams struct {
-	query string
-	limit int
-	page  int
+	query            string
+	limit            int
+	cursor           string
+	contextChannelID string
+	channelTypes     []string
+	authorFilter     *searchAuthorFilter
+}
+
+type searchAuthorFilter struct {
+	UserID string
+	Name   string
 }
 
 type addMessageParams struct {
@@ -609,33 +617,228 @@ func (ch *ConversationsHandler) ConversationsSearchHandler(ctx context.Context, 
 		ch.logger.Error("Failed to parse search params", zap.Error(err))
 		return nil, err
 	}
-	ch.logger.Debug("Search params parsed", zap.String("query", params.query), zap.Int("limit", params.limit), zap.Int("page", params.page))
+	ch.logger.Debug("Search params parsed", zap.String("query", params.query), zap.Int("limit", params.limit), zap.String("cursor", params.cursor))
 
-	searchParams := slack.SearchParameters{
-		Sort:          slack.DEFAULT_SEARCH_SORT,
-		SortDirection: slack.DEFAULT_SEARCH_SORT_DIR,
-		Highlight:     false,
-		Count:         params.limit,
-		Page:          params.page,
+	limit := params.limit
+	if limit > 20 {
+		limit = 20 // Slack assistant.search.context has a hard 20-result maximum.
 	}
 
+	// Author filtering is performed against the structured author_user_id returned
+	// by assistant.search.context. Slack accepts from: modifiers on this endpoint
+	// but currently does not enforce them, so relying on the modifier returns mixed
+	// authors. Scan a bounded number of pages to avoid returning a false empty first
+	// page when the requested historical author is not among the first 20 results.
+	maxPages := 1
+	if params.authorFilter != nil {
+		maxPages = 10
+	}
+
+	cursor := params.cursor
 	rl := limiter.Tier2.Limiter()
-	messagesRes, err := limiter.CallWithRetry(ctx, rl, 2, slackRetryAfter, func() (*slack.SearchMessages, error) {
-		msgs, _, err := ch.apiProvider.Slack().SearchContext(ctx, params.query, searchParams)
-		return msgs, err
+	for page := 0; page < maxPages; page++ {
+		result, callErr := limiter.CallWithRetry(ctx, rl, 2, slackRetryAfter, func() (json.RawMessage, error) {
+			return ch.apiProvider.Slack().AssistantSearchContext(ctx, provider.AssistantSearchContextRequest{
+				Query:                  params.query,
+				ChannelTypes:           params.channelTypes,
+				ContentTypes:           []string{"messages"},
+				ContextChannelID:       params.contextChannelID,
+				Cursor:                 cursor,
+				Limit:                  limit,
+				IncludeContextMessages: true,
+				DisableSemanticSearch:  true,
+			})
+		})
+		if callErr != nil {
+			ch.logger.Error("Slack AssistantSearchContext failed", zap.Error(callErr))
+			return nil, callErr
+		}
+		if params.authorFilter == nil {
+			return mcp.NewToolResultText(string(result)), nil
+		}
+
+		filtered, matchCount, nextCursor, filterErr := filterAssistantSearchPage(result, params.authorFilter)
+		if filterErr != nil {
+			ch.logger.Error("Failed to filter assistant search response", zap.Error(filterErr))
+			return nil, filterErr
+		}
+		if matchCount > 0 || nextCursor == "" || page == maxPages-1 {
+			return mcp.NewToolResultText(string(filtered)), nil
+		}
+		cursor = nextCursor
+	}
+
+	return nil, errors.New("assistant search pagination ended unexpectedly")
+}
+
+func newSearchAuthorFilter(raw string, usersInv map[string]string) *searchAuthorFilter {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimSuffix(raw, ">")
+	raw = strings.TrimPrefix(raw, "<@")
+	raw = strings.TrimPrefix(raw, "@")
+	if raw == "" {
+		return nil
+	}
+	if isSlackUserIDPrefix(raw) {
+		return &searchAuthorFilter{UserID: raw}
+	}
+	if userID, ok := usersInv[raw]; ok {
+		return &searchAuthorFilter{UserID: userID}
+	}
+	for name, userID := range usersInv {
+		if strings.EqualFold(strings.TrimSpace(name), raw) {
+			return &searchAuthorFilter{UserID: userID}
+		}
+	}
+	return &searchAuthorFilter{Name: raw}
+}
+
+func searchAuthorFromUsersResponse(raw json.RawMessage, requestedName string) (*searchAuthorFilter, error) {
+	var response struct {
+		OK       bool   `json:"ok"`
+		APIError string `json:"error"`
+		Results  struct {
+			Users []struct {
+				UserID   string `json:"user_id"`
+				FullName string `json:"full_name"`
+				Email    string `json:"email"`
+			} `json:"users"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return nil, fmt.Errorf("decode historical user search response: %w", err)
+	}
+	if !response.OK {
+		if response.APIError == "" {
+			response.APIError = "unknown_error"
+		}
+		return nil, fmt.Errorf("historical user search failed: %s", response.APIError)
+	}
+
+	requested := strings.TrimSpace(strings.TrimPrefix(requestedName, "@"))
+	for _, user := range response.Results.Users {
+		emailName := user.Email
+		if at := strings.IndexByte(emailName, '@'); at >= 0 {
+			emailName = emailName[:at]
+		}
+		if strings.EqualFold(user.UserID, requested) ||
+			strings.EqualFold(strings.TrimSpace(user.FullName), requested) ||
+			strings.EqualFold(strings.TrimSpace(user.Email), requested) ||
+			strings.EqualFold(strings.TrimSpace(emailName), requested) {
+			return &searchAuthorFilter{UserID: user.UserID}, nil
+		}
+	}
+	if len(response.Results.Users) == 1 && response.Results.Users[0].UserID != "" {
+		return &searchAuthorFilter{UserID: response.Results.Users[0].UserID}, nil
+	}
+	return nil, nil
+}
+
+func (ch *ConversationsHandler) resolveSearchAuthorFilter(ctx context.Context, raw string) (*searchAuthorFilter, error) {
+	filter := newSearchAuthorFilter(raw, ch.apiProvider.ProvideUsersMap().UsersInv)
+	if filter == nil {
+		return nil, errors.New("filter_users_from must not be empty")
+	}
+	if filter.UserID != "" {
+		return filter, nil
+	}
+
+	// Current users may be absent from users.list/users.info after deactivation,
+	// while their historical messages remain searchable. The assistant search API
+	// can include deleted users and returns the stable historical user ID.
+	rl := limiter.Tier2.Limiter()
+	result, err := limiter.CallWithRetry(ctx, rl, 2, slackRetryAfter, func() (json.RawMessage, error) {
+		return ch.apiProvider.Slack().AssistantSearchContext(ctx, provider.AssistantSearchContextRequest{
+			Query:                 filter.Name,
+			ContentTypes:          []string{"users"},
+			Limit:                 20,
+			IncludeDeletedUsers:   true,
+			DisableSemanticSearch: true,
+		})
 	})
 	if err != nil {
-		ch.logger.Error("Slack SearchContext failed", zap.Error(err))
-		return nil, err
+		ch.logger.Warn("Historical user lookup unavailable; falling back to returned author name",
+			zap.String("author", filter.Name), zap.Error(err))
+		return filter, nil
 	}
-	ch.logger.Debug("Search completed", zap.Int("matches", len(messagesRes.Matches)))
+	resolved, err := searchAuthorFromUsersResponse(result, filter.Name)
+	if err != nil {
+		ch.logger.Warn("Historical user lookup could not be decoded; falling back to returned author name",
+			zap.String("author", filter.Name), zap.Error(err))
+		return filter, nil
+	}
+	if resolved != nil {
+		return resolved, nil
+	}
+	return filter, nil
+}
 
-	messages := ch.convertMessagesFromSearch(ctx, messagesRes.Matches)
-	if len(messages) > 0 && messagesRes.Pagination.Page < messagesRes.Pagination.PageCount {
-		nextCursor := fmt.Sprintf("page:%d", messagesRes.Pagination.Page+1)
-		messages[len(messages)-1].Cursor = base64.StdEncoding.EncodeToString([]byte(nextCursor))
+func filterAssistantSearchPage(raw json.RawMessage, author *searchAuthorFilter) (json.RawMessage, int, string, error) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, 0, "", fmt.Errorf("decode assistant search response: %w", err)
 	}
-	return marshalMessagesToCSV(messages)
+
+	var metadata struct {
+		NextCursor string `json:"next_cursor"`
+	}
+	if metadataRaw, ok := envelope["response_metadata"]; ok {
+		if err := json.Unmarshal(metadataRaw, &metadata); err != nil {
+			return nil, 0, "", fmt.Errorf("decode assistant search cursor: %w", err)
+		}
+	}
+
+	var results map[string]json.RawMessage
+	if resultsRaw, ok := envelope["results"]; ok {
+		if err := json.Unmarshal(resultsRaw, &results); err != nil {
+			return nil, 0, "", fmt.Errorf("decode assistant search results: %w", err)
+		}
+	} else {
+		return raw, 0, metadata.NextCursor, nil
+	}
+
+	var messages []json.RawMessage
+	if messagesRaw, ok := results["messages"]; ok {
+		if err := json.Unmarshal(messagesRaw, &messages); err != nil {
+			return nil, 0, "", fmt.Errorf("decode assistant search messages: %w", err)
+		}
+	}
+
+	filtered := make([]json.RawMessage, 0, len(messages))
+	for _, message := range messages {
+		var identity struct {
+			AuthorUserID string `json:"author_user_id"`
+			AuthorName   string `json:"author_name"`
+		}
+		if err := json.Unmarshal(message, &identity); err != nil {
+			return nil, 0, "", fmt.Errorf("decode assistant search message author: %w", err)
+		}
+		matches := author == nil
+		if author != nil && author.UserID != "" {
+			matches = identity.AuthorUserID == author.UserID
+		} else if author != nil && author.Name != "" {
+			matches = strings.EqualFold(strings.TrimSpace(identity.AuthorName), strings.TrimSpace(author.Name))
+		}
+		if matches {
+			filtered = append(filtered, message)
+		}
+	}
+
+	filteredJSON, err := json.Marshal(filtered)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("encode filtered assistant search messages: %w", err)
+	}
+	results["messages"] = filteredJSON
+	resultsJSON, err := json.Marshal(results)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("encode filtered assistant search results: %w", err)
+	}
+	envelope["results"] = resultsJSON
+	responseJSON, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, 0, "", fmt.Errorf("encode filtered assistant search response: %w", err)
+	}
+	return responseJSON, len(filtered), metadata.NextCursor, nil
 }
 
 // UnreadChannel represents a channel with unread messages
@@ -1993,7 +2196,11 @@ func (ch *ConversationsHandler) parseParamsToolMark(request mcp.CallToolRequest)
 }
 func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req mcp.CallToolRequest) (*searchParams, error) {
 	rawQuery := strings.TrimSpace(req.GetString("search_query", ""))
-	freeText, filters := splitQuery(rawQuery)
+	freeTextParts, filters := splitQuery(rawQuery)
+	freeText := strings.Join(freeTextParts, " ")
+	channelTypes := []string{"public_channel", "private_channel", "mpim"}
+	contextChannelID := ""
+	var authorFilter *searchAuthorFilter
 
 	if req.GetBool("filter_threads_only", false) {
 		addFilter(filters, "is", "thread")
@@ -2005,13 +2212,17 @@ func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req m
 			return nil, err
 		}
 		addFilter(filters, "in", f)
-	} else if im := req.GetString("filter_in_im_or_mpim", ""); im != "" {
-		f, err := ch.paramFormatUser(ctx, im)
+		contextChannelID, err = ch.resolveChannelID(ctx, chName)
 		if err != nil {
-			ch.logger.Error("Invalid IM/MPIM filter", zap.String("filter", im), zap.Error(err))
 			return nil, err
 		}
-		addFilter(filters, "in", f)
+		if cached, ok := ch.apiProvider.ProvideChannelsMaps().Channels[contextChannelID]; ok && cached.IsPrivate {
+			channelTypes = []string{"private_channel"}
+		} else {
+			channelTypes = []string{"public_channel"}
+		}
+	} else if im := req.GetString("filter_in_im_or_mpim", ""); im != "" {
+		return nil, fmt.Errorf("DM-specific search is unavailable because this Slack app cannot obtain im:read; search public/private channels or MPIMs instead")
 	}
 	if with := req.GetString("filter_users_with", ""); with != "" {
 		f, err := ch.paramFormatUser(ctx, with)
@@ -2022,12 +2233,17 @@ func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req m
 		addFilter(filters, "with", f)
 	}
 	if from := req.GetString("filter_users_from", ""); from != "" {
-		f, err := ch.paramFormatUser(ctx, from)
+		f, err := ch.resolveSearchAuthorFilter(ctx, from)
 		if err != nil {
 			ch.logger.Error("Invalid from-user filter", zap.String("filter", from), zap.Error(err))
 			return nil, err
 		}
-		addFilter(filters, "from", f)
+		authorFilter = f
+		if f.UserID != "" {
+			addFilter(filters, "from", fmt.Sprintf("<@%s>", f.UserID))
+		} else {
+			addFilter(filters, "from", f.Name)
+		}
 	}
 
 	dateMap, err := buildDateFilters(
@@ -2044,43 +2260,28 @@ func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req m
 		addFilter(filters, key, val)
 	}
 
-	finalQuery := buildQuery(freeText, filters)
-	limit := req.GetInt("limit", 100)
+	finalQuery := buildQuery(freeTextParts, filters)
+	if freeText == "" {
+		return nil, errors.New("search_query must include search text")
+	}
+	limit := req.GetInt("limit", 20)
+	if limit < 1 {
+		return nil, errors.New("limit must be at least 1")
+	}
 	cursor := req.GetString("cursor", "")
 
-	var (
-		page          int
-		decodedCursor []byte
-	)
-	if cursor != "" {
-		decodedCursor, err = base64.StdEncoding.DecodeString(cursor)
-		if err != nil {
-			ch.logger.Error("Invalid cursor decoding", zap.String("cursor", cursor), zap.Error(err))
-			return nil, fmt.Errorf("invalid cursor: %v", err)
-		}
-		parts := strings.Split(string(decodedCursor), ":")
-		if len(parts) != 2 {
-			ch.logger.Error("Invalid cursor format", zap.String("cursor", cursor))
-			return nil, fmt.Errorf("invalid cursor: %v", cursor)
-		}
-		page, err = strconv.Atoi(parts[1])
-		if err != nil || page < 1 {
-			ch.logger.Error("Invalid cursor page", zap.String("cursor", cursor), zap.Error(err))
-			return nil, fmt.Errorf("invalid cursor page: %v", err)
-		}
-	} else {
-		page = 1
-	}
-
 	ch.logger.Debug("Search parameters built",
-		zap.String("query", finalQuery),
+		zap.String("query", freeText),
+		zap.String("legacy_query", finalQuery),
 		zap.Int("limit", limit),
-		zap.Int("page", page),
 	)
 	return &searchParams{
-		query: finalQuery,
-		limit: limit,
-		page:  page,
+		query:            freeText,
+		limit:            limit,
+		cursor:           cursor,
+		contextChannelID: contextChannelID,
+		channelTypes:     channelTypes,
+		authorFilter:     authorFilter,
 	}, nil
 }
 

--- a/pkg/handler/conversations_test.go
+++ b/pkg/handler/conversations_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
@@ -652,4 +653,76 @@ func TestUnitIsSlackUserIDPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnitNewSearchAuthorFilterAcceptsOrphanedSlackID(t *testing.T) {
+	filter := newSearchAuthorFilter("<@UDELETED123>", nil)
+	require.NotNil(t, filter)
+	assert.Equal(t, "UDELETED123", filter.UserID)
+	assert.Empty(t, filter.Name)
+}
+
+func TestUnitSearchAuthorFromUsersResponseResolvesDeletedUser(t *testing.T) {
+	raw := json.RawMessage(`{
+		"ok": true,
+		"results": {
+			"users": [
+				{"user_id": "UDELETED123", "full_name": "Former Engineer"}
+			]
+		}
+	}`)
+
+	filter, err := searchAuthorFromUsersResponse(raw, "Former Engineer")
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+	assert.Equal(t, "UDELETED123", filter.UserID)
+}
+
+func TestUnitFilterAssistantSearchPageByHistoricalAuthor(t *testing.T) {
+	raw := json.RawMessage(`{
+		"ok": true,
+		"results": {
+			"messages": [
+				{"author_user_id": "UDELETED123", "author_name": "Former Engineer", "content": "matching"},
+				{"author_user_id": "UCURRENT456", "author_name": "Current Engineer", "content": "not matching"}
+			],
+			"files": []
+		},
+		"response_metadata": {"next_cursor": "next-page"}
+	}`)
+
+	filtered, count, nextCursor, err := filterAssistantSearchPage(raw, &searchAuthorFilter{UserID: "UDELETED123"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "next-page", nextCursor)
+
+	var response struct {
+		Results struct {
+			Messages []struct {
+				AuthorUserID string `json:"author_user_id"`
+				Content      string `json:"content"`
+			} `json:"messages"`
+		} `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(filtered, &response))
+	require.Len(t, response.Results.Messages, 1)
+	assert.Equal(t, "UDELETED123", response.Results.Messages[0].AuthorUserID)
+	assert.Equal(t, "matching", response.Results.Messages[0].Content)
+}
+
+func TestUnitFilterAssistantSearchPageFallsBackToHistoricalName(t *testing.T) {
+	raw := json.RawMessage(`{
+		"ok": true,
+		"results": {
+			"messages": [
+				{"author_user_id": "UOLD", "author_name": "Former Engineer"},
+				{"author_user_id": "UNEW", "author_name": "Someone Else"}
+			]
+		},
+		"response_metadata": {"next_cursor": ""}
+	}`)
+
+	_, count, _, err := filterAssistantSearchPage(raw, &searchAuthorFilter{Name: "former engineer"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
 }

--- a/pkg/handler/conversations_test.go
+++ b/pkg/handler/conversations_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -13,13 +14,18 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/korotovsky/slack-mcp-server/pkg/provider"
 	"github.com/korotovsky/slack-mcp-server/pkg/test/util"
+	"github.com/korotovsky/slack-mcp-server/pkg/text"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/responses"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestIntegrationConversations(t *testing.T) {
@@ -91,7 +97,7 @@ func TestIntegrationConversations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			params := responses.ResponseNewParams{
-				Model: "gpt-4.1-mini",
+				Model: "gpt-5.4-mini",
 				Tools: []responses.ToolUnionParam{
 					{
 						OfMcp: &responses.ToolMcpParam{
@@ -642,6 +648,14 @@ func TestUnitIsSlackUserIDPrefix(t *testing.T) {
 	}{
 		{"U prefix", "U0123ABCD", true},
 		{"W prefix", "W0123ABCD", true},
+		{"orphaned stable ID", "UDELETED123", true},
+		{"short stable ID", "U1", true},
+		{"uppercase name starting U", "Ursula", false},
+		{"uppercase name starting W", "Workspace", false},
+		{"lowercase name", "workspace", false},
+		{"lowercase ID characters", "U0123abc", false},
+		{"ID punctuation", "U0123-ABC", false},
+		{"prefix only", "U", false},
 		{"plain name not ID", "alice", false},
 		{"empty", "", false},
 	}
@@ -678,51 +692,689 @@ func TestUnitSearchAuthorFromUsersResponseResolvesDeletedUser(t *testing.T) {
 	assert.Equal(t, "UDELETED123", filter.UserID)
 }
 
-func TestUnitFilterAssistantSearchPageByHistoricalAuthor(t *testing.T) {
+func TestUnitSearchAuthorFromUsersResponseRejectsSoleFuzzyResult(t *testing.T) {
 	raw := json.RawMessage(`{
 		"ok": true,
 		"results": {
-			"messages": [
-				{"author_user_id": "UDELETED123", "author_name": "Former Engineer", "content": "matching"},
-				{"author_user_id": "UCURRENT456", "author_name": "Current Engineer", "content": "not matching"}
-			],
-			"files": []
-		},
-		"response_metadata": {"next_cursor": "next-page"}
+			"users": [
+				{"user_id": "UWRONG123", "full_name": "Former Engineering Manager"}
+			]
+		}
 	}`)
 
-	filtered, count, nextCursor, err := filterAssistantSearchPage(raw, &searchAuthorFilter{UserID: "UDELETED123"})
+	filter, err := searchAuthorFromUsersResponse(raw, "Former Engineer")
 	require.NoError(t, err)
-	assert.Equal(t, 1, count)
-	assert.Equal(t, "next-page", nextCursor)
-
-	var response struct {
-		Results struct {
-			Messages []struct {
-				AuthorUserID string `json:"author_user_id"`
-				Content      string `json:"content"`
-			} `json:"messages"`
-		} `json:"results"`
-	}
-	require.NoError(t, json.Unmarshal(filtered, &response))
-	require.Len(t, response.Results.Messages, 1)
-	assert.Equal(t, "UDELETED123", response.Results.Messages[0].AuthorUserID)
-	assert.Equal(t, "matching", response.Results.Messages[0].Content)
+	assert.Nil(t, filter)
 }
 
-func TestUnitFilterAssistantSearchPageFallsBackToHistoricalName(t *testing.T) {
+func TestUnitSearchAuthorFromUsersResponseMatchesExactIdentities(t *testing.T) {
 	raw := json.RawMessage(`{
 		"ok": true,
 		"results": {
-			"messages": [
-				{"author_user_id": "UOLD", "author_name": "Former Engineer"},
-				{"author_user_id": "UNEW", "author_name": "Someone Else"}
+			"users": [
+				{"user_id": "UDELETED123", "full_name": "Former Engineer", "email": "former.engineer@example.com"}
 			]
-		},
-		"response_metadata": {"next_cursor": ""}
+		}
 	}`)
 
-	_, count, _, err := filterAssistantSearchPage(raw, &searchAuthorFilter{Name: "former engineer"})
+	for _, query := range []string{
+		"udeleted123",
+		"former engineer",
+		"FORMER.ENGINEER@EXAMPLE.COM",
+		"Former.Engineer",
+	} {
+		t.Run(query, func(t *testing.T) {
+			filter, err := searchAuthorFromUsersResponse(raw, query)
+			require.NoError(t, err)
+			require.NotNil(t, filter)
+			assert.Equal(t, "UDELETED123", filter.UserID)
+		})
+	}
+}
+
+func TestUnitParseParamsToolSearchStoresNormalizedLegacyQuery(t *testing.T) {
+	handler := &ConversationsHandler{
+		apiProvider: &fakeConversationsProvider{
+			slackClient: &fakeAssistantSlack{},
+			users: &provider.UsersCache{
+				Users:    map[string]slack.User{"UALICE123": {ID: "UALICE123", Name: "alice"}},
+				UsersInv: map[string]string{"alice": "UALICE123"},
+			},
+			channels: &provider.ChannelsCache{
+				Channels:    map[string]provider.Channel{"CGENERAL1": {ID: "CGENERAL1", Name: "#general"}},
+				ChannelsInv: map[string]string{"#general": "CGENERAL1"},
+			},
+		},
+		logger: zap.NewNop(),
+	}
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"search_query":        "launch plan from:alice after:2026-01-01 in:general is:thread",
+		"filter_threads_only": true,
+	}
+
+	params, err := handler.parseParamsToolSearch(context.Background(), request)
 	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+	assert.Equal(t, "launch plan is:thread in:#general from:<@UALICE123> after:2026-01-01", params.query)
+	require.NotNil(t, params.authorFilter)
+	assert.Equal(t, "UALICE123", params.authorFilter.UserID)
+	assert.Equal(t, "CGENERAL1", params.contextChannelID)
+	assert.Equal(t, []string{"public_channel"}, params.channelTypes)
+}
+
+func TestUnitParseParamsToolSearchRejectsConflictingChannelScopes(t *testing.T) {
+	handler := &ConversationsHandler{
+		apiProvider: &fakeConversationsProvider{
+			slackClient: &fakeAssistantSlack{},
+			users:       &provider.UsersCache{Users: map[string]slack.User{}, UsersInv: map[string]string{}},
+			channels: &provider.ChannelsCache{
+				Channels: map[string]provider.Channel{
+					"CGENERAL1": {ID: "CGENERAL1", Name: "#general"},
+					"COTHER001": {ID: "COTHER001", Name: "#other"},
+				},
+				ChannelsInv: map[string]string{"#general": "CGENERAL1", "#other": "COTHER001"},
+			},
+		},
+		logger: zap.NewNop(),
+	}
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"search_query":      "launch in:general",
+		"filter_in_channel": "COTHER001",
+	}
+
+	params, err := handler.parseParamsToolSearch(context.Background(), request)
+	require.Error(t, err)
+	assert.Nil(t, params)
+	assert.Contains(t, err.Error(), "conflicting channel filters")
+}
+
+func TestUnitParseParamsToolSearchResolvesRawStableAuthorModifier(t *testing.T) {
+	handler := &ConversationsHandler{
+		apiProvider: &fakeConversationsProvider{
+			slackClient: &fakeAssistantSlack{},
+			users:       &provider.UsersCache{Users: map[string]slack.User{}, UsersInv: map[string]string{}},
+			channels:    &provider.ChannelsCache{Channels: map[string]provider.Channel{}, ChannelsInv: map[string]string{}},
+		},
+		logger: zap.NewNop(),
+	}
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{"search_query": "launch from:UDELETED123"}
+
+	params, err := handler.parseParamsToolSearch(context.Background(), request)
+	require.NoError(t, err)
+	assert.Equal(t, "launch from:<@UDELETED123>", params.query)
+	require.NotNil(t, params.authorFilter)
+	assert.Equal(t, "UDELETED123", params.authorFilter.UserID)
+}
+
+func TestUnitParseParamsToolSearchAllowsFilterOnlyQuery(t *testing.T) {
+	handler := &ConversationsHandler{logger: zap.NewNop()}
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"filter_threads_only": true,
+	}
+
+	params, err := handler.parseParamsToolSearch(context.Background(), request)
+	require.NoError(t, err)
+	assert.Equal(t, "is:thread", params.query)
+}
+
+func TestUnitParseParamsToolSearchRejectsUnverifiableWithFilters(t *testing.T) {
+	handler := &ConversationsHandler{logger: zap.NewNop()}
+
+	for _, arguments := range []map[string]any{
+		{"search_query": "launch with:UOTHER123"},
+		{"search_query": "launch", "filter_users_with": "UOTHER123"},
+	} {
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = arguments
+		params, err := handler.parseParamsToolSearch(context.Background(), request)
+		require.Error(t, err)
+		assert.Nil(t, params)
+		assert.Contains(t, err.Error(), "unsupported")
+		assert.Contains(t, err.Error(), "with")
+	}
+}
+
+func TestUnitParseParamsToolSearchValidatesIntegerLimitBoundaries(t *testing.T) {
+	handler := &ConversationsHandler{logger: zap.NewNop()}
+
+	for _, limit := range []int{1, 100} {
+		t.Run(fmt.Sprintf("accepts %d", limit), func(t *testing.T) {
+			request := mcp.CallToolRequest{}
+			request.Params.Arguments = map[string]any{"search_query": "launch", "limit": limit}
+			params, err := handler.parseParamsToolSearch(context.Background(), request)
+			require.NoError(t, err)
+			assert.Equal(t, limit, params.limit)
+		})
+	}
+
+	for _, limit := range []any{0, 101, 1.5} {
+		t.Run(fmt.Sprintf("rejects %v", limit), func(t *testing.T) {
+			request := mcp.CallToolRequest{}
+			request.Params.Arguments = map[string]any{"search_query": "launch", "limit": limit}
+			_, err := handler.parseParamsToolSearch(context.Background(), request)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "limit")
+		})
+	}
+}
+
+func TestUnitSearchChannelTypesForCachedChannel(t *testing.T) {
+	tests := []struct {
+		name    string
+		channel provider.Channel
+		want    []string
+	}{
+		{
+			name:    "MPIM takes precedence over private",
+			channel: provider.Channel{IsMpIM: true, IsPrivate: true},
+			want:    []string{"mpim"},
+		},
+		{
+			name:    "private channel",
+			channel: provider.Channel{IsPrivate: true},
+			want:    []string{"private_channel"},
+		},
+		{
+			name:    "public channel",
+			channel: provider.Channel{},
+			want:    []string{"public_channel"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, searchChannelTypesForCachedChannel(tt.channel))
+		})
+	}
+}
+
+func TestUnitParseSearchRejectsMPIMViaChannelFilter(t *testing.T) {
+	fakeProvider := &fakeConversationsProvider{
+		slackClient: &fakeAssistantSlack{},
+		users:       &provider.UsersCache{Users: map[string]slack.User{}, UsersInv: map[string]string{}},
+		channels: &provider.ChannelsCache{
+			Channels: map[string]provider.Channel{
+				"GMPIM123": {ID: "GMPIM123", Name: "@mpdm-alice-bob-1", IsMpIM: true, IsPrivate: true},
+			},
+			ChannelsInv: map[string]string{"@mpdm-alice-bob-1": "GMPIM123"},
+		},
+	}
+	handler := &ConversationsHandler{apiProvider: fakeProvider, logger: zap.NewNop()}
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"search_query":      "launch",
+		"filter_in_channel": "GMPIM123",
+	}
+
+	_, err := handler.parseParamsToolSearch(context.Background(), request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "filter_in_im_or_mpim")
+}
+
+func TestUnitResolveCachedMPIM(t *testing.T) {
+	channels := &provider.ChannelsCache{
+		Channels: map[string]provider.Channel{
+			"GMPIM123": {ID: "GMPIM123", Name: "@mpdm-alice-bob-1", IsMpIM: true, IsPrivate: true},
+			"DUSER123": {ID: "DUSER123", Name: "@alice_dm", IsIM: true, IsPrivate: true},
+			"GPRIVATE": {ID: "GPRIVATE", Name: "#private", IsPrivate: true},
+		},
+		ChannelsInv: map[string]string{
+			"@mpdm-alice-bob-1": "GMPIM123",
+			"@alice_dm":         "DUSER123",
+			"#private":          "GPRIVATE",
+		},
+	}
+
+	for _, input := range []string{"GMPIM123", "@mpdm-alice-bob-1"} {
+		t.Run("accepts "+input, func(t *testing.T) {
+			channel, err := resolveCachedMPIM(input, channels)
+			require.NoError(t, err)
+			assert.Equal(t, "GMPIM123", channel.ID)
+		})
+	}
+
+	for _, input := range []string{"DUSER123", "@alice_dm"} {
+		t.Run("rejects one-to-one "+input, func(t *testing.T) {
+			_, err := resolveCachedMPIM(input, channels)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "one-to-one DM")
+			assert.Contains(t, err.Error(), "im:read")
+		})
+	}
+
+	_, err := resolveCachedMPIM("GPRIVATE", channels)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not an MPIM")
+}
+
+func TestUnitSearchHistoricalAuthorPagesPaginatesToExactMatch(t *testing.T) {
+	var cursors []string
+	filter, err := searchHistoricalAuthorPages(
+		context.Background(),
+		"Former Engineer",
+		func(_ context.Context, cursor string) (json.RawMessage, error) {
+			cursors = append(cursors, cursor)
+			if cursor == "" {
+				return json.RawMessage(`{
+					"ok": true,
+					"results": {"users": [{"user_id": "UFUZZY123", "full_name": "Former Engineering Manager"}]},
+					"response_metadata": {"next_cursor": "page-two"}
+				}`), nil
+			}
+			return json.RawMessage(`{
+				"ok": true,
+				"results": {"users": [{"user_id": "UEXACT123", "full_name": "Former Engineer"}]},
+				"response_metadata": {"next_cursor": ""}
+			}`), nil
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, filter)
+	assert.Equal(t, "UEXACT123", filter.UserID)
+	assert.Equal(t, []string{"", "page-two"}, cursors)
+}
+
+func TestUnitSearchHistoricalAuthorPagesFailsClosed(t *testing.T) {
+	t.Run("API errors propagate", func(t *testing.T) {
+		sentinel := errors.New("network down")
+		_, err := searchHistoricalAuthorPages(
+			context.Background(),
+			"Former Engineer",
+			func(context.Context, string) (json.RawMessage, error) {
+				return nil, sentinel
+			},
+		)
+		require.ErrorIs(t, err, sentinel)
+	})
+
+	t.Run("no exact result is user not found", func(t *testing.T) {
+		_, err := searchHistoricalAuthorPages(
+			context.Background(),
+			"Former Engineer",
+			func(context.Context, string) (json.RawMessage, error) {
+				return json.RawMessage(`{
+					"ok": true,
+					"results": {"users": [{"user_id": "UFUZZY123", "full_name": "Former Engineering Manager"}]},
+					"response_metadata": {"next_cursor": ""}
+				}`), nil
+			},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `user "Former Engineer" not found`)
+	})
+
+	t.Run("pagination has a ten page safety bound", func(t *testing.T) {
+		calls := 0
+		_, err := searchHistoricalAuthorPages(
+			context.Background(),
+			"Former Engineer",
+			func(context.Context, string) (json.RawMessage, error) {
+				calls++
+				return json.RawMessage(fmt.Sprintf(`{
+					"ok": true,
+					"results": {"users": []},
+					"response_metadata": {"next_cursor": "page-%d"}
+				}`, calls+1)), nil
+			},
+		)
+		require.Error(t, err)
+		assert.Equal(t, 10, calls)
+		assert.Contains(t, err.Error(), "pagination truncated")
+	})
+
+	t.Run("repeated cursor is explicit", func(t *testing.T) {
+		calls := 0
+		_, err := searchHistoricalAuthorPages(
+			context.Background(),
+			"Former Engineer",
+			func(context.Context, string) (json.RawMessage, error) {
+				calls++
+				return json.RawMessage(`{
+					"ok": true,
+					"results": {"users": []},
+					"response_metadata": {"next_cursor": "same-page"}
+				}`), nil
+			},
+		)
+		require.Error(t, err)
+		assert.Equal(t, 2, calls)
+		assert.Contains(t, err.Error(), "repeated cursor")
+	})
+}
+
+func TestUnitSearchHistoricalAuthorPagesRejectsAmbiguousAndInvalidMatches(t *testing.T) {
+	t.Run("exhausts pages before reporting ambiguity", func(t *testing.T) {
+		filter, err := searchHistoricalAuthorPages(
+			context.Background(),
+			"Former Engineer",
+			func(_ context.Context, cursor string) (json.RawMessage, error) {
+				if cursor == "" {
+					return json.RawMessage(`{
+						"ok": true,
+						"results": {"users": [{"user_id": "UONE12345", "full_name": "Former Engineer"}]},
+						"response_metadata": {"next_cursor": "page-two"}
+					}`), nil
+				}
+				return json.RawMessage(`{
+					"ok": true,
+					"results": {"users": [{"user_id": "UTWO45678", "full_name": "former engineer"}]},
+					"response_metadata": {"next_cursor": ""}
+				}`), nil
+			},
+		)
+		assert.Nil(t, filter)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ambiguous")
+	})
+
+	t.Run("matching candidate requires a stable user ID", func(t *testing.T) {
+		_, err := searchHistoricalAuthorPages(
+			context.Background(),
+			"Former Engineer",
+			func(context.Context, string) (json.RawMessage, error) {
+				return json.RawMessage(`{
+					"ok": true,
+					"results": {"users": [{"user_id": "", "full_name": "Former Engineer"}]},
+					"response_metadata": {"next_cursor": ""}
+				}`), nil
+			},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "stable user ID")
+	})
+
+	t.Run("stable ID outranks lower-priority name match", func(t *testing.T) {
+		filter, err := searchHistoricalAuthorPages(
+			context.Background(),
+			"UWINNER123",
+			func(context.Context, string) (json.RawMessage, error) {
+				return json.RawMessage(`{
+					"ok": true,
+					"results": {"users": [
+						{"user_id": "ULOWER456", "full_name": "UWINNER123"},
+						{"user_id": "UWINNER123", "full_name": "Someone Else"}
+					]},
+					"response_metadata": {"next_cursor": ""}
+				}`), nil
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, filter)
+		assert.Equal(t, "UWINNER123", filter.UserID)
+	})
+}
+
+type fakeAssistantSlack struct {
+	provider.SlackAPI
+	pages    map[string]json.RawMessage
+	requests []provider.AssistantSearchContextRequest
+}
+
+func (f *fakeAssistantSlack) AssistantSearchContext(_ context.Context, request provider.AssistantSearchContextRequest) (json.RawMessage, error) {
+	f.requests = append(f.requests, request)
+	page, ok := f.pages[request.Cursor]
+	if !ok {
+		return nil, fmt.Errorf("unexpected cursor %q", request.Cursor)
+	}
+	return page, nil
+}
+
+type boundedAssistantSlack struct {
+	provider.SlackAPI
+	requests []provider.AssistantSearchContextRequest
+}
+
+func (f *boundedAssistantSlack) AssistantSearchContext(_ context.Context, request provider.AssistantSearchContextRequest) (json.RawMessage, error) {
+	f.requests = append(f.requests, request)
+	nextCursor := ""
+	if len(f.requests) <= 10 {
+		nextCursor = fmt.Sprintf("unique-page-%d", len(f.requests)+1)
+	}
+	return json.RawMessage(fmt.Sprintf(`{
+		"ok": true,
+		"results": {"messages": []},
+		"response_metadata": {"next_cursor": %q}
+	}`, nextCursor)), nil
+}
+
+type fakeConversationsProvider struct {
+	slackClient provider.SlackAPI
+	users       *provider.UsersCache
+	channels    *provider.ChannelsCache
+}
+
+func (f *fakeConversationsProvider) ServerTransport() string  { return "stdio" }
+func (f *fakeConversationsProvider) IsReady() (bool, error)   { return true, nil }
+func (f *fakeConversationsProvider) Slack() provider.SlackAPI { return f.slackClient }
+func (f *fakeConversationsProvider) ProvideUsersMap() *provider.UsersCache {
+	return f.users
+}
+func (f *fakeConversationsProvider) ProvideChannelsMaps() *provider.ChannelsCache {
+	return f.channels
+}
+func (f *fakeConversationsProvider) SearchUsers(context.Context, string, int) ([]slack.User, error) {
+	return nil, nil
+}
+func (f *fakeConversationsProvider) IsBotToken() bool { return false }
+func (f *fakeConversationsProvider) IsOAuth() bool    { return true }
+func (f *fakeConversationsProvider) ForceRefreshChannels(context.Context) error {
+	return nil
+}
+func (f *fakeConversationsProvider) PatchUser(context.Context, string) (*slack.User, error) {
+	return nil, errors.New("not found")
+}
+
+func TestUnitConversationsSearchHandlerAggregatesNormalizedCSV(t *testing.T) {
+	api := &fakeAssistantSlack{pages: map[string]json.RawMessage{
+		"start": json.RawMessage(`{
+			"ok": true,
+			"results": {"messages": [
+				{"author_email":"other@example.com","author_name":"Other Person","author_user_id":"UOTHER123","channel_id":"CSEARCH123","channel_name":"search","content":"ignore me","message_ts":"1760000000.000001","permalink":"https://example.slack.com/archives/CSEARCH123/p1760000000000001","team_id":"T123","secret":"must-not-leak"},
+				{"author_email":"former@example.com","author_name":"Former Engineer","author_user_id":"UAUTHOR123","channel_id":"COTHER123","channel_name":"other","content":"wrong channel","message_ts":"1760000000.500001","permalink":"https://example.slack.com/archives/COTHER123/p1760000000500001","team_id":"T123","secret":"must-not-leak"},
+				{"author_email":"former@example.com","author_name":"Former Engineer","author_user_id":"UAUTHOR123","channel_id":"CSEARCH123","channel_name":"search","content":"first <https://example.com|docs>","message_ts":"1760000001.000002","permalink":"https://example.slack.com/archives/CSEARCH123/p1760000001000002?thread_ts=1759999999.000001","team_id":"T123","secret":"must-not-leak"},
+				{"author_email":"former@example.com","author_name":"Former Engineer","author_user_id":"UAUTHOR123","channel_id":"CSEARCH123","channel_name":"search","content":"second","is_author_bot":true,"message_ts":"1760000002.000003","permalink":"https://example.slack.com/archives/CSEARCH123/p1760000002000003","team_id":"T123","secret":"must-not-leak"}
+			]},
+			"response_metadata": {"next_cursor": "page-two"}
+		}`),
+		"page-two": json.RawMessage(`{
+			"ok": true,
+			"results": {"messages": [
+				{"author_email":"former@example.com","author_name":"Former Engineer","author_user_id":"UAUTHOR123","channel_id":"CSEARCH123","channel_name":"search","content":"third","message_ts":"1760000003.000004","permalink":"https://example.slack.com/archives/CSEARCH123/p1760000003000004","team_id":"T123","secret":"must-not-leak"}
+			]},
+			"response_metadata": {"next_cursor": "page-three"}
+		}`),
+	}}
+	fakeProvider := &fakeConversationsProvider{
+		slackClient: api,
+		users: &provider.UsersCache{
+			Users: map[string]slack.User{
+				"UAUTHOR123": {ID: "UAUTHOR123", Name: "former.engineer"},
+			},
+			UsersInv: map[string]string{"former.engineer": "UAUTHOR123"},
+		},
+		channels: &provider.ChannelsCache{
+			Channels: map[string]provider.Channel{
+				"CSEARCH123": {ID: "CSEARCH123", Name: "#search", IsPrivate: true},
+			},
+			ChannelsInv: map[string]string{"#search": "CSEARCH123"},
+		},
+	}
+	handler := &ConversationsHandler{apiProvider: fakeProvider, logger: zap.NewNop()}
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"search_query":        "launch plan after:2026-01-01",
+		"filter_threads_only": true,
+		"filter_in_channel":   "CSEARCH123",
+		"filter_users_from":   "UAUTHOR123",
+		"cursor":              "start",
+		"limit":               3,
+	}
+
+	result, err := handler.ConversationsSearchHandler(context.Background(), request)
+	require.NoError(t, err)
+	require.Len(t, api.requests, 2)
+	assert.Equal(t, "launch plan is:thread in:#search from:<@UAUTHOR123> after:2026-01-01", api.requests[0].Query)
+	assert.Equal(t, []string{"private_channel"}, api.requests[0].ChannelTypes)
+	assert.Equal(t, []string{"messages"}, api.requests[0].ContentTypes)
+	assert.Equal(t, "CSEARCH123", api.requests[0].ContextChannelID)
+	assert.Equal(t, "start", api.requests[0].Cursor)
+	assert.Equal(t, 3, api.requests[0].Limit)
+	assert.True(t, api.requests[0].IncludeContextMessages)
+	assert.True(t, api.requests[0].DisableSemanticSearch)
+	assert.Equal(t, "page-two", api.requests[1].Cursor)
+	assert.Equal(t, 1, api.requests[1].Limit)
+
+	require.Len(t, result.Content, 1)
+	content, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.NotContains(t, content.Text, "must-not-leak")
+	assert.NotContains(t, content.Text, "author_email")
+
+	rows, err := csv.NewReader(strings.NewReader(content.Text)).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 4)
+	columns := make(map[string]int, len(rows[0]))
+	for i, name := range rows[0] {
+		columns[name] = i
+	}
+	for _, requiredColumn := range []string{"MsgID", "UserID", "UserName", "RealName", "Channel", "ThreadTs", "Text", "Time", "Permalink", "BotName", "Cursor"} {
+		_, exists := columns[requiredColumn]
+		assert.Truef(t, exists, "missing normalized Message column %s", requiredColumn)
+	}
+	assert.Equal(t, "1760000001.000002", rows[1][columns["MsgID"]])
+	assert.Equal(t, "UAUTHOR123", rows[1][columns["UserID"]])
+	assert.Equal(t, "former.engineer", rows[1][columns["UserName"]])
+	assert.Equal(t, "Former Engineer", rows[1][columns["RealName"]])
+	assert.Equal(t, "CSEARCH123 (#search)", rows[1][columns["Channel"]])
+	assert.Equal(t, "1759999999.000001", rows[1][columns["ThreadTs"]])
+	assert.Equal(t, text.ProcessText("first <https://example.com|docs>"), rows[1][columns["Text"]])
+	wantTime, err := text.TimestampToIsoRFC3339("1760000001.000002")
+	require.NoError(t, err)
+	assert.Equal(t, wantTime, rows[1][columns["Time"]])
+	assert.Empty(t, rows[1][columns["Cursor"]])
+	assert.Equal(t, "Former Engineer", rows[2][columns["BotName"]])
+	assert.Empty(t, rows[2][columns["Cursor"]])
+	assert.Equal(t, "page-three", rows[3][columns["Cursor"]])
+}
+
+func TestUnitConversationsSearchHandlerRejectsRepeatedCursor(t *testing.T) {
+	api := &fakeAssistantSlack{pages: map[string]json.RawMessage{
+		"start": json.RawMessage(`{
+			"ok": true,
+			"results": {"messages": []},
+			"response_metadata": {"next_cursor": "start"}
+		}`),
+	}}
+	handler := &ConversationsHandler{
+		apiProvider: &fakeConversationsProvider{
+			slackClient: api,
+			users:       &provider.UsersCache{Users: map[string]slack.User{}, UsersInv: map[string]string{}},
+			channels:    &provider.ChannelsCache{Channels: map[string]provider.Channel{}, ChannelsInv: map[string]string{}},
+		},
+		logger: zap.NewNop(),
+	}
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{"search_query": "launch", "cursor": "start", "limit": 1}
+
+	_, err := handler.ConversationsSearchHandler(context.Background(), request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repeated cursor")
+}
+
+func TestUnitConversationsSearchHandlerRejectsRepeatedCursorEvenWhenPageFillsLimit(t *testing.T) {
+	api := &fakeAssistantSlack{pages: map[string]json.RawMessage{
+		"start": json.RawMessage(`{
+			"ok": true,
+			"results": {"messages": [
+				{"author_name":"Engineer","author_user_id":"UAUTHOR123","channel_id":"CSEARCH123","channel_name":"search","content":"match","message_ts":"1760000001.000002","permalink":"https://example.slack.com/archives/CSEARCH123/p1760000001000002"}
+			]},
+			"response_metadata": {"next_cursor": "start"}
+		}`),
+	}}
+	handler := &ConversationsHandler{
+		apiProvider: &fakeConversationsProvider{
+			slackClient: api,
+			users:       &provider.UsersCache{Users: map[string]slack.User{}, UsersInv: map[string]string{}},
+			channels:    &provider.ChannelsCache{Channels: map[string]provider.Channel{}, ChannelsInv: map[string]string{}},
+		},
+		logger: zap.NewNop(),
+	}
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{"search_query": "launch", "cursor": "start", "limit": 1}
+
+	_, err := handler.ConversationsSearchHandler(context.Background(), request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repeated cursor")
+}
+
+func TestUnitDecodeAssistantSearchMessagePageRejectsMalformedSuccess(t *testing.T) {
+	for _, raw := range []json.RawMessage{
+		json.RawMessage(`{"ok":true}`),
+		json.RawMessage(`{"ok":true,"results":{}}`),
+		json.RawMessage(`{"ok":true,"results":{"files":[]}}`),
+		json.RawMessage(`{"ok":true,"results":{"messages":null}}`),
+	} {
+		page, err := decodeAssistantSearchMessagePage(raw)
+		require.Error(t, err)
+		assert.Empty(t, page.Messages)
+		assert.Contains(t, err.Error(), "messages")
+	}
+}
+
+func TestUnitConversationsSearchHandlerFailsExplicitlyAtPageBound(t *testing.T) {
+	api := &boundedAssistantSlack{}
+	handler := &ConversationsHandler{
+		apiProvider: &fakeConversationsProvider{
+			slackClient: api,
+			users:       &provider.UsersCache{Users: map[string]slack.User{}, UsersInv: map[string]string{}},
+			channels:    &provider.ChannelsCache{Channels: map[string]provider.Channel{}, ChannelsInv: map[string]string{}},
+		},
+		logger: zap.NewNop(),
+	}
+	request := mcp.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"search_query": "launch from:UDELETED123",
+		"limit":        1,
+	}
+
+	_, err := handler.ConversationsSearchHandler(context.Background(), request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pagination truncated")
+	assert.Len(t, api.requests, 10)
+}
+
+func TestUnitConvertAssistantSearchUsesAuthorNameWhenUserLookupFails(t *testing.T) {
+	handler := &ConversationsHandler{
+		apiProvider: &fakeConversationsProvider{
+			slackClient: &fakeAssistantSlack{},
+			users:       &provider.UsersCache{Users: map[string]slack.User{}, UsersInv: map[string]string{}},
+			channels:    &provider.ChannelsCache{Channels: map[string]provider.Channel{}, ChannelsInv: map[string]string{}},
+		},
+		logger: zap.NewNop(),
+	}
+	messages := handler.convertMessagesFromAssistantSearch(context.Background(), []assistantSearchMessage{{
+		AuthorName: "Former Engineer", AuthorUserID: "UDELETED123", ChannelID: "C1",
+		Content: "historical", MessageTS: "1760000001.000002",
+	}})
+
+	require.Len(t, messages, 1)
+	assert.Equal(t, "UDELETED123", messages[0].UserName)
+	assert.Equal(t, "Former Engineer", messages[0].RealName)
+}
+
+func TestUnitValidateAssistantSearchToken(t *testing.T) {
+	require.NoError(t, validateAssistantSearchToken(true, false))
+
+	err := validateAssistantSearchToken(true, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user token")
+	assert.Contains(t, err.Error(), "action_token")
+
+	err = validateAssistantSearchToken(false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "User OAuth token")
+	assert.Contains(t, err.Error(), "browser session tokens")
 }

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -1,11 +1,13 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -31,6 +33,12 @@ const defaultCacheTTL = 24 * time.Hour
 const defaultMinRefreshInterval = 30 * time.Second
 
 var AllChanTypes = []string{"mpim", "im", "public_channel", "private_channel"}
+
+// StartupChanTypes excludes direct messages. Some Slack Enterprise workspaces
+// do not offer im:read to user-token apps, although other conversation scopes
+// are available. Bootstrap the cache only with conversation types the local
+// app can enumerate; direct-message operations remain scope-gated at use time.
+var StartupChanTypes = []string{"mpim", "public_channel", "private_channel"}
 var PrivateChanType = "private_channel"
 var PubChanType = "public_channel"
 
@@ -226,6 +234,7 @@ type SlackAPI interface {
 	GetConversationHistoryContext(ctx context.Context, params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
 	GetConversationRepliesContext(ctx context.Context, params *slack.GetConversationRepliesParameters) (msgs []slack.Message, hasMore bool, nextCursor string, err error)
 	SearchContext(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchMessages, *slack.SearchFiles, error)
+	AssistantSearchContext(ctx context.Context, params AssistantSearchContextRequest) (json.RawMessage, error)
 
 	// Used to get files
 	GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*slack.File, []slack.Comment, *slack.Paging, error)
@@ -262,6 +271,7 @@ type SlackAPI interface {
 type MCPSlackClient struct {
 	slackClient *slack.Client
 	edgeClient  *edge.Client
+	httpClient  *http.Client
 
 	authResponse *slack.AuthTestResponse
 	authProvider auth.Provider
@@ -350,6 +360,7 @@ func NewMCPSlackClient(authProvider auth.Provider, logger *zap.Logger) (*MCPSlac
 	return &MCPSlackClient{
 		slackClient:  slackClient,
 		edgeClient:   edgeClient,
+		httpClient:   httpClient,
 		authResponse: authResponse,
 		authProvider: authProvider,
 		isEnterprise: isEnterprise,
@@ -527,6 +538,60 @@ func (c *MCPSlackClient) GetConversationRepliesContext(ctx context.Context, para
 
 func (c *MCPSlackClient) SearchContext(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchMessages, *slack.SearchFiles, error) {
 	return c.slackClient.SearchContext(ctx, query, params)
+}
+
+// AssistantSearchContextRequest is the supported Slack Real-time Search API
+// request for apps granted granular search:read.* scopes.
+type AssistantSearchContextRequest struct {
+	Query                  string   `json:"query"`
+	ChannelTypes           []string `json:"channel_types,omitempty"`
+	ContentTypes           []string `json:"content_types,omitempty"`
+	ContextChannelID       string   `json:"context_channel_id,omitempty"`
+	Cursor                 string   `json:"cursor,omitempty"`
+	Limit                  int      `json:"limit,omitempty"`
+	IncludeDeletedUsers    bool     `json:"include_deleted_users,omitempty"`
+	IncludeContextMessages bool     `json:"include_context_messages,omitempty"`
+	DisableSemanticSearch  bool     `json:"disable_semantic_search,omitempty"`
+}
+
+// AssistantSearchContext calls Slack's current AI search API directly. The
+// slack-go version pinned by v1.3.0 only implements legacy search.messages,
+// which requires the unavailable aggregate search:read scope.
+func (c *MCPSlackClient) AssistantSearchContext(ctx context.Context, params AssistantSearchContextRequest) (json.RawMessage, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal assistant search request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.teamEndpoint+"api/assistant.search.context", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create assistant search request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.authProvider.SlackToken())
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("assistant search request: %w", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 5<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read assistant search response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("assistant search HTTP %d", resp.StatusCode)
+	}
+	var envelope struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(responseBody, &envelope); err != nil {
+		return nil, fmt.Errorf("decode assistant search response: %w", err)
+	}
+	if !envelope.OK {
+		return nil, fmt.Errorf("assistant search failed: %s", envelope.Error)
+	}
+	return json.RawMessage(responseBody), nil
 }
 
 func (c *MCPSlackClient) PostMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error) {
@@ -1164,7 +1229,7 @@ func (ap *ApiProvider) fetchAndStoreChannels(ctx context.Context) error {
 	ap.fetchChannelsMu.Lock()
 	defer ap.fetchChannelsMu.Unlock()
 
-	channels := ap.GetChannels(ctx, AllChanTypes)
+	channels := ap.GetChannels(ctx, StartupChanTypes)
 
 	if len(channels) == 0 {
 		if ap.channelsReady.Load() {
@@ -1302,7 +1367,7 @@ func (ap *ApiProvider) GetChannels(ctx context.Context, channelTypes []string) [
 	// conversations.list API supports multiple types per request, and the edge
 	// API (Enterprise Grid + non-OAuth) returns all types regardless. This
 	// avoids making 4 separate API round-trips (one per type).
-	chans := ap.getChannelsMultiType(ctx, AllChanTypes)
+	chans := ap.getChannelsMultiType(ctx, channelTypes)
 
 	// Build new snapshot with all fetched channels
 	newSnapshot := &ChannelsCache{

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -34,11 +34,11 @@ const defaultMinRefreshInterval = 30 * time.Second
 
 var AllChanTypes = []string{"mpim", "im", "public_channel", "private_channel"}
 
-// StartupChanTypes excludes direct messages. Some Slack Enterprise workspaces
+// UserOAuthStartupChanTypes excludes direct messages. Some Slack Enterprise workspaces
 // do not offer im:read to user-token apps, although other conversation scopes
 // are available. Bootstrap the cache only with conversation types the local
 // app can enumerate; direct-message operations remain scope-gated at use time.
-var StartupChanTypes = []string{"mpim", "public_channel", "private_channel"}
+var UserOAuthStartupChanTypes = []string{"mpim", "public_channel", "private_channel"}
 var PrivateChanType = "private_channel"
 var PubChanType = "public_channel"
 
@@ -284,9 +284,11 @@ type MCPSlackClient struct {
 }
 
 type ApiProvider struct {
-	transport string
-	client    SlackAPI
-	logger    *zap.Logger
+	transport  string
+	client     SlackAPI
+	logger     *zap.Logger
+	isOAuth    bool
+	isBotToken bool
 
 	rateLimiter        *rate.Limiter
 	cacheTTL           time.Duration
@@ -554,6 +556,8 @@ type AssistantSearchContextRequest struct {
 	DisableSemanticSearch  bool     `json:"disable_semantic_search,omitempty"`
 }
 
+const maxAssistantSearchRetryAfter = 5 * time.Minute
+
 // AssistantSearchContext calls Slack's current AI search API directly. The
 // slack-go version pinned by v1.3.0 only implements legacy search.messages,
 // which requires the unavailable aggregate search:read scope.
@@ -569,7 +573,13 @@ func (c *MCPSlackClient) AssistantSearchContext(ctx context.Context, params Assi
 	req.Header.Set("Authorization", "Bearer "+c.authProvider.SlackToken())
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(req)
+	// Slack's search endpoint is credentialed and is not expected to redirect.
+	// Do not allow Authorization or auth cookies to cross a redirect boundary.
+	httpClient := *c.httpClient
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("assistant search request: %w", err)
 	}
@@ -578,8 +588,27 @@ func (c *MCPSlackClient) AssistantSearchContext(ctx context.Context, params Assi
 	if err != nil {
 		return nil, fmt.Errorf("read assistant search response: %w", err)
 	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := time.Second
+		if seconds, parseErr := strconv.ParseInt(strings.TrimSpace(resp.Header.Get("Retry-After")), 10, 64); parseErr == nil && seconds > 0 {
+			candidate := time.Duration(seconds) * time.Second
+			if candidate > 0 && int64(candidate/time.Second) == seconds && candidate <= maxAssistantSearchRetryAfter {
+				retryAfter = candidate
+			}
+		}
+		return nil, &slack.RateLimitedError{RetryAfter: retryAfter}
+	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("assistant search HTTP %d", resp.StatusCode)
+		status := safeHTTPStatus(resp.StatusCode)
+		var envelope struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(responseBody, &envelope) == nil {
+			if code := safeSlackErrorCode(envelope.Error); code != "" {
+				return nil, fmt.Errorf("assistant search HTTP %s: %s", status, code)
+			}
+		}
+		return nil, fmt.Errorf("assistant search HTTP %s", status)
 	}
 	var envelope struct {
 		OK    bool   `json:"ok"`
@@ -589,9 +618,30 @@ func (c *MCPSlackClient) AssistantSearchContext(ctx context.Context, params Assi
 		return nil, fmt.Errorf("decode assistant search response: %w", err)
 	}
 	if !envelope.OK {
-		return nil, fmt.Errorf("assistant search failed: %s", envelope.Error)
+		code := safeSlackErrorCode(envelope.Error)
+		if code == "" {
+			code = "unknown_error"
+		}
+		return nil, fmt.Errorf("assistant search failed: %s", code)
 	}
 	return json.RawMessage(responseBody), nil
+}
+
+var slackAPIErrorCodePattern = regexp.MustCompile(`^[a-z0-9_]+$`)
+
+func safeHTTPStatus(statusCode int) string {
+	if statusText := http.StatusText(statusCode); statusText != "" {
+		return fmt.Sprintf("%d %s", statusCode, statusText)
+	}
+	return strconv.Itoa(statusCode)
+}
+
+func safeSlackErrorCode(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) == 0 || len(value) > 128 || !slackAPIErrorCodePattern.MatchString(value) {
+		return ""
+	}
+	return value
 }
 
 func (c *MCPSlackClient) PostMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error) {
@@ -760,6 +810,7 @@ func newWithXOXP(transport string, authProvider auth.ValueAuth, logger *zap.Logg
 		client *MCPSlackClient
 		err    error
 	)
+	isBotToken := strings.HasPrefix(authProvider.SlackToken(), "xoxb-") || strings.HasPrefix(authProvider.SlackToken(), "xoxe.xoxb-")
 
 	teamID, err := validateAuthAndGetTeamID(authProvider, logger)
 	if err != nil {
@@ -773,7 +824,7 @@ func newWithXOXP(transport string, authProvider auth.ValueAuth, logger *zap.Logg
 
 	channelsCache := os.Getenv("SLACK_MCP_CHANNELS_CACHE")
 	if channelsCache == "" {
-		channelsCache = getCachePathWithTeamID(teamID, "channels_cache_v2.json")
+		channelsCache = getCachePathWithTeamID(teamID, oauthChannelsCacheFilename(isBotToken))
 	}
 
 	if os.Getenv("SLACK_MCP_XOXP_TOKEN") == "demo" || (os.Getenv("SLACK_MCP_XOXC_TOKEN") == "demo" && os.Getenv("SLACK_MCP_XOXD_TOKEN") == "demo") {
@@ -786,9 +837,11 @@ func newWithXOXP(transport string, authProvider auth.ValueAuth, logger *zap.Logg
 	}
 
 	ap := &ApiProvider{
-		transport: transport,
-		client:    client,
-		logger:    logger,
+		transport:  transport,
+		client:     client,
+		logger:     logger,
+		isOAuth:    true,
+		isBotToken: isBotToken,
 
 		rateLimiter:        limiter.Tier2.Limiter(),
 		cacheTTL:           getCacheTTL(),
@@ -813,6 +866,13 @@ func newWithXOXB(transport string, authProvider auth.ValueAuth, logger *zap.Logg
 	// Bot tokens do not support demo mode, but otherwise share the same
 	// initialization logic as user OAuth tokens.
 	return newWithXOXP(transport, authProvider, logger)
+}
+
+func oauthChannelsCacheFilename(isBotToken bool) string {
+	if isBotToken {
+		return "channels_cache_v2.json"
+	}
+	return "channels_cache_v2_user_oauth.json"
 }
 
 func newWithXOXC(transport string, authProvider auth.ValueAuth, logger *zap.Logger) *ApiProvider {
@@ -1147,6 +1207,13 @@ func (ap *ApiProvider) refreshChannelsInternal(ctx context.Context, force bool) 
 				ap.logger.Warn("Channels cache is empty or null, will refetch",
 					zap.String("cache_file", ap.channelsCachePath))
 			} else {
+				cachedChannels = filterChannelsByTypes(cachedChannels, ap.startupChannelTypes())
+				if len(cachedChannels) == 0 {
+					ap.logger.Warn("Channels cache has no supported startup channel types, will refetch",
+						zap.String("cache_file", ap.channelsCachePath))
+					ap.channelsMu.Unlock()
+					return ap.fetchAndStoreChannels(ctx)
+				}
 				// Re-map channels with current users cache to ensure DM names are populated
 				usersMap := ap.ProvideUsersMap().Users
 				newSnapshot := &ChannelsCache{
@@ -1229,7 +1296,7 @@ func (ap *ApiProvider) fetchAndStoreChannels(ctx context.Context) error {
 	ap.fetchChannelsMu.Lock()
 	defer ap.fetchChannelsMu.Unlock()
 
-	channels := ap.GetChannels(ctx, StartupChanTypes)
+	channels := ap.GetChannels(ctx, ap.startupChannelTypes())
 
 	if len(channels) == 0 {
 		if ap.channelsReady.Load() {
@@ -1358,6 +1425,30 @@ func (ap *ApiProvider) getChannelsMultiType(ctx context.Context, channelTypes []
 	return chans
 }
 
+func filterChannelsByTypes(channels []Channel, channelTypes []string) []Channel {
+	allowed := make(map[string]struct{}, len(channelTypes))
+	for _, channelType := range channelTypes {
+		allowed[channelType] = struct{}{}
+	}
+
+	filtered := make([]Channel, 0, len(channels))
+	for _, channel := range channels {
+		channelType := "public_channel"
+		switch {
+		case channel.IsIM:
+			channelType = "im"
+		case channel.IsMpIM:
+			channelType = "mpim"
+		case channel.IsPrivate:
+			channelType = "private_channel"
+		}
+		if _, ok := allowed[channelType]; ok {
+			filtered = append(filtered, channel)
+		}
+	}
+	return filtered
+}
+
 func (ap *ApiProvider) GetChannels(ctx context.Context, channelTypes []string) []Channel {
 	if len(channelTypes) == 0 {
 		channelTypes = AllChanTypes
@@ -1367,7 +1458,7 @@ func (ap *ApiProvider) GetChannels(ctx context.Context, channelTypes []string) [
 	// conversations.list API supports multiple types per request, and the edge
 	// API (Enterprise Grid + non-OAuth) returns all types regardless. This
 	// avoids making 4 separate API round-trips (one per type).
-	chans := ap.getChannelsMultiType(ctx, channelTypes)
+	chans := filterChannelsByTypes(ap.getChannelsMultiType(ctx, channelTypes), channelTypes)
 
 	// Build new snapshot with all fetched channels
 	newSnapshot := &ChannelsCache{
@@ -1380,26 +1471,7 @@ func (ap *ApiProvider) GetChannels(ctx context.Context, channelTypes []string) [
 	}
 	ap.channelsSnapshot.Store(newSnapshot)
 
-	// Filter by requested channel types
-	var res []Channel
-	for _, t := range channelTypes {
-		for _, channel := range newSnapshot.Channels {
-			if t == "public_channel" && !channel.IsPrivate && !channel.IsIM && !channel.IsMpIM {
-				res = append(res, channel)
-			}
-			if t == "private_channel" && channel.IsPrivate && !channel.IsIM && !channel.IsMpIM {
-				res = append(res, channel)
-			}
-			if t == "im" && channel.IsIM {
-				res = append(res, channel)
-			}
-			if t == "mpim" && channel.IsMpIM {
-				res = append(res, channel)
-			}
-		}
-	}
-
-	return res
+	return chans
 }
 
 func (ap *ApiProvider) ProvideUsersMap() *UsersCache {
@@ -1440,16 +1512,34 @@ func (ap *ApiProvider) Slack() SlackAPI {
 
 func (ap *ApiProvider) IsBotToken() bool {
 	client, ok := ap.client.(*MCPSlackClient)
-	return ok && client != nil && client.IsBotToken()
+	if ok && client != nil {
+		return client.IsBotToken()
+	}
+	return ap.isBotToken
 }
 
 func (ap *ApiProvider) IsOAuth() bool {
 	client, ok := ap.client.(*MCPSlackClient)
-	return ok && client != nil && client.IsOAuth()
+	if ok && client != nil {
+		return client.IsOAuth()
+	}
+	return ap.isOAuth
+}
+
+func (ap *ApiProvider) startupChannelTypes() []string {
+	if ap.IsOAuth() && !ap.IsBotToken() {
+		return UserOAuthStartupChanTypes
+	}
+	return AllChanTypes
 }
 
 // slackUserIDPattern matches Slack user IDs (e.g., U07VCEPP4N5, W0123456789).
-var slackUserIDPattern = regexp.MustCompile(`^[UW][A-Z0-9]{2,}$`)
+var slackUserIDPattern = regexp.MustCompile(`^[UW][A-Z0-9]+$`)
+
+// IsValidSlackUserID reports whether value has Slack's stable user-ID form.
+func IsValidSlackUserID(value string) bool {
+	return slackUserIDPattern.MatchString(value)
+}
 
 // SearchUsers searches for users by name, email, or display name.
 // If the query matches a Slack user ID pattern (e.g., U07VCEPP4N5), it looks up the user
@@ -1457,7 +1547,7 @@ var slackUserIDPattern = regexp.MustCompile(`^[UW][A-Z0-9]{2,}$`)
 // For OAuth tokens (xoxp/xoxb), it searches the local users cache using regex matching.
 // For browser tokens (xoxc/xoxd), it uses the edge API's UsersSearch method.
 func (ap *ApiProvider) SearchUsers(ctx context.Context, query string, limit int) ([]slack.User, error) {
-	if slackUserIDPattern.MatchString(query) {
+	if IsValidSlackUserID(query) {
 		users, err := ap.client.GetUsersInfo(query)
 		if err != nil {
 			return nil, err

--- a/pkg/provider/api_channels_test.go
+++ b/pkg/provider/api_channels_test.go
@@ -1,111 +1,156 @@
 package provider
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/korotovsky/slack-mcp-server/pkg/limiter"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
-// TestChannelTypeFiltering verifies the channel type classification logic used
-// in GetChannels to filter the snapshot by requested types.
-func TestChannelTypeFiltering(t *testing.T) {
-	channels := map[string]Channel{
-		"C1": {ID: "C1", Name: "#general", IsPrivate: false, IsIM: false, IsMpIM: false},
-		"C2": {ID: "C2", Name: "#secret", IsPrivate: true, IsIM: false, IsMpIM: false},
-		"D1": {ID: "D1", Name: "@alice", IsPrivate: true, IsIM: true, IsMpIM: false},
-		"G1": {ID: "G1", Name: "mpdm-a-b-c", IsPrivate: true, IsIM: false, IsMpIM: true},
+type channelListSlack struct {
+	SlackAPI
+	channels []slack.Channel
+}
+
+func (f *channelListSlack) GetConversationsContext(context.Context, *slack.GetConversationsParameters) ([]slack.Channel, string, error) {
+	return f.channels, "", nil
+}
+
+func TestUnitFilterChannelsByTypes(t *testing.T) {
+	channels := []Channel{
+		{ID: "C1", Name: "#general"},
+		{ID: "C2", Name: "#secret", IsPrivate: true},
+		{ID: "D1", Name: "@alice", IsPrivate: true, IsIM: true},
+		{ID: "G1", Name: "mpdm-a-b-c", IsPrivate: true, IsMpIM: true},
 	}
 
-	// This mirrors the filtering logic in GetChannels
-	filterByTypes := func(channels map[string]Channel, types []string) []Channel {
-		var res []Channel
-		for _, t := range types {
-			for _, ch := range channels {
-				switch {
-				case t == "public_channel" && !ch.IsPrivate && !ch.IsIM && !ch.IsMpIM:
-					res = append(res, ch)
-				case t == "private_channel" && ch.IsPrivate && !ch.IsIM && !ch.IsMpIM:
-					res = append(res, ch)
-				case t == "im" && ch.IsIM:
-					res = append(res, ch)
-				case t == "mpim" && ch.IsMpIM:
-					res = append(res, ch)
-				}
+	tests := []struct {
+		name  string
+		types []string
+		ids   []string
+	}{
+		{name: "public channel only", types: []string{"public_channel"}, ids: []string{"C1"}},
+		{name: "private channel only", types: []string{"private_channel"}, ids: []string{"C2"}},
+		{name: "IM only", types: []string{"im"}, ids: []string{"D1"}},
+		{name: "MPIM only", types: []string{"mpim"}, ids: []string{"G1"}},
+		{name: "all types", types: AllChanTypes, ids: []string{"C1", "C2", "D1", "G1"}},
+		{name: "user OAuth startup excludes only IM", types: UserOAuthStartupChanTypes, ids: []string{"C1", "C2", "G1"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := filterChannelsByTypes(channels, test.types)
+			ids := make([]string, 0, len(got))
+			for _, channel := range got {
+				ids = append(ids, channel.ID)
 			}
-		}
-		return res
+			assert.ElementsMatch(t, test.ids, ids)
+		})
 	}
-
-	t.Run("public_channel only", func(t *testing.T) {
-		res := filterByTypes(channels, []string{"public_channel"})
-		assert.Len(t, res, 1)
-		assert.Equal(t, "C1", res[0].ID)
-	})
-
-	t.Run("private_channel only", func(t *testing.T) {
-		res := filterByTypes(channels, []string{"private_channel"})
-		assert.Len(t, res, 1)
-		assert.Equal(t, "C2", res[0].ID)
-	})
-
-	t.Run("im only", func(t *testing.T) {
-		res := filterByTypes(channels, []string{"im"})
-		assert.Len(t, res, 1)
-		assert.Equal(t, "D1", res[0].ID)
-	})
-
-	t.Run("mpim only", func(t *testing.T) {
-		res := filterByTypes(channels, []string{"mpim"})
-		assert.Len(t, res, 1)
-		assert.Equal(t, "G1", res[0].ID)
-	})
-
-	t.Run("all types returns all channels", func(t *testing.T) {
-		res := filterByTypes(channels, AllChanTypes)
-		assert.Len(t, res, 4)
-	})
-
-	t.Run("multiple types", func(t *testing.T) {
-		res := filterByTypes(channels, []string{"public_channel", "im"})
-		assert.Len(t, res, 2)
-		ids := map[string]bool{}
-		for _, ch := range res {
-			ids[ch.ID] = true
-		}
-		assert.True(t, ids["C1"], "should include public channel")
-		assert.True(t, ids["D1"], "should include IM")
-	})
-
-	t.Run("im is not classified as private_channel", func(t *testing.T) {
-		// IMs have IsPrivate=true but should only match "im", not "private_channel"
-		res := filterByTypes(channels, []string{"private_channel"})
-		for _, ch := range res {
-			assert.False(t, ch.IsIM, "IMs should not appear in private_channel results")
-		}
-	})
-
-	t.Run("mpim is not classified as private_channel", func(t *testing.T) {
-		// MPIMs have IsPrivate=true but should only match "mpim", not "private_channel"
-		res := filterByTypes(channels, []string{"private_channel"})
-		for _, ch := range res {
-			assert.False(t, ch.IsMpIM, "MPIMs should not appear in private_channel results")
-		}
-	})
 }
 
-// TestAllChanTypesConstant verifies the expected channel types are defined.
-func TestAllChanTypesConstant(t *testing.T) {
-	assert.Len(t, AllChanTypes, 4, "should have 4 channel types")
-	assert.Contains(t, AllChanTypes, "public_channel")
-	assert.Contains(t, AllChanTypes, "private_channel")
-	assert.Contains(t, AllChanTypes, "im")
-	assert.Contains(t, AllChanTypes, "mpim")
+func TestUnitGetChannelsFiltersEnterpriseLikeExtraIMBeforeSnapshot(t *testing.T) {
+	client := &channelListSlack{channels: []slack.Channel{
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C1"}, Name: "general"}},
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C2", IsPrivate: true}, Name: "secret"}},
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "G1", IsPrivate: true, IsMpIM: true}, Name: "mpdm-a-b-c"}},
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "D1", IsPrivate: true, IsIM: true}}},
+	}}
+	ap := &ApiProvider{client: client, logger: zap.NewNop(), rateLimiter: limiter.Tier2.Limiter()}
+	ap.usersSnapshot.Store(&UsersCache{Users: map[string]slack.User{}, UsersInv: map[string]string{}})
+
+	got := ap.GetChannels(context.Background(), UserOAuthStartupChanTypes)
+	require.Len(t, got, 3)
+	for _, channel := range got {
+		assert.False(t, channel.IsIM)
+	}
+	snapshot := ap.ProvideChannelsMaps()
+	require.Len(t, snapshot.Channels, 3)
+	_, foundIM := snapshot.Channels["D1"]
+	assert.False(t, foundIM, "unsupported IM must not enter the startup snapshot")
 }
 
-func TestStartupChanTypesExcludeIM(t *testing.T) {
-	assert.Len(t, StartupChanTypes, 3)
-	assert.Contains(t, StartupChanTypes, "public_channel")
-	assert.Contains(t, StartupChanTypes, "private_channel")
-	assert.Contains(t, StartupChanTypes, "mpim")
-	assert.NotContains(t, StartupChanTypes, "im")
+func TestUnitRefreshChannelsDropsLegacyCachedIM(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "channels.json")
+	cached := []Channel{
+		{ID: "C1", Name: "#general"},
+		{ID: "C2", Name: "#secret", IsPrivate: true},
+		{ID: "G1", Name: "@mpdm-a-b-c", IsPrivate: true, IsMpIM: true},
+		{ID: "D1", Name: "@alice_dm", IsPrivate: true, IsIM: true, User: "U1"},
+	}
+	data, err := json.Marshal(cached)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(cachePath, data, 0o600))
+
+	ap := &ApiProvider{logger: zap.NewNop(), channelsCachePath: cachePath, cacheTTL: time.Hour, isOAuth: true}
+	ap.usersSnapshot.Store(&UsersCache{Users: map[string]slack.User{}, UsersInv: map[string]string{}})
+	require.NoError(t, ap.refreshChannelsInternal(context.Background(), false))
+
+	snapshot := ap.ProvideChannelsMaps()
+	require.Len(t, snapshot.Channels, 3)
+	_, foundIM := snapshot.Channels["D1"]
+	assert.False(t, foundIM, "legacy cached IM must be discarded before snapshot use")
+	assert.Contains(t, snapshot.Channels, "C1")
+	assert.Contains(t, snapshot.Channels, "C2")
+	assert.Contains(t, snapshot.Channels, "G1")
+}
+
+func TestUnitRefreshChannelsRetainsCachedIMForSessionAuth(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "channels.json")
+	cached := []Channel{
+		{ID: "C1", Name: "#general"},
+		{ID: "D1", Name: "@alice_dm", IsPrivate: true, IsIM: true, User: "U1"},
+	}
+	data, err := json.Marshal(cached)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(cachePath, data, 0o600))
+
+	ap := &ApiProvider{logger: zap.NewNop(), channelsCachePath: cachePath, cacheTTL: time.Hour}
+	ap.usersSnapshot.Store(&UsersCache{
+		Users:    map[string]slack.User{"U1": {ID: "U1", Name: "alice"}},
+		UsersInv: map[string]string{"alice": "U1"},
+	})
+	require.NoError(t, ap.refreshChannelsInternal(context.Background(), false))
+
+	snapshot := ap.ProvideChannelsMaps()
+	require.Len(t, snapshot.Channels, 2)
+	assert.Contains(t, snapshot.Channels, "D1", "session auth must preserve available direct messages")
+}
+
+func TestUnitStartupChannelTypesAreAuthSpecific(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  *ApiProvider
+		wantTypes []string
+	}{
+		{name: "user OAuth omits IM", provider: &ApiProvider{isOAuth: true}, wantTypes: UserOAuthStartupChanTypes},
+		{name: "bot OAuth preserves IM", provider: &ApiProvider{isOAuth: true, isBotToken: true}, wantTypes: AllChanTypes},
+		{name: "session auth preserves IM", provider: &ApiProvider{}, wantTypes: AllChanTypes},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.ElementsMatch(t, test.wantTypes, test.provider.startupChannelTypes())
+		})
+	}
+}
+
+func TestUnitOAuthChannelCacheFilenamesPreventUserCacheContamination(t *testing.T) {
+	assert.Equal(t, "channels_cache_v2_user_oauth.json", oauthChannelsCacheFilename(false))
+	assert.Equal(t, "channels_cache_v2.json", oauthChannelsCacheFilename(true))
+}
+
+func TestUnitAllChanTypesConstant(t *testing.T) {
+	assert.ElementsMatch(t, []string{"public_channel", "private_channel", "im", "mpim"}, AllChanTypes)
+}
+
+func TestUnitUserOAuthStartupChanTypesExcludeIM(t *testing.T) {
+	assert.ElementsMatch(t, []string{"public_channel", "private_channel", "mpim"}, UserOAuthStartupChanTypes)
+	assert.NotContains(t, UserOAuthStartupChanTypes, "im")
 }

--- a/pkg/provider/api_channels_test.go
+++ b/pkg/provider/api_channels_test.go
@@ -101,3 +101,11 @@ func TestAllChanTypesConstant(t *testing.T) {
 	assert.Contains(t, AllChanTypes, "im")
 	assert.Contains(t, AllChanTypes, "mpim")
 }
+
+func TestStartupChanTypesExcludeIM(t *testing.T) {
+	assert.Len(t, StartupChanTypes, 3)
+	assert.Contains(t, StartupChanTypes, "public_channel")
+	assert.Contains(t, StartupChanTypes, "private_channel")
+	assert.Contains(t, StartupChanTypes, "mpim")
+	assert.NotContains(t, StartupChanTypes, "im")
+}

--- a/pkg/provider/api_patch_test.go
+++ b/pkg/provider/api_patch_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -31,6 +32,12 @@ func newTestApiProvider(client SlackAPI, snapshot *UsersCache) *ApiProvider {
 	}
 	ap.usersSnapshot.Store(snapshot)
 	return ap
+}
+
+func TestUnitAssistantSearchContextRequestIncludesDeletedUsers(t *testing.T) {
+	body, err := json.Marshal(AssistantSearchContextRequest{IncludeDeletedUsers: true})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"query":"","include_deleted_users":true}`, string(body))
 }
 
 // TestUnitPatchUser verifies the targeted single-user cache patch behavior.

--- a/pkg/provider/api_patch_test.go
+++ b/pkg/provider/api_patch_test.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/rusq/slackdump/v3/auth"
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +31,12 @@ func (m *mockSlackClient) GetUsersInfo(users ...string) (*[]slack.User, error) {
 	return m.usersInfoResult, m.usersInfoErr
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func newTestApiProvider(client SlackAPI, snapshot *UsersCache) *ApiProvider {
 	ap := &ApiProvider{
 		client: client,
@@ -34,10 +46,209 @@ func newTestApiProvider(client SlackAPI, snapshot *UsersCache) *ApiProvider {
 	return ap
 }
 
-func TestUnitAssistantSearchContextRequestIncludesDeletedUsers(t *testing.T) {
-	body, err := json.Marshal(AssistantSearchContextRequest{IncludeDeletedUsers: true})
+func TestUnitAssistantSearchContextRequestSerializesSearchFields(t *testing.T) {
+	body, err := json.Marshal(AssistantSearchContextRequest{
+		Query:               "launch plan in:general from:<@U123ABC> after:2026-01-01",
+		Cursor:              "next-page",
+		IncludeDeletedUsers: true,
+	})
 	require.NoError(t, err)
-	assert.JSONEq(t, `{"query":"","include_deleted_users":true}`, string(body))
+	assert.JSONEq(t, `{
+		"query":"launch plan in:general from:<@U123ABC> after:2026-01-01",
+		"cursor":"next-page",
+		"include_deleted_users":true
+	}`, string(body))
+}
+
+func TestUnitAssistantSearchContextReturnsSlackRateLimitedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	authProvider, err := auth.NewValueAuth("xoxp-test", "")
+	require.NoError(t, err)
+	client := &MCPSlackClient{
+		httpClient:   server.Client(),
+		authProvider: authProvider,
+		teamEndpoint: server.URL + "/",
+	}
+
+	_, err = client.AssistantSearchContext(context.Background(), AssistantSearchContextRequest{Query: "test"})
+	require.Error(t, err)
+
+	var rateLimited *slack.RateLimitedError
+	require.ErrorAs(t, err, &rateLimited)
+	assert.Equal(t, 7*time.Second, rateLimited.RetryAfter)
+}
+
+func TestUnitAssistantSearchContextDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"results":{"messages":[]}}`))
+	}))
+	t.Cleanup(redirectTarget.Close)
+
+	redirectSource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL+"/capture", http.StatusFound)
+	}))
+	t.Cleanup(redirectSource.Close)
+
+	authProvider, err := auth.NewValueAuth("xoxp-test-token", "")
+	require.NoError(t, err)
+	client := &MCPSlackClient{
+		httpClient:   redirectSource.Client(),
+		authProvider: authProvider,
+		teamEndpoint: redirectSource.URL + "/",
+	}
+
+	_, err = client.AssistantSearchContext(context.Background(), AssistantSearchContextRequest{Query: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "302 Found")
+	assert.Zero(t, redirectedRequests.Load(), "assistant search must not follow redirects")
+}
+
+func TestUnitAssistantSearchContextSendsExpectedHTTPRequest(t *testing.T) {
+	type capturedRequest struct {
+		method      string
+		path        string
+		authorize   string
+		contentType string
+		body        []byte
+	}
+	captured := make(chan capturedRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured <- capturedRequest{
+			method:      r.Method,
+			path:        r.URL.Path,
+			authorize:   r.Header.Get("Authorization"),
+			contentType: r.Header.Get("Content-Type"),
+			body:        body,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"results":{"messages":[]}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	authProvider, err := auth.NewValueAuth("xoxp-test-token", "")
+	require.NoError(t, err)
+	client := &MCPSlackClient{httpClient: server.Client(), authProvider: authProvider, teamEndpoint: server.URL + "/"}
+	request := AssistantSearchContextRequest{
+		Query:                  "launch plan in:general from:<@U12345678>",
+		ChannelTypes:           []string{"public_channel", "private_channel"},
+		ContentTypes:           []string{"messages"},
+		ContextChannelID:       "C12345678",
+		Cursor:                 "next-page",
+		Limit:                  20,
+		IncludeDeletedUsers:    true,
+		IncludeContextMessages: true,
+		DisableSemanticSearch:  true,
+	}
+
+	_, err = client.AssistantSearchContext(context.Background(), request)
+	require.NoError(t, err)
+	got := <-captured
+	assert.Equal(t, http.MethodPost, got.method)
+	assert.Equal(t, "/api/assistant.search.context", got.path)
+	assert.Equal(t, "Bearer xoxp-test-token", got.authorize)
+	assert.Equal(t, "application/json", got.contentType)
+	wantBody, err := json.Marshal(request)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(wantBody), string(got.body))
+}
+
+func TestUnitAssistantSearchContextKeepsMalformedRateLimitsTyped(t *testing.T) {
+	for _, retryAfter := range []string{"", "nonsense", "-7", "0", "301", "9223372036", "9223372036854775807"} {
+		t.Run("Retry-After="+retryAfter, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Retry-After", retryAfter)
+				w.WriteHeader(http.StatusTooManyRequests)
+			}))
+			t.Cleanup(server.Close)
+			authProvider, err := auth.NewValueAuth("xoxp-test", "")
+			require.NoError(t, err)
+			client := &MCPSlackClient{httpClient: server.Client(), authProvider: authProvider, teamEndpoint: server.URL + "/"}
+
+			_, err = client.AssistantSearchContext(context.Background(), AssistantSearchContextRequest{Query: "test"})
+			require.Error(t, err)
+			var rateLimited *slack.RateLimitedError
+			require.ErrorAs(t, err, &rateLimited)
+			assert.Equal(t, time.Second, rateLimited.RetryAfter)
+		})
+	}
+}
+
+func TestUnitAssistantSearchContextSanitizesNonSuccessBody(t *testing.T) {
+	t.Run("extracts only a valid Slack error code", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"missing_scope","private_detail":"` + strings.Repeat("secret", 1000) + `"}`))
+		}))
+		t.Cleanup(server.Close)
+		authProvider, err := auth.NewValueAuth("xoxp-test", "")
+		require.NoError(t, err)
+		client := &MCPSlackClient{httpClient: server.Client(), authProvider: authProvider, teamEndpoint: server.URL + "/"}
+
+		_, err = client.AssistantSearchContext(context.Background(), AssistantSearchContextRequest{Query: "test"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing_scope")
+		assert.NotContains(t, err.Error(), "private_detail")
+		assert.NotContains(t, err.Error(), "secret")
+		assert.LessOrEqual(t, len(err.Error()), 256)
+	})
+
+	t.Run("does not echo non-JSON upstream content", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("upstream\nfailed\x00 " + strings.Repeat("x", 4000) + " secret-tail"))
+		}))
+		t.Cleanup(server.Close)
+		authProvider, err := auth.NewValueAuth("xoxp-test", "")
+		require.NoError(t, err)
+		client := &MCPSlackClient{httpClient: server.Client(), authProvider: authProvider, teamEndpoint: server.URL + "/"}
+
+		_, err = client.AssistantSearchContext(context.Background(), AssistantSearchContextRequest{Query: "test"})
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "upstream")
+		assert.NotContains(t, err.Error(), "secret-tail")
+		assert.LessOrEqual(t, len(err.Error()), 256)
+	})
+
+	t.Run("does not echo an upstream-controlled HTTP reason phrase", func(t *testing.T) {
+		secretStatus := "502 " + strings.Repeat("private-status-", 100)
+		httpClient := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadGateway,
+				Status:     secretStatus,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"ok":false}`)),
+			}, nil
+		})}
+		authProvider, err := auth.NewValueAuth("xoxp-test", "")
+		require.NoError(t, err)
+		client := &MCPSlackClient{httpClient: httpClient, authProvider: authProvider, teamEndpoint: "https://slack.invalid/"}
+
+		_, err = client.AssistantSearchContext(context.Background(), AssistantSearchContextRequest{Query: "test"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "502 Bad Gateway")
+		assert.NotContains(t, err.Error(), "private-status")
+		assert.LessOrEqual(t, len(err.Error()), 256)
+	})
+}
+
+func TestUnitDemoXOXPReportsUserOAuthWithoutLiveClient(t *testing.T) {
+	t.Setenv("SLACK_MCP_XOXP_TOKEN", "demo")
+	t.Setenv("SLACK_MCP_XOXB_TOKEN", "")
+	t.Setenv("SLACK_MCP_XOXC_TOKEN", "")
+	t.Setenv("SLACK_MCP_XOXD_TOKEN", "")
+
+	provider := New("stdio", zap.NewNop())
+	assert.True(t, provider.IsOAuth())
+	assert.False(t, provider.IsBotToken())
 }
 
 // TestUnitPatchUser verifies the targeted single-user cache patch behavior.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,6 +49,20 @@ const (
 	ToolSavedClearCompleted         = "saved_clear_completed"
 )
 
+func supportsAssistantSearch(isOAuth, isBotToken bool) bool {
+	return isOAuth && !isBotToken
+}
+
+func assistantSearchLimitOptions() []mcp.PropertyOption {
+	return []mcp.PropertyOption{
+		func(schema map[string]any) { schema["type"] = "integer" },
+		mcp.DefaultNumber(20),
+		mcp.Min(1),
+		mcp.Max(100),
+		mcp.Description("The maximum number of items to return. Must be an integer between 1 and 100."),
+	}
+}
+
 var ValidToolNames = []string{
 	ToolConversationsHistory,
 	ToolConversationsReplies,
@@ -252,20 +266,17 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 	}
 
 	conversationsSearchTool := mcp.NewTool(ToolConversationsSearchMessages,
-		mcp.WithDescription("Search messages in a public channel, private channel, or direct message (DM, or IM) conversation using filters. All filters are optional, if not provided then search_query is required."),
+		mcp.WithDescription("Search messages in public channels, private channels, or multi-person direct messages (MPIMs) using filters. All filters are optional; if none are provided, search_query is required."),
 		mcp.WithTitleAnnotation("Search Messages"),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("search_query",
-			mcp.Description("Search query to filter messages. Example: 'marketing report' or full URL of Slack message e.g. 'https://slack.com/archives/C1234567890/p1234567890123456', then the tool will return a single message matching given URL, herewith all other parameters will be ignored."),
+			mcp.Description("Free-text search query with optional Slack search modifiers such as 'in:#general' or 'from:@alice'. Structured filter parameters are combined with this query."),
 		),
 		mcp.WithString("filter_in_channel",
-			mcp.Description("Filter messages in a specific public/private channel by its ID or name. Example: 'C1234567890', 'G1234567890', or '#general'. If not provided, all channels will be searched."),
+			mcp.Description("Filter messages in a specific public or private channel by its ID or name. Example: 'C1234567890', 'G1234567890', or '#general'. Use filter_in_im_or_mpim for cached MPIMs. If not provided, all supported conversations will be searched."),
 		),
 		mcp.WithString("filter_in_im_or_mpim",
-			mcp.Description("Filter messages in a direct message (DM) or multi-person direct message (MPIM) conversation by its ID or name. Example: 'D1234567890' or '@username_dm'. If not provided, all DMs and MPIMs will be searched."),
-		),
-		mcp.WithString("filter_users_with",
-			mcp.Description("Filter messages with a specific user by their ID or display name in threads and DMs. Example: 'U1234567890' or '@username'. If not provided, all threads and DMs will be searched."),
+			mcp.Description("Filter messages in a cached multi-person direct message (MPIM) by its ID or name. One-to-one DM search is unavailable because search:read.im is not part of the documented search configuration."),
 		),
 		mcp.WithString("filter_users_from",
 			mcp.Description("Filter messages from a specific user by their ID or display name. Example: 'U1234567890' or '@username'. If not provided, all users will be searched."),
@@ -289,13 +300,11 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 			mcp.DefaultString(""),
 			mcp.Description("Cursor for pagination. Use the value of the last row and column in the response as next_cursor field returned from the previous request."),
 		),
-		mcp.WithNumber("limit",
-			mcp.DefaultNumber(20),
-			mcp.Description("The maximum number of items to return. Must be an integer between 1 and 100."),
-		),
+		mcp.WithNumber("limit", assistantSearchLimitOptions()...),
 	)
-	// Only register search tool for non-bot tokens (bot tokens cannot use search.messages API)
-	if !provider.IsBotToken() && shouldAddTool(ToolConversationsSearchMessages, enabledTools, "") {
+	// assistant.search.context requires an event action_token for bot tokens,
+	// which is unavailable to this stdio handler.
+	if supportsAssistantSearch(provider.IsOAuth(), provider.IsBotToken()) && shouldAddTool(ToolConversationsSearchMessages, enabledTools, "") {
 		s.AddTool(conversationsSearchTool, conversationsHandler.ConversationsSearchHandler)
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -43,6 +43,34 @@ func TestShouldAddTool_ReadOnly_EmptyEnabledTools(t *testing.T) {
 	})
 }
 
+func TestUnitSupportsAssistantSearch(t *testing.T) {
+	tests := []struct {
+		name       string
+		isOAuth    bool
+		isBotToken bool
+		want       bool
+	}{
+		{name: "user OAuth including rotating xoxp", isOAuth: true, isBotToken: false, want: true},
+		{name: "bot OAuth including rotating xoxb", isOAuth: true, isBotToken: true, want: false},
+		{name: "browser session token", isOAuth: false, isBotToken: false, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, supportsAssistantSearch(tt.isOAuth, tt.isBotToken))
+		})
+	}
+}
+
+func TestUnitAssistantSearchLimitSchema(t *testing.T) {
+	tool := mcp.NewTool("test", mcp.WithNumber("limit", assistantSearchLimitOptions()...))
+	property, ok := tool.InputSchema.Properties["limit"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "integer", property["type"])
+	assert.Equal(t, float64(1), property["minimum"])
+	assert.Equal(t, float64(100), property["maximum"])
+}
+
 func TestShouldAddTool_ReadOnly_ExplicitEnabledTools(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

- add `assistant.search.context` support for granular Slack User OAuth tokens
- register `conversations_search_messages` only for real User OAuth credentials
- support stable author/channel filtering and bounded pagination while failing closed on unsupported or malformed responses
- isolate User OAuth channel caches from bot/session caches and harden credentialed requests against redirects and unsafe retry behavior
- document the required Slack User Token Scopes and actual search limitations
- update the existing OpenAI-driven integration harness to `gpt-5.4-mini`

## Security and compatibility

- validates returned author and channel IDs locally rather than trusting query constraints as authorization
- rejects unsupported `with:` and `filter_users_with` participant filters
- does not follow redirects on credentialed assistant-search requests
- preserves existing bot OAuth and browser-session DM cache behavior
- keeps Slack page sizes at 20 while exposing MCP limits from 1–100

## Verification

- [x] `go test -mod=readonly ./... -run ".*Unit.*" -count=1`
- [x] `go test -mod=readonly -race ./... -run ".*Unit.*" -count=1`
- [x] `go vet -mod=readonly ./...`
- [x] `go mod tidy -diff` with `GOPROXY=off`
- [x] production Docker image built on Linux ARM64
- [x] native ARM64 and network-isolated container MCP stdio handshakes passed
- [x] direct live Slack User OAuth `assistant.search.context` probe passed without OpenAI or ngrok and returned zero message rows
- [x] independent final review passed with no findings

Credentialed repository integration tests requiring Slack, OpenAI, and ngrok secrets were not run as a suite. The Slack search path itself was exercised directly against the live Slack API.
