### PR TITLE
Add conversations_kick tool to remove a member from a channel

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -101,6 +101,16 @@ type addMessageParams struct {
 	blocks      []slack.Block
 }
 
+type deleteMessageParams struct {
+	channel   string
+	timestamp string
+}
+
+type openConversationParams struct {
+	users    []string
+	returnIM bool
+}
+
 type addReactionParams struct {
 	channel   string
 	timestamp string
@@ -282,6 +292,174 @@ func (ch *ConversationsHandler) ConversationsAddMessageHandler(ctx context.Conte
 		return mcp.NewToolResultText(fmt.Sprintf("Successfully posted message to channel %s in thread %s (ts=%s)", respChannel, params.threadTs, respTimestamp)), nil
 	}
 	return mcp.NewToolResultText(fmt.Sprintf("Successfully posted message to channel %s (ts=%s)", respChannel, respTimestamp)), nil
+}
+
+// ConversationsDeleteMessageHandler deletes a message and returns a confirmation
+func (ch *ConversationsHandler) ConversationsDeleteMessageHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsDeleteMessageHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	params, err := ch.parseParamsToolDeleteMessage(ctx, request)
+	if err != nil {
+		ch.logger.Error("Failed to parse delete-message params", zap.Error(err))
+		return nil, err
+	}
+
+	ch.logger.Debug("Deleting Slack message",
+		zap.String("channel", params.channel),
+		zap.String("timestamp", params.timestamp),
+	)
+	respChannel, respTimestamp, err := ch.apiProvider.Slack().DeleteMessageContext(ctx, params.channel, params.timestamp)
+	if err != nil {
+		ch.logger.Error("Slack DeleteMessageContext failed", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Successfully deleted message from channel %s (ts=%s)", respChannel, respTimestamp)), nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolDeleteMessage(ctx context.Context, request mcp.CallToolRequest) (*deleteMessageParams, error) {
+	toolConfig := os.Getenv("SLACK_MCP_DELETE_MESSAGE_TOOL")
+	enabledTools := os.Getenv("SLACK_MCP_ENABLED_TOOLS")
+
+	if toolConfig == "" {
+		if !strings.Contains(enabledTools, "conversations_delete_message") {
+			ch.logger.Error("Delete-message tool disabled by default")
+			return nil, errors.New(
+				"by default, the conversations_delete_message tool is disabled to guard Slack workspaces against accidental deletion. " +
+					"To enable it, set the SLACK_MCP_DELETE_MESSAGE_TOOL environment variable to true, 1, or comma separated list of channels, " +
+					"e.g. 'SLACK_MCP_DELETE_MESSAGE_TOOL=true' for all channels and DMs",
+			)
+		}
+		toolConfig = "true"
+	}
+
+	channel := request.GetString("channel_id", "")
+	if channel == "" {
+		ch.logger.Error("channel_id missing in delete-message params")
+		return nil, errors.New("channel_id must be a string")
+	}
+	channel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		ch.logger.Error("Channel not found", zap.String("channel", channel), zap.Error(err))
+		return nil, err
+	}
+	if !isChannelAllowedForConfig(channel, toolConfig) {
+		ch.logger.Warn("Delete-message tool not allowed for channel", zap.String("channel", channel), zap.String("policy", toolConfig))
+		return nil, fmt.Errorf("conversations_delete_message tool is not allowed for channel %q, applied policy: %s", channel, toolConfig)
+	}
+
+	timestamp := request.GetString("timestamp", "")
+	if timestamp == "" {
+		ch.logger.Error("timestamp missing in delete-message params")
+		return nil, errors.New("timestamp must be a string")
+	}
+	if !strings.Contains(timestamp, ".") {
+		ch.logger.Error("Invalid timestamp format", zap.String("timestamp", timestamp))
+		return nil, errors.New("timestamp must be a valid timestamp in format 1234567890.123456")
+	}
+
+	return &deleteMessageParams{
+		channel:   channel,
+		timestamp: timestamp,
+	}, nil
+}
+
+// ConversationsOpenHandler opens (or resumes) a direct message or multi-person
+// direct message and returns the resulting channel ID.
+func (ch *ConversationsHandler) ConversationsOpenHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsOpenHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	params, err := ch.parseParamsToolOpenConversation(ctx, request)
+	if err != nil {
+		ch.logger.Error("Failed to parse open-conversation params", zap.Error(err))
+		return nil, err
+	}
+
+	ch.logger.Debug("Opening Slack conversation", zap.Strings("users", params.users))
+	channel, noOp, alreadyOpen, err := ch.apiProvider.Slack().OpenConversationContext(ctx, &slack.OpenConversationParameters{
+		Users:    params.users,
+		ReturnIM: params.returnIM,
+	})
+	if err != nil {
+		ch.logger.Error("Slack OpenConversationContext failed", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf(
+		"Opened conversation %s with users [%s] (already_open=%v, no_op=%v)",
+		channel.ID, strings.Join(params.users, ", "), alreadyOpen, noOp,
+	)), nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolOpenConversation(ctx context.Context, request mcp.CallToolRequest) (*openConversationParams, error) {
+	toolConfig := os.Getenv("SLACK_MCP_OPEN_CONVERSATION_TOOL")
+	if toolConfig == "" {
+		ch.logger.Error("Open-conversation tool disabled by default")
+		return nil, errors.New(
+			"by default, the conversations_open tool is disabled to guard against accidentally creating new DMs or group DMs. " +
+				"To enable it, set the SLACK_MCP_OPEN_CONVERSATION_TOOL environment variable to true, " +
+				"e.g. 'SLACK_MCP_OPEN_CONVERSATION_TOOL=true'",
+		)
+	}
+
+	raw := request.GetString("users", "")
+	if raw == "" {
+		ch.logger.Error("users missing in open-conversation params")
+		return nil, errors.New("users must be a non-empty comma-separated list of Slack user IDs, @handles, or emails")
+	}
+
+	tokens := strings.Split(raw, ",")
+	userIDs := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		token = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(token), "@"))
+		if token == "" {
+			continue
+		}
+
+		// SearchUsers already short-circuits to an exact ID lookup when token
+		// looks like a Slack user ID (Uxxxxxxxxxx), so we don't duplicate that
+		// pattern match here - every token, ID or handle, goes through it.
+		matches, err := ch.apiProvider.SearchUsers(ctx, token, 5)
+		if err != nil {
+			ch.logger.Error("Failed to resolve user for open-conversation", zap.String("query", token), zap.Error(err))
+			return nil, fmt.Errorf("failed to resolve user %q: %w", token, err)
+		}
+		exact := make([]slack.User, 0, 1)
+		for _, m := range matches {
+			if strings.EqualFold(m.Name, token) || strings.EqualFold(m.Profile.DisplayName, token) || strings.EqualFold(m.Profile.Email, token) {
+				exact = append(exact, m)
+			}
+		}
+		switch {
+		case len(exact) == 1:
+			userIDs = append(userIDs, exact[0].ID)
+		case len(matches) == 1:
+			userIDs = append(userIDs, matches[0].ID)
+		case len(matches) == 0:
+			return nil, fmt.Errorf("no Slack user found matching %q", token)
+		default:
+			return nil, fmt.Errorf("ambiguous user %q matched %d users, use a raw user ID (Uxxxxxxxxxx) instead", token, len(matches))
+		}
+	}
+
+	if len(userIDs) == 0 {
+		return nil, errors.New("no valid users resolved from the users parameter")
+	}
+
+	return &openConversationParams{
+		users:    userIDs,
+		returnIM: request.GetBool("return_im", false),
+	}, nil
 }
 
 // ReactionsAddHandler adds an emoji reaction to a message

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -1614,6 +1614,34 @@ func (ch *ConversationsHandler) ConversationsJoinHandler(ctx context.Context, re
 	return mcp.NewToolResultText(fmt.Sprintf("Successfully joined %s", channel)), nil
 }
 
