### PR TITLE
feat(add-message): render text/markdown via native Slack markdown block (fixes #140)

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -237,13 +237,27 @@ func (ch *ConversationsHandler) ConversationsAddMessageHandler(ctx context.Conte
 			options = append(options, slack.MsgOptionDisableMarkdown())
 			options = append(options, slack.MsgOptionText(params.text, false))
 		case "text/markdown":
-			blocks, err := slackGoUtil.ConvertMarkdownTextToBlocks(params.text)
-			if err != nil {
-				ch.logger.Warn("Markdown parsing error", zap.Error(err))
-				options = append(options, slack.MsgOptionDisableMarkdown())
+			// Post as a single native Slack `markdown` block, which delegates
+			// rendering to Slack itself. GitHub-flavored Markdown — tables,
+			// headings, code blocks, lists, links — renders faithfully. The
+			// older slack-go-util converter lowers Markdown into rich_text/
+			// section blocks, which silently drops tables and mangles
+			// headings; keep it only as a fallback for oversized input, since
+			// Slack caps a markdown block's text at 12,000 characters.
+			const markdownBlockLimit = 12000
+			if len([]rune(params.text)) <= markdownBlockLimit {
+				options = append(options, slack.MsgOptionBlocks(slack.NewMarkdownBlock("", params.text)))
+				// Top-level text serves as the notification / legacy-client fallback.
 				options = append(options, slack.MsgOptionText(params.text, false))
 			} else {
-				options = append(options, slack.MsgOptionBlocks(blocks...))
+				blocks, err := slackGoUtil.ConvertMarkdownTextToBlocks(params.text)
+				if err != nil {
+					ch.logger.Warn("Markdown parsing error", zap.Error(err))
+					options = append(options, slack.MsgOptionDisableMarkdown())
+					options = append(options, slack.MsgOptionText(params.text, false))
+				} else {
+					options = append(options, slack.MsgOptionBlocks(blocks...))
+				}
 			}
 		default:
 			return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")


### PR DESCRIPTION
## Summary

Render `content_type: text/markdown` messages via Slack's native **`markdown` Block Kit block** (`slack.NewMarkdownBlock`) instead of `slackGoUtil.ConvertMarkdownTextToBlocks`.

The converter lowers Markdown into `rich_text`/`section` blocks. That path **silently drops GitHub-flavored tables** (they arrive as raw `| pipes |` text) and mangles headings. The native `markdown` block delegates rendering to Slack itself, so tables, headings, code blocks, lists, and links all render faithfully — the same approach Slack recommends for LLM-generated Markdown.

Fixes #140.

## Before / after

Posting this Markdown via `conversations_add_message`:

```markdown
## Table
| Component | Status | Count |
|-----------|--------|------:|
| Sofa Milano | completed | 12 |
| Chair Oslo | rejected | 3 |
```

- **Before:** renders as literal text — `| Component | Status | Count | |---|---|---:| | Sofa Milano | ...` — pipes and separator row visible, no grid.
- **After:** renders as a real bordered table with a right-aligned numeric column; the `##` heading renders as a heading.

(Verified empirically against a live workspace via `chat.postMessage`.)

## Changes

- `pkg/handler/conversations.go`: the `text/markdown` case now posts a single `slack.NewMarkdownBlock("", text)`.
  - The old `ConvertMarkdownTextToBlocks` path is **kept as a fallback** for input longer than Slack's 12,000-character `markdown`-block limit, so large messages still get chunked rather than rejected.
  - A top-level `text` is retained as the notification / legacy-client fallback (matching the existing raw-`blocks` branch just above).

## Notes

- `slack-go` already ships `NewMarkdownBlock` (no dependency change needed).
- Slack's docs frame the `markdown` block around "apps that use AI features," but it works for any app via standard `chat.postMessage` — confirmed against a plain (non-AI) bot token.
- Behavior shift worth calling out: because Slack now interprets the text as GitHub-flavored Markdown, `*single asterisk*` is italic and `**double**` is bold (GFM), rather than the legacy mrkdwn `*bold*`. This matches what LLM clients emit.