+func (ch *ConversationsHandler) ConversationsRenameHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsRenameHandler called", zap.Any("params", request.Params))
+
+	channel := request.GetString("channel_id", "")
+	if channel == "" {
+		return nil, fmt.Errorf("channel_id is required")
+	}
+
+	name := request.GetString("name", "")
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	channel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve channel: %w", err)
+	}
+
+	renamed, err := ch.apiProvider.Slack().RenameConversationContext(ctx, channel, name)
+	if err != nil {
+		ch.logger.Error("Failed to rename conversation", zap.Error(err))
+		return nil, fmt.Errorf("failed to rename conversation: %v", err)
+	}
+
+	ch.logger.Info("Renamed conversation", zap.String("channel", channel), zap.String("name", renamed.Name))
+	return mcp.NewToolResultText(fmt.Sprintf("Successfully renamed %s to #%s", channel, renamed.Name)), nil
+}
+
 // sortChannelsByPriority sorts channels: DMs > group_dm > partner > internal
 func (ch *ConversationsHandler) sortChannelsByPriority(channels []UnreadChannel) {
 	priority := map[string]int{

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -157,6 +157,11 @@ type inviteParams struct {
 	channel string
 	users   []string
 }
+
+type kickParams struct {
+	channel string
+	user    string
+}
 type ConversationsHandler struct {
 	apiProvider *provider.ApiProvider
 	logger      *zap.Logger
@@ -1742,6 +1747,51 @@ func (ch *ConversationsHandler) parseParamsToolInvite(ctx context.Context, reque
 	}
 
 	return &inviteParams{channel: channel, users: userIDs}, nil
+}
+
+func (ch *ConversationsHandler) ConversationsKickHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsKickHandler called", zap.Any("params", request.Params))
+
+	params, err := ch.parseParamsToolKick(ctx, request)
+	if err != nil {
+		ch.logger.Error("Failed to parse kick params", zap.Error(err))
+		return nil, err
+	}
+
+	if err := ch.apiProvider.Slack().KickUserFromConversationContext(ctx, params.channel, params.user); err != nil {
+		ch.logger.Error("Slack KickUserFromConversationContext failed", zap.Error(err))
+		return nil, fmt.Errorf("failed to remove user %s from channel %s: %w", params.user, params.channel, err)
+	}
+
+	ch.logger.Info("Removed user from conversation", zap.String("channel", params.channel), zap.String("user", params.user))
+	return mcp.NewToolResultText(fmt.Sprintf("Removed %s from %s", params.user, params.channel)), nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolKick(ctx context.Context, request mcp.CallToolRequest) (*kickParams, error) {
+	channel := request.GetString("channel_id", "")
+	if channel == "" {
+		return nil, errors.New("channel_id is required")
+	}
+
+	channel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve channel: %w", err)
+	}
+
+	raw := request.GetString("user_id", "")
+	if raw == "" {
+		return nil, errors.New("user_id is required and must be a Slack user ID, @handle, or email")
+	}
+
+	userIDs, err := ch.resolveUserTokens(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(userIDs) != 1 {
+		return nil, errors.New("user_id must resolve to exactly one Slack user")
+	}
+
+	return &kickParams{channel: channel, user: userIDs[0]}, nil
 }
 
 func (ch *ConversationsHandler) ConversationsInviteSharedHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -141,6 +141,17 @@ type markParams struct {
 	channel string
 	ts      string
 }
+
+type createConversationParams struct {
+	name      string
+	isPrivate bool
+}
+
+type inviteSharedParams struct {
+	channel string
+	emails  []string
+	userIDs []string
+}
 type ConversationsHandler struct {
 	apiProvider *provider.ApiProvider
 	logger      *zap.Logger
@@ -1640,6 +1651,127 @@ func (ch *ConversationsHandler) ConversationsRenameHandler(ctx context.Context, 
 
 	ch.logger.Info("Renamed conversation", zap.String("channel", channel), zap.String("name", renamed.Name))
 	return mcp.NewToolResultText(fmt.Sprintf("Successfully renamed %s to #%s", channel, renamed.Name)), nil
+}
+
+func (ch *ConversationsHandler) ConversationsCreateHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsCreateHandler called", zap.Any("params", request.Params))
+
+	params, err := ch.parseParamsToolCreateConversation(request)
+	if err != nil {
+		ch.logger.Error("Failed to parse create-conversation params", zap.Error(err))
+		return nil, err
+	}
+
+	channel, err := ch.apiProvider.Slack().CreateConversationContext(ctx, slack.CreateConversationParams{
+		ChannelName: params.name,
+		IsPrivate:   params.isPrivate,
+	})
+	if err != nil {
+		ch.logger.Error("Slack CreateConversationContext failed", zap.Error(err))
+		return nil, fmt.Errorf("failed to create channel %q: %w", params.name, err)
+	}
+
+	ch.logger.Info("Created conversation", zap.String("channel", channel.ID), zap.String("name", channel.Name))
+	return mcp.NewToolResultText(fmt.Sprintf("Created channel #%s with ID %s", channel.Name, channel.ID)), nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolCreateConversation(request mcp.CallToolRequest) (*createConversationParams, error) {
+	name := request.GetString("name", "")
+	if name == "" {
+		return nil, errors.New("name is required")
+	}
+
+	return &createConversationParams{
+		name:      name,
+		isPrivate: request.GetBool("is_private", false),
+	}, nil
+}
+
+func (ch *ConversationsHandler) ConversationsInviteSharedHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsInviteSharedHandler called", zap.Any("params", request.Params))
+
+	if toolConfig := os.Getenv("SLACK_MCP_INVITE_SHARED_TOOL"); toolConfig == "" {
+		ch.logger.Error("Invite-shared tool disabled by default")
+		return nil, errors.New(
+			"by default, the conversations_invite_shared tool is disabled to guard against accidentally sending real Slack Connect invites. " +
+				"To enable it, set the SLACK_MCP_INVITE_SHARED_TOOL environment variable, e.g. 'SLACK_MCP_INVITE_SHARED_TOOL=true'",
+		)
+	}
+
+	params, err := ch.parseParamsToolInviteShared(ctx, request)
+	if err != nil {
+		ch.logger.Error("Failed to parse invite-shared params", zap.Error(err))
+		return nil, err
+	}
+
+	var inviteID string
+	var isLegacySharedChannel bool
+	if len(params.emails) > 0 {
+		inviteID, isLegacySharedChannel, err = ch.apiProvider.Slack().InviteSharedEmailsToConversationContext(ctx, params.channel, params.emails...)
+	} else {
+		inviteID, isLegacySharedChannel, err = ch.apiProvider.Slack().InviteSharedUserIDsToConversationContext(ctx, params.channel, params.userIDs...)
+	}
+	if err != nil {
+		ch.logger.Error("Slack InviteSharedToConversationContext failed", zap.Error(err))
+		return nil, fmt.Errorf("failed to send Slack Connect invite for channel %s: %w", params.channel, err)
+	}
+
+	invitees := params.emails
+	if len(invitees) == 0 {
+		invitees = params.userIDs
+	}
+
+	ch.logger.Info("Sent Slack Connect invite",
+		zap.String("channel", params.channel),
+		zap.Strings("invitees", invitees),
+		zap.String("invite_id", inviteID),
+	)
+	return mcp.NewToolResultText(fmt.Sprintf(
+		"Sent Slack Connect invite for channel %s to [%s] (invite_id=%s, is_legacy_shared_channel=%v)",
+		params.channel, strings.Join(invitees, ", "), inviteID, isLegacySharedChannel,
+	)), nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolInviteShared(ctx context.Context, request mcp.CallToolRequest) (*inviteSharedParams, error) {
+	channel := request.GetString("channel_id", "")
+	if channel == "" {
+		return nil, errors.New("channel_id is required")
+	}
+
+	channel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve channel: %w", err)
+	}
+
+	emailsRaw := request.GetString("emails", "")
+	userIDsRaw := request.GetString("user_ids", "")
+	if emailsRaw == "" && userIDsRaw == "" {
+		return nil, errors.New("either emails or user_ids must be provided")
+	}
+	if emailsRaw != "" && userIDsRaw != "" {
+		return nil, errors.New("provide either emails or user_ids, not both")
+	}
+
+	splitAndTrim := func(raw string) []string {
+		tokens := strings.Split(raw, ",")
+		out := make([]string, 0, len(tokens))
+		for _, t := range tokens {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+
+	params := &inviteSharedParams{channel: channel}
+	if emailsRaw != "" {
+		params.emails = splitAndTrim(emailsRaw)
+	} else {
+		params.userIDs = splitAndTrim(userIDsRaw)
+	}
+
+	return params, nil
 }
 
 // sortChannelsByPriority sorts channels: DMs > group_dm > partner > internal

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -152,6 +152,11 @@ type inviteSharedParams struct {
 	emails  []string
 	userIDs []string
 }
+
+type inviteParams struct {
+	channel string
+	users   []string
+}
 type ConversationsHandler struct {
 	apiProvider *provider.ApiProvider
 	logger      *zap.Logger
@@ -429,6 +434,21 @@ func (ch *ConversationsHandler) parseParamsToolOpenConversation(ctx context.Cont
 		return nil, errors.New("users must be a non-empty comma-separated list of Slack user IDs, @handles, or emails")
 	}
 
+	userIDs, err := ch.resolveUserTokens(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &openConversationParams{
+		users:    userIDs,
+		returnIM: request.GetBool("return_im", false),
+	}, nil
+}
+
+// resolveUserTokens resolves a comma-separated list of Slack user IDs, @handles, or emails
+// to their canonical user IDs, via SearchUsers (which already short-circuits to an exact ID
+// lookup when a token looks like a Slack user ID, so we don't duplicate that pattern match here).
+func (ch *ConversationsHandler) resolveUserTokens(ctx context.Context, raw string) ([]string, error) {
 	tokens := strings.Split(raw, ",")
 	userIDs := make([]string, 0, len(tokens))
 	for _, token := range tokens {
@@ -437,12 +457,9 @@ func (ch *ConversationsHandler) parseParamsToolOpenConversation(ctx context.Cont
 			continue
 		}
 
-		// SearchUsers already short-circuits to an exact ID lookup when token
-		// looks like a Slack user ID (Uxxxxxxxxxx), so we don't duplicate that
-		// pattern match here - every token, ID or handle, goes through it.
 		matches, err := ch.apiProvider.SearchUsers(ctx, token, 5)
 		if err != nil {
-			ch.logger.Error("Failed to resolve user for open-conversation", zap.String("query", token), zap.Error(err))
+			ch.logger.Error("Failed to resolve user", zap.String("query", token), zap.Error(err))
 			return nil, fmt.Errorf("failed to resolve user %q: %w", token, err)
 		}
 		exact := make([]slack.User, 0, 1)
@@ -467,10 +484,7 @@ func (ch *ConversationsHandler) parseParamsToolOpenConversation(ctx context.Cont
 		return nil, errors.New("no valid users resolved from the users parameter")
 	}
 
-	return &openConversationParams{
-		users:    userIDs,
-		returnIM: request.GetBool("return_im", false),
-	}, nil
+	return userIDs, nil
 }
 
 // ReactionsAddHandler adds an emoji reaction to a message
@@ -1685,6 +1699,49 @@ func (ch *ConversationsHandler) parseParamsToolCreateConversation(request mcp.Ca
 		name:      name,
 		isPrivate: request.GetBool("is_private", false),
 	}, nil
+}
+
+func (ch *ConversationsHandler) ConversationsInviteHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsInviteHandler called", zap.Any("params", request.Params))
+
+	params, err := ch.parseParamsToolInvite(ctx, request)
+	if err != nil {
+		ch.logger.Error("Failed to parse invite params", zap.Error(err))
+		return nil, err
+	}
+
+	channel, err := ch.apiProvider.Slack().InviteUsersToConversationContext(ctx, params.channel, params.users...)
+	if err != nil {
+		ch.logger.Error("Slack InviteUsersToConversationContext failed", zap.Error(err))
+		return nil, fmt.Errorf("failed to invite users to channel %s: %w", params.channel, err)
+	}
+
+	ch.logger.Info("Invited users to conversation", zap.String("channel", channel.ID), zap.Strings("users", params.users))
+	return mcp.NewToolResultText(fmt.Sprintf("Invited [%s] to %s", strings.Join(params.users, ", "), channel.ID)), nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolInvite(ctx context.Context, request mcp.CallToolRequest) (*inviteParams, error) {
+	channel := request.GetString("channel_id", "")
+	if channel == "" {
+		return nil, errors.New("channel_id is required")
+	}
+
+	channel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve channel: %w", err)
+	}
+
+	raw := request.GetString("users", "")
+	if raw == "" {
+		return nil, errors.New("users must be a non-empty comma-separated list of Slack user IDs, @handles, or emails")
+	}
+
+	userIDs, err := ch.resolveUserTokens(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &inviteParams{channel: channel, users: userIDs}, nil
 }
 
 func (ch *ConversationsHandler) ConversationsInviteSharedHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -225,6 +225,7 @@ type SlackAPI interface {
 	JoinConversationContext(ctx context.Context, channelID string) (*slack.Channel, string, []string, error)
 	RenameConversationContext(ctx context.Context, channelID, channelName string) (*slack.Channel, error)
 	CreateConversationContext(ctx context.Context, params slack.CreateConversationParams) (*slack.Channel, error)
+	InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*slack.Channel, error)
 	InviteSharedEmailsToConversationContext(ctx context.Context, channelID string, emails ...string) (string, bool, error)
 	InviteSharedUserIDsToConversationContext(ctx context.Context, channelID string, userIDs ...string) (string, bool, error)
 
@@ -424,6 +425,10 @@ func (c *MCPSlackClient) RenameConversationContext(ctx context.Context, channelI
 
 func (c *MCPSlackClient) CreateConversationContext(ctx context.Context, params slack.CreateConversationParams) (*slack.Channel, error) {
 	return c.slackClient.CreateConversationContext(ctx, params)
+}
+
+func (c *MCPSlackClient) InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*slack.Channel, error) {
+	return c.slackClient.InviteUsersToConversationContext(ctx, channelID, users...)
 }
 
 func (c *MCPSlackClient) InviteSharedEmailsToConversationContext(ctx context.Context, channelID string, emails ...string) (string, bool, error) {

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -226,6 +226,7 @@ type SlackAPI interface {
 	RenameConversationContext(ctx context.Context, channelID, channelName string) (*slack.Channel, error)
 	CreateConversationContext(ctx context.Context, params slack.CreateConversationParams) (*slack.Channel, error)
 	InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*slack.Channel, error)
+	KickUserFromConversationContext(ctx context.Context, channelID string, user string) error
 	InviteSharedEmailsToConversationContext(ctx context.Context, channelID string, emails ...string) (string, bool, error)
 	InviteSharedUserIDsToConversationContext(ctx context.Context, channelID string, userIDs ...string) (string, bool, error)
 
@@ -429,6 +430,10 @@ func (c *MCPSlackClient) CreateConversationContext(ctx context.Context, params s
 
 func (c *MCPSlackClient) InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*slack.Channel, error) {
 	return c.slackClient.InviteUsersToConversationContext(ctx, channelID, users...)
+}
+
+func (c *MCPSlackClient) KickUserFromConversationContext(ctx context.Context, channelID string, user string) error {
+	return c.slackClient.KickUserFromConversationContext(ctx, channelID, user)
 }
 
 func (c *MCPSlackClient) InviteSharedEmailsToConversationContext(ctx context.Context, channelID string, emails ...string) (string, bool, error) {

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -216,6 +216,8 @@ type SlackAPI interface {
 	GetUsersContext(ctx context.Context, options ...slack.GetUsersOption) ([]slack.User, error)
 	GetUsersInfo(users ...string) (*[]slack.User, error)
 	PostMessageContext(ctx context.Context, channel string, options ...slack.MsgOption) (string, string, error)
+	DeleteMessageContext(ctx context.Context, channel, msgTimestamp string) (string, string, error)
+	OpenConversationContext(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
 	MarkConversationContext(ctx context.Context, channel, ts string) error
 	AddReactionContext(ctx context.Context, name string, item slack.ItemRef) error
 	RemoveReactionContext(ctx context.Context, name string, item slack.ItemRef) error
@@ -531,6 +533,14 @@ func (c *MCPSlackClient) SearchContext(ctx context.Context, query string, params
 
 func (c *MCPSlackClient) PostMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (string, string, error) {
 	return c.slackClient.PostMessageContext(ctx, channelID, options...)
+}
+
+func (c *MCPSlackClient) DeleteMessageContext(ctx context.Context, channel, msgTimestamp string) (string, string, error) {
+	return c.slackClient.DeleteMessageContext(ctx, channel, msgTimestamp)
+}
+
+func (c *MCPSlackClient) OpenConversationContext(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+	return c.slackClient.OpenConversationContext(ctx, params)
 }
 
 func (c *MCPSlackClient) AddReactionContext(ctx context.Context, name string, item slack.ItemRef) error {

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -224,6 +224,9 @@ type SlackAPI interface {
 	LeaveConversationContext(ctx context.Context, channelID string) (bool, error)
 	JoinConversationContext(ctx context.Context, channelID string) (*slack.Channel, string, []string, error)
 	RenameConversationContext(ctx context.Context, channelID, channelName string) (*slack.Channel, error)
+	CreateConversationContext(ctx context.Context, params slack.CreateConversationParams) (*slack.Channel, error)
+	InviteSharedEmailsToConversationContext(ctx context.Context, channelID string, emails ...string) (string, bool, error)
+	InviteSharedUserIDsToConversationContext(ctx context.Context, channelID string, userIDs ...string) (string, bool, error)
 
 	// Used to get messages
 	GetConversationHistoryContext(ctx context.Context, params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
@@ -417,6 +420,18 @@ func (c *MCPSlackClient) JoinConversationContext(ctx context.Context, channelID 
 
 func (c *MCPSlackClient) RenameConversationContext(ctx context.Context, channelID, channelName string) (*slack.Channel, error) {
 	return c.slackClient.RenameConversationContext(ctx, channelID, channelName)
+}
+
+func (c *MCPSlackClient) CreateConversationContext(ctx context.Context, params slack.CreateConversationParams) (*slack.Channel, error) {
+	return c.slackClient.CreateConversationContext(ctx, params)
+}
+
+func (c *MCPSlackClient) InviteSharedEmailsToConversationContext(ctx context.Context, channelID string, emails ...string) (string, bool, error) {
+	return c.slackClient.InviteSharedEmailsToConversationContext(ctx, channelID, emails...)
+}
+
+func (c *MCPSlackClient) InviteSharedUserIDsToConversationContext(ctx context.Context, channelID string, userIDs ...string) (string, bool, error) {
+	return c.slackClient.InviteSharedUserIDsToConversationContext(ctx, channelID, userIDs...)
 }
 
 func (c *MCPSlackClient) GetConversationsContext(ctx context.Context, params *slack.GetConversationsParameters) ([]slack.Channel, string, error) {

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -223,6 +223,7 @@ type SlackAPI interface {
 	RemoveReactionContext(ctx context.Context, name string, item slack.ItemRef) error
 	LeaveConversationContext(ctx context.Context, channelID string) (bool, error)
 	JoinConversationContext(ctx context.Context, channelID string) (*slack.Channel, string, []string, error)
+	RenameConversationContext(ctx context.Context, channelID, channelName string) (*slack.Channel, error)
 
 	// Used to get messages
 	GetConversationHistoryContext(ctx context.Context, params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
@@ -412,6 +413,10 @@ func (c *MCPSlackClient) LeaveConversationContext(ctx context.Context, channelID
 
 func (c *MCPSlackClient) JoinConversationContext(ctx context.Context, channelID string) (*slack.Channel, string, []string, error) {
 	return c.slackClient.JoinConversationContext(ctx, channelID)
+}
+
+func (c *MCPSlackClient) RenameConversationContext(ctx context.Context, channelID, channelName string) (*slack.Channel, error) {
+	return c.slackClient.RenameConversationContext(ctx, channelID, channelName)
 }
 
 func (c *MCPSlackClient) GetConversationsContext(ctx context.Context, params *slack.GetConversationsParameters) ([]slack.Channel, string, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,7 @@ const (
 	ToolConversationsJoin           = "conversations_join"
 	ToolConversationsRename         = "conversations_rename"
 	ToolConversationsCreate         = "conversations_create"
+	ToolConversationsInvite         = "conversations_invite"
 	ToolConversationsInviteShared   = "conversations_invite_shared"
 	ToolChannelsList                = "channels_list"
 	ToolChannelsMe                  = "channels_me"
@@ -70,6 +71,7 @@ var ValidToolNames = []string{
 	ToolConversationsJoin,
 	ToolConversationsRename,
 	ToolConversationsCreate,
+	ToolConversationsInvite,
 	ToolConversationsInviteShared,
 	ToolChannelsList,
 	ToolChannelsMe,
@@ -459,6 +461,22 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Whether the channel should be private. Default is false (public channel)."),
 			),
 		), conversationsHandler.ConversationsCreateHandler)
+	}
+
+	if shouldAddTool(ToolConversationsInvite, enabledTools, "SLACK_MCP_INVITE_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsInvite,
+			mcp.WithDescription("Invite one or more existing workspace members to a public or private channel."),
+			mcp.WithTitleAnnotation("Invite Users"),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... (e.g., #general)."),
+			),
+			mcp.WithString("users",
+				mcp.Required(),
+				mcp.Description("Comma-separated list of Slack user IDs, @handles, or emails to invite, e.g. 'U0123456,U0654321' or '@iffat.hasan'."),
+			),
+		), conversationsHandler.ConversationsInviteHandler)
 	}
 
 	if shouldAddTool(ToolConversationsInviteShared, enabledTools, "SLACK_MCP_INVITE_SHARED_TOOL") {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,6 +28,8 @@ const (
 	ToolConversationsHistory        = "conversations_history"
 	ToolConversationsReplies        = "conversations_replies"
 	ToolConversationsAddMessage     = "conversations_add_message"
+	ToolConversationsDeleteMessage  = "conversations_delete_message"
+	ToolConversationsOpen           = "conversations_open"
 	ToolReactionsAdd                = "reactions_add"
 	ToolReactionsRemove             = "reactions_remove"
 	ToolAttachmentGetData           = "attachment_get_data"
@@ -53,6 +55,8 @@ var ValidToolNames = []string{
 	ToolConversationsHistory,
 	ToolConversationsReplies,
 	ToolConversationsAddMessage,
+	ToolConversationsDeleteMessage,
+	ToolConversationsOpen,
 	ToolReactionsAdd,
 	ToolReactionsRemove,
 	ToolAttachmentGetData,
@@ -199,6 +203,38 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Raw Slack Block Kit JSON array for rich message formatting (rich_text lists, code blocks, etc.). When provided, this takes precedence over text/content_type for rendering. The text parameter becomes the notification fallback text."),
 			),
 		), conversationsHandler.ConversationsAddMessageHandler)
+	}
+
+	if shouldAddTool(ToolConversationsDeleteMessage, enabledTools, "SLACK_MCP_DELETE_MESSAGE_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsDeleteMessage,
+			mcp.WithDescription("Delete a message from a public channel, private channel, or direct message (DM, or IM) conversation by channel_id and timestamp."),
+			mcp.WithTitleAnnotation("Delete Message"),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
+			),
+			mcp.WithString("timestamp",
+				mcp.Required(),
+				mcp.Description("The timestamp of the message to delete in format 1234567890.123456."),
+			),
+		), conversationsHandler.ConversationsDeleteMessageHandler)
+	}
+
+	if shouldAddTool(ToolConversationsOpen, enabledTools, "SLACK_MCP_OPEN_CONVERSATION_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsOpen,
+			mcp.WithDescription("Open or resume a direct message (1 user) or multi-person direct message / group DM (2+ users). Returns the resulting channel_id, which can then be used with conversations_add_message."),
+			mcp.WithTitleAnnotation("Open Conversation"),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithString("users",
+				mcp.Required(),
+				mcp.Description("Comma-separated list of Slack user IDs, @handles, or emails to open a conversation with, e.g. 'U0123456,U0654321' or '@iffat.hasan,@mary.toledano'. One user opens/resumes a 1:1 DM; two or more open/resume a group DM (mpim)."),
+			),
+			mcp.WithBoolean("return_im",
+				mcp.DefaultBool(false),
+				mcp.Description("Whether to return the full IM channel definition in the response. Only meaningful for a single-user (1:1 DM) request."),
+			),
+		), conversationsHandler.ConversationsOpenHandler)
 	}
 
 	if shouldAddTool(ToolReactionsAdd, enabledTools, "SLACK_MCP_REACTION_TOOL") {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -41,6 +41,7 @@ const (
 	ToolConversationsRename         = "conversations_rename"
 	ToolConversationsCreate         = "conversations_create"
 	ToolConversationsInvite         = "conversations_invite"
+	ToolConversationsKick           = "conversations_kick"
 	ToolConversationsInviteShared   = "conversations_invite_shared"
 	ToolChannelsList                = "channels_list"
 	ToolChannelsMe                  = "channels_me"
@@ -72,6 +73,7 @@ var ValidToolNames = []string{
 	ToolConversationsRename,
 	ToolConversationsCreate,
 	ToolConversationsInvite,
+	ToolConversationsKick,
 	ToolConversationsInviteShared,
 	ToolChannelsList,
 	ToolChannelsMe,
@@ -477,6 +479,22 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Comma-separated list of Slack user IDs, @handles, or emails to invite, e.g. 'U0123456,U0654321' or '@iffat.hasan'."),
 			),
 		), conversationsHandler.ConversationsInviteHandler)
+	}
+
+	if shouldAddTool(ToolConversationsKick, enabledTools, "SLACK_MCP_KICK_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsKick,
+			mcp.WithDescription("Remove (kick) a single existing member from a public or private channel."),
+			mcp.WithTitleAnnotation("Kick User"),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... (e.g., #general)."),
+			),
+			mcp.WithString("user_id",
+				mcp.Required(),
+				mcp.Description("A single Slack user to remove, given as a user ID, @handle, or email, e.g. 'U0123456', '@iffat.hasan', or 'iffat@example.com'."),
+			),
+		), conversationsHandler.ConversationsKickHandler)
 	}
 
 	if shouldAddTool(ToolConversationsInviteShared, enabledTools, "SLACK_MCP_INVITE_SHARED_TOOL") {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -38,6 +38,7 @@ const (
 	ToolConversationsMark           = "conversations_mark"
 	ToolConversationsLeave          = "conversations_leave"
 	ToolConversationsJoin           = "conversations_join"
+	ToolConversationsRename         = "conversations_rename"
 	ToolChannelsList                = "channels_list"
 	ToolChannelsMe                  = "channels_me"
 	ToolUsergroupsList              = "usergroups_list"
@@ -65,6 +66,7 @@ var ValidToolNames = []string{
 	ToolConversationsMark,
 	ToolConversationsLeave,
 	ToolConversationsJoin,
+	ToolConversationsRename,
 	ToolChannelsList,
 	ToolChannelsMe,
 	ToolUsergroupsList,
@@ -424,6 +426,22 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 			),
 		), conversationsHandler.ConversationsJoinHandler)
 	}
+	if shouldAddTool(ToolConversationsRename, enabledTools, "SLACK_MCP_RENAME_CHANNEL_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsRename,
+			mcp.WithDescription("Rename a public or private channel. Requires the acting user to be the channel creator or a workspace admin/owner."),
+			mcp.WithTitleAnnotation("Rename Channel"),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... (e.g., #general)."),
+			),
+			mcp.WithString("name",
+				mcp.Required(),
+				mcp.Description("New name for the channel, without the leading #. Lowercase, no spaces (use hyphens)."),
+			),
+		), conversationsHandler.ConversationsRenameHandler)
+	}
+
 	channelsHandler := handler.NewChannelsHandler(provider, logger)
 	usergroupsHandler := handler.NewUsergroupsHandler(provider, logger)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,6 +39,8 @@ const (
 	ToolConversationsLeave          = "conversations_leave"
 	ToolConversationsJoin           = "conversations_join"
 	ToolConversationsRename         = "conversations_rename"
+	ToolConversationsCreate         = "conversations_create"
+	ToolConversationsInviteShared   = "conversations_invite_shared"
 	ToolChannelsList                = "channels_list"
 	ToolChannelsMe                  = "channels_me"
 	ToolUsergroupsList              = "usergroups_list"
@@ -67,6 +69,8 @@ var ValidToolNames = []string{
 	ToolConversationsLeave,
 	ToolConversationsJoin,
 	ToolConversationsRename,
+	ToolConversationsCreate,
+	ToolConversationsInviteShared,
 	ToolChannelsList,
 	ToolChannelsMe,
 	ToolUsergroupsList,
@@ -440,6 +444,39 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("New name for the channel, without the leading #. Lowercase, no spaces (use hyphens)."),
 			),
 		), conversationsHandler.ConversationsRenameHandler)
+	}
+
+	if shouldAddTool(ToolConversationsCreate, enabledTools, "SLACK_MCP_CREATE_CHANNEL_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsCreate,
+			mcp.WithDescription("Create a new public or private channel. Returns the resulting channel_id, which can then be used with conversations_invite_shared or conversations_add_message."),
+			mcp.WithTitleAnnotation("Create Channel"),
+			mcp.WithString("name",
+				mcp.Required(),
+				mcp.Description("Name for the new channel, without the leading #. Lowercase, no spaces (use hyphens)."),
+			),
+			mcp.WithBoolean("is_private",
+				mcp.DefaultBool(false),
+				mcp.Description("Whether the channel should be private. Default is false (public channel)."),
+			),
+		), conversationsHandler.ConversationsCreateHandler)
+	}
+
+	if shouldAddTool(ToolConversationsInviteShared, enabledTools, "SLACK_MCP_INVITE_SHARED_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsInviteShared,
+			mcp.WithDescription("Invite external people to a channel via Slack Connect, turning it into a shared channel. This sends a real invite (by email, or directly if the person already has a Slack Connect relationship) that is visible to the recipient outside this workspace - it is not a preview or a draft. Requires the acting user/token to have permission to send Slack Connect invites for this workspace."),
+			mcp.WithTitleAnnotation("Invite External User (Slack Connect)"),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... (e.g., #general)."),
+			),
+			mcp.WithString("emails",
+				mcp.Description("Comma-separated list of external email addresses to invite via Slack Connect, e.g. 'ben@platter.com'. Provide either emails or user_ids, not both."),
+			),
+			mcp.WithString("user_ids",
+				mcp.Description("Comma-separated list of Slack user IDs to invite via Slack Connect. Provide either emails or user_ids, not both."),
+			),
+		), conversationsHandler.ConversationsInviteSharedHandler)
 	}
 
 	channelsHandler := handler.NewChannelsHandler(provider, logger)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -97,6 +97,8 @@ func TestValidToolNames(t *testing.T) {
 			ToolConversationsHistory:        true,
 			ToolConversationsReplies:        true,
 			ToolConversationsAddMessage:     true,
+			ToolConversationsDeleteMessage:  true,
+			ToolConversationsOpen:           true,
 			ToolReactionsAdd:                true,
 			ToolReactionsRemove:             true,
 			ToolAttachmentGetData:           true,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -109,6 +109,7 @@ func TestValidToolNames(t *testing.T) {
 			ToolConversationsJoin:           true,
 			ToolConversationsRename:         true,
 			ToolConversationsCreate:         true,
+			ToolConversationsInvite:         true,
 			ToolConversationsInviteShared:   true,
 			ToolChannelsList:                true,
 			ToolChannelsMe:                  true,
@@ -144,6 +145,7 @@ func TestValidToolNames(t *testing.T) {
 		assert.Equal(t, "conversations_join", ToolConversationsJoin)
 		assert.Equal(t, "conversations_rename", ToolConversationsRename)
 		assert.Equal(t, "conversations_create", ToolConversationsCreate)
+		assert.Equal(t, "conversations_invite", ToolConversationsInvite)
 		assert.Equal(t, "conversations_invite_shared", ToolConversationsInviteShared)
 		assert.Equal(t, "channels_list", ToolChannelsList)
 		assert.Equal(t, "channels_me", ToolChannelsMe)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -110,6 +110,7 @@ func TestValidToolNames(t *testing.T) {
 			ToolConversationsRename:         true,
 			ToolConversationsCreate:         true,
 			ToolConversationsInvite:         true,
+			ToolConversationsKick:           true,
 			ToolConversationsInviteShared:   true,
 			ToolChannelsList:                true,
 			ToolChannelsMe:                  true,
@@ -146,6 +147,7 @@ func TestValidToolNames(t *testing.T) {
 		assert.Equal(t, "conversations_rename", ToolConversationsRename)
 		assert.Equal(t, "conversations_create", ToolConversationsCreate)
 		assert.Equal(t, "conversations_invite", ToolConversationsInvite)
+		assert.Equal(t, "conversations_kick", ToolConversationsKick)
 		assert.Equal(t, "conversations_invite_shared", ToolConversationsInviteShared)
 		assert.Equal(t, "channels_list", ToolChannelsList)
 		assert.Equal(t, "channels_me", ToolChannelsMe)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -107,6 +107,9 @@ func TestValidToolNames(t *testing.T) {
 			ToolConversationsMark:           true,
 			ToolConversationsLeave:          true,
 			ToolConversationsJoin:           true,
+			ToolConversationsRename:         true,
+			ToolConversationsCreate:         true,
+			ToolConversationsInviteShared:   true,
 			ToolChannelsList:                true,
 			ToolChannelsMe:                  true,
 			ToolUsergroupsList:              true,
@@ -139,6 +142,9 @@ func TestValidToolNames(t *testing.T) {
 		assert.Equal(t, "conversations_mark", ToolConversationsMark)
 		assert.Equal(t, "conversations_leave", ToolConversationsLeave)
 		assert.Equal(t, "conversations_join", ToolConversationsJoin)
+		assert.Equal(t, "conversations_rename", ToolConversationsRename)
+		assert.Equal(t, "conversations_create", ToolConversationsCreate)
+		assert.Equal(t, "conversations_invite_shared", ToolConversationsInviteShared)
 		assert.Equal(t, "channels_list", ToolChannelsList)
 		assert.Equal(t, "channels_me", ToolChannelsMe)
 		assert.Equal(t, "usergroups_list", ToolUsergroupsList)


### PR DESCRIPTION
## Summary

Adds a new `conversations_kick` MCP tool that removes a single member from a public or private channel by wrapping Slack's `conversations.kick` API (slack-go's `KickUserFromConversationContext`).

It takes:
- `channel_id` — channel ID (`Cxxxxxxxxxx`) or `#name`
- `user_id` — a single user given as a Slack user ID, `@handle`, or email

The `user_id` is resolved through the same `resolveUserTokens` helper already used by `conversations_invite` and `conversations_open`, so ID/handle/email all work consistently.

## Opt-in

Disabled by default. Set `SLACK_MCP_KICK_TOOL=true` to enable it, matching the opt-in pattern used for the other `conversations_*` write tools (`conversations_invite`, `conversations_create`, `conversations_rename`, `conversations_invite_shared`).

This complements the existing invite/create/rename tools by providing the inverse of `conversations_invite` — a way to remove a member from a channel.

## Changes
- `pkg/handler/conversations.go` — `ConversationsKickHandler` + param parsing
- `pkg/provider/api.go` — `KickUserFromConversationContext` on the Slack API interface and client
- `pkg/server/server.go` — tool registration gated on `SLACK_MCP_KICK_TOOL`
- `pkg/server/server_test.go` — extend the valid tool-name test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQRrufmUR2ZvsQsxKc9QSk