### PR TITLE
Add canvas read, create and edit tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,34 @@ Clear all completed saved items from the "Save for Later" panel. This is a bulk 
 
 - **Parameters:** None.
 
+### 19. canvases_read
+Read a canvas along with the section IDs needed to target an edit with `canvases_edit`.
+
+> **Note:** Slack serves canvas content as HTML, not markdown; each block carries the `id` attribute used as `section_id`. Writes take markdown, reads return HTML.
+
+> **Note:** Canvas tools are disabled by default. To enable, set the `SLACK_MCP_CANVAS_TOOL` environment variable. Requires the `canvases:read` and `canvases:write` scopes on the token.
+
+- **Parameters:**
+  - `canvas_id` (string, required): ID of the canvas in format `Fxxxxxxxxxx`. A canvas is a file, so this is its file ID.
+  - `include_sections` (boolean, optional): If `true` (default), also returns section IDs.
+  - `contains_text` (string, optional): Only return sections whose text contains this string, via `canvases.sections.lookup`. Omit to return every section parsed from the content.
+
+### 20. canvases_create
+Create a standalone canvas from markdown. Returns the new canvas ID, which `canvases_read` and `canvases_edit` take as `canvas_id`.
+
+- **Parameters:**
+  - `title` (string, optional): Title of the canvas, shown in the file list and the browser tab.
+  - `markdown` (string, required): Initial canvas content as markdown. Headings become sections that `canvases_edit` can target.
+
+### 21. canvases_edit
+Edit an existing canvas by applying a markdown change: append or prepend content, insert relative to a section, replace a section, or delete one. Use `canvases_read` first to look up section IDs.
+
+- **Parameters:**
+  - `canvas_id` (string, required): ID of the canvas to edit, in format `Fxxxxxxxxxx`.
+  - `operation` (string, required): One of `insert_at_end`, `insert_at_start`, `insert_after`, `insert_before`, `replace`, `delete`. The last four act on `section_id`.
+  - `markdown` (string, optional): Markdown content to apply. Required for every operation except `delete`.
+  - `section_id` (string, optional): Section to act on, from `canvases_read`. Required for `insert_after`, `insert_before`, `replace` and `delete`.
+
 ## Resources
 
 The Slack MCP Server exposes two special directory resources for easy access to workspace metadata:
@@ -292,12 +320,13 @@ Fetches a CSV directory of all users in the workspace.
 | `SLACK_MCP_ADD_MESSAGE_UNFURLING` | No        | `nil`                     | Enable to let Slack unfurl posted links or set comma-separated list of domains e.g. `github.com,slack.com` to whitelist unfurling only for them. If text contains whitelisted and unknown domain unfurling will be disabled for security reasons.                                         |
 | `SLACK_MCP_REACTION_TOOL`        | No        | `nil`                     | Enable `reactions_add` and `reactions_remove` tools by setting to `true` for all channels, a comma-separated list of channel IDs to whitelist specific channels, or use `!` before a channel ID to allow all except specified ones. If empty, the tools are only registered when explicitly listed in `SLACK_MCP_ENABLED_TOOLS`. |
 | `SLACK_MCP_ATTACHMENT_TOOL`      | No        | `nil`                     | Enable the `attachment_get_data` tool by setting to `true`, `1`, or `yes`. Does not support channel-level restrictions. If empty, the tool is only registered when explicitly listed in `SLACK_MCP_ENABLED_TOOLS`. |
+| `SLACK_MCP_CANVAS_TOOL`          | No        | `nil`                     | Enable the `canvases_read`, `canvases_create` and `canvases_edit` tools by setting to `true`. Requires the `canvases:read` and `canvases:write` scopes on the token. Does not support channel-level restrictions. If empty, the tools are only registered when explicitly listed in `SLACK_MCP_ENABLED_TOOLS`. |
 | `SLACK_MCP_MARK_TOOL`             | No        | `nil`                     | Enable the `conversations_mark` tool by setting to `true` or `1`. Disabled by default to prevent accidental marking of messages as read.                                                                                                                                                  |
 | `SLACK_MCP_USERS_CACHE`           | No        | `~/Library/Caches/slack-mcp-server/users_cache.json` (macOS)<br>`~/.cache/slack-mcp-server/users_cache.json` (Linux)<br>`%LocalAppData%/slack-mcp-server/users_cache.json` (Windows) | Path to the users cache file. Used to cache Slack user information to avoid repeated API calls on startup. |
 | `SLACK_MCP_CHANNELS_CACHE`        | No        | `~/Library/Caches/slack-mcp-server/channels_cache_v2.json` (macOS)<br>`~/.cache/slack-mcp-server/channels_cache_v2.json` (Linux)<br>`%LocalAppData%/slack-mcp-server/channels_cache_v2.json` (Windows) | Path to the channels cache file. Used to cache Slack channel information to avoid repeated API calls on startup. |
 | `SLACK_MCP_LOG_LEVEL`             | No        | `info`                    | Log-level for stdout or stderr. Valid values are: `debug`, `info`, `warn`, `error`, `panic` and `fatal`                                                                                                                                                                                   |
 | `SLACK_MCP_GOVSLACK`              | No        | `nil`                     | Set to `true` to enable [GovSlack](https://slack.com/solutions/govslack) mode. Routes API calls to `slack-gov.com` endpoints instead of `slack.com` for FedRAMP-compliant government workspaces.                                                                                          |
-| `SLACK_MCP_ENABLED_TOOLS`         | No        | `nil`                     | Comma-separated list of tools to register. If empty, all read-only tools and usergroups tools are registered; write tools (`conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`) require their specific env var OR must be explicitly listed here. When a write tool is listed here, it's enabled without channel restrictions. Available tools: `conversations_history`, `conversations_replies`, `conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`, `conversations_search_messages`, `channels_list`, `usergroups_list`, `usergroups_me`, `usergroups_create`, `usergroups_update`, `usergroups_users_update`. |
+| `SLACK_MCP_ENABLED_TOOLS`         | No        | `nil`                     | Comma-separated list of tools to register. If empty, all read-only tools and usergroups tools are registered; write tools (`conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`) require their specific env var OR must be explicitly listed here. When a write tool is listed here, it's enabled without channel restrictions. Available tools: `conversations_history`, `conversations_replies`, `conversations_add_message`, `reactions_add`, `reactions_remove`, `attachment_get_data`, `conversations_search_messages`, `channels_list`, `usergroups_list`, `usergroups_me`, `usergroups_create`, `usergroups_update`, `usergroups_users_update`, `canvases_read`, `canvases_create`, `canvases_edit`. |
 
 *You need one of: `xoxp` (user), `xoxb` (bot), or both `xoxc`/`xoxd` tokens for authentication.
 

--- a/pkg/handler/canvases.go
+++ b/pkg/handler/canvases.go
@@ -1,0 +1,304 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/korotovsky/slack-mcp-server/pkg/provider"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/slack-go/slack"
+	"go.uber.org/zap"
+)
+
+// canvasEditOperations are the operations accepted by canvases.edit.
+// insert_before and insert_after additionally require a section_id.
+var canvasEditOperations = []string{
+	"insert_after",
+	"insert_at_end",
+	"insert_at_start",
+	"insert_before",
+	"replace",
+	"delete",
+}
+
+type CanvasSection struct {
+	ID string `json:"id"`
+}
+
+type CanvasReadResponse struct {
+	CanvasID string          `json:"canvas_id"`
+	Title    string          `json:"title,omitempty"`
+	Content  string          `json:"content"`
+	Sections []CanvasSection `json:"sections,omitempty"`
+}
+
+type CanvasCreateResponse struct {
+	CanvasID string `json:"canvas_id"`
+	Title    string `json:"title,omitempty"`
+}
+
+type CanvasesHandler struct {
+	apiProvider *provider.ApiProvider
+	logger      *zap.Logger
+}
+
+func NewCanvasesHandler(apiProvider *provider.ApiProvider, logger *zap.Logger) *CanvasesHandler {
+	return &CanvasesHandler{
+		apiProvider: apiProvider,
+		logger:      logger,
+	}
+}
+
+// CanvasesReadHandler returns a canvas's content along with the section IDs
+// needed to target an edit. Slack serves canvas content as HTML, not markdown.
+func (h *CanvasesHandler) CanvasesReadHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	h.logger.Debug("CanvasesReadHandler called", zap.Any("params", request.Params))
+
+	if ready, err := h.apiProvider.IsReady(); !ready {
+		h.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	canvasID := request.GetString("canvas_id", "")
+	if canvasID == "" {
+		return nil, errors.New("canvas_id must be provided")
+	}
+
+	includeSections := request.GetBool("include_sections", true)
+	containsText := request.GetString("contains_text", "")
+
+	api := h.apiProvider.Slack()
+
+	// Canvases are files, so the metadata and the download URL come from files.info.
+	file, _, _, err := api.GetFileInfoContext(ctx, canvasID, 0, 0)
+	if err != nil {
+		h.logger.Error("Failed to get canvas file info",
+			zap.String("canvas_id", canvasID),
+			zap.Error(err),
+		)
+		return nil, fmt.Errorf("failed to read canvas %s: %w", canvasID, err)
+	}
+
+	content, err := h.downloadCanvas(ctx, file.URLPrivateDownload)
+	if err != nil {
+		h.logger.Error("Failed to download canvas content",
+			zap.String("canvas_id", canvasID),
+			zap.Error(err),
+		)
+		return nil, fmt.Errorf("failed to download canvas %s: %w", canvasID, err)
+	}
+
+	response := CanvasReadResponse{
+		CanvasID: canvasID,
+		Title:    file.Title,
+		Content:  content,
+	}
+
+	// Section IDs are embedded in the content as `id` attributes, so they are
+	// parsed from there rather than fetched. canvases.sections.lookup requires a
+	// criteria filter and cannot enumerate every section, so it is only used
+	// when the caller is actually filtering.
+	if includeSections {
+		if containsText != "" {
+			sections, err := api.LookupCanvasSectionsContext(ctx, slack.LookupCanvasSectionsParams{
+				CanvasID: canvasID,
+				Criteria: slack.LookupCanvasSectionsCriteria{
+					ContainsText: containsText,
+				},
+			})
+			if err != nil {
+				h.logger.Error("Failed to look up canvas sections",
+					zap.String("canvas_id", canvasID),
+					zap.Error(err),
+				)
+				return nil, fmt.Errorf("failed to look up sections in canvas %s: %w", canvasID, err)
+			}
+			for _, section := range sections {
+				response.Sections = append(response.Sections, CanvasSection{ID: section.ID})
+			}
+		} else {
+			response.Sections = parseSectionIDs(content)
+		}
+	}
+
+	out, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+// CanvasesCreateHandler creates a standalone canvas from markdown.
+func (h *CanvasesHandler) CanvasesCreateHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	h.logger.Debug("CanvasesCreateHandler called", zap.Any("params", request.Params))
+
+	if ready, err := h.apiProvider.IsReady(); !ready {
+		h.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	title := request.GetString("title", "")
+	markdown := request.GetString("markdown", "")
+	if markdown == "" {
+		return nil, errors.New("markdown must be provided")
+	}
+
+	h.logger.Debug("Request parameters",
+		zap.String("title", title),
+		zap.Int("markdown_length", len(markdown)),
+	)
+
+	canvasID, err := h.apiProvider.Slack().CreateCanvasContext(ctx, title, slack.DocumentContent{
+		Type:     "markdown",
+		Markdown: markdown,
+	})
+	if err != nil {
+		h.logger.Error("CreateCanvasContext failed", zap.Error(err))
+		return nil, err
+	}
+
+	h.logger.Debug("Created canvas", zap.String("canvas_id", canvasID), zap.String("title", title))
+
+	result := CanvasCreateResponse{
+		CanvasID: canvasID,
+		Title:    title,
+	}
+
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		h.logger.Error("Failed to marshal created canvas to JSON", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// CanvasesEditHandler applies a single change to an existing canvas.
+func (h *CanvasesHandler) CanvasesEditHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	h.logger.Debug("CanvasesEditHandler called", zap.Any("params", request.Params))
+
+	if ready, err := h.apiProvider.IsReady(); !ready {
+		h.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	canvasID := request.GetString("canvas_id", "")
+	if canvasID == "" {
+		return nil, errors.New("canvas_id must be provided")
+	}
+
+	operation := request.GetString("operation", "")
+	if operation == "" {
+		return nil, errors.New("operation must be provided")
+	}
+	if !contains(canvasEditOperations, operation) {
+		return nil, fmt.Errorf("operation must be one of %s, got %q",
+			strings.Join(canvasEditOperations, ", "), operation)
+	}
+
+	sectionID := request.GetString("section_id", "")
+	if sectionID == "" && requiresSection(operation) {
+		return nil, fmt.Errorf("section_id is required for operation %q; "+
+			"use canvases_read to look up section IDs", operation)
+	}
+
+	markdown := request.GetString("markdown", "")
+	if markdown == "" && operation != "delete" {
+		return nil, errors.New("markdown must be provided for operations other than delete")
+	}
+
+	change := slack.CanvasChange{
+		Operation: operation,
+		SectionID: sectionID,
+		DocumentContent: slack.DocumentContent{
+			Type:     "markdown",
+			Markdown: markdown,
+		},
+	}
+
+	err := h.apiProvider.Slack().EditCanvasContext(ctx, slack.EditCanvasParams{
+		CanvasID: canvasID,
+		Changes:  []slack.CanvasChange{change},
+	})
+	if err != nil {
+		h.logger.Error("Failed to edit canvas",
+			zap.String("canvas_id", canvasID),
+			zap.String("operation", operation),
+			zap.Error(err),
+		)
+		return nil, fmt.Errorf("failed to edit canvas %s: %w", canvasID, err)
+	}
+
+	h.logger.Debug("Canvas edited",
+		zap.String("canvas_id", canvasID),
+		zap.String("operation", operation),
+	)
+
+	return mcp.NewToolResultText(
+		fmt.Sprintf("Applied %q to canvas %s.", operation, canvasID),
+	), nil
+}
+
+// downloadCanvas fetches canvas content from its private download URL. It goes
+// through the Slack client so the request carries the same auth as the API,
+// which works for both xoxp and xoxc/xoxd tokens.
+func (h *CanvasesHandler) downloadCanvas(ctx context.Context, url string) (string, error) {
+	if url == "" {
+		return "", errors.New("canvas has no downloadable content URL")
+	}
+
+	var buf bytes.Buffer
+	if err := h.apiProvider.Slack().GetFileContext(ctx, url, &buf); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// sectionIDPattern matches the `id` attribute Slack embeds on each canvas
+// block, e.g. `<h2 id="temp:C:AQB...">`.
+var sectionIDPattern = regexp.MustCompile(`id="(temp:[^"]+)"`)
+
+// parseSectionIDs extracts section IDs from canvas content in document order.
+// canvases.sections.lookup cannot enumerate sections without a filter, so the
+// IDs are read from the content itself.
+func parseSectionIDs(content string) []CanvasSection {
+	matches := sectionIDPattern.FindAllStringSubmatch(content, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool, len(matches))
+	sections := make([]CanvasSection, 0, len(matches))
+	for _, match := range matches {
+		id := match[1]
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		sections = append(sections, CanvasSection{ID: id})
+	}
+	return sections
+}
+
+func requiresSection(operation string) bool {
+	return operation == "insert_before" ||
+		operation == "insert_after" ||
+		operation == "replace" ||
+		operation == "delete"
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/handler/canvases.go
+++ b/pkg/handler/canvases.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/korotovsky/slack-mcp-server/pkg/provider"
@@ -197,7 +198,7 @@ func (h *CanvasesHandler) CanvasesEditHandler(ctx context.Context, request mcp.C
 	if operation == "" {
 		return nil, errors.New("operation must be provided")
 	}
-	if !contains(canvasEditOperations, operation) {
+	if !slices.Contains(canvasEditOperations, operation) {
 		return nil, fmt.Errorf("operation must be one of %s, got %q",
 			strings.Join(canvasEditOperations, ", "), operation)
 	}
@@ -292,13 +293,4 @@ func requiresSection(operation string) bool {
 		operation == "insert_after" ||
 		operation == "replace" ||
 		operation == "delete"
-}
-
-func contains(haystack []string, needle string) bool {
-	for _, v := range haystack {
-		if v == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/handler/canvases_test.go
+++ b/pkg/handler/canvases_test.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSectionIDs(t *testing.T) {
+	t.Run("extracts ids in document order", func(t *testing.T) {
+		content := `<div class="quip-canvas-content">` +
+			`<h1 id="temp:C:AAA1">Title</h1>` +
+			`<p id="temp:C:BBB2" class="line">Body</p>` +
+			`<h2 id="temp:C:CCC3">Section</h2>` +
+			`</div>`
+
+		sections := parseSectionIDs(content)
+
+		assert.Equal(t, []CanvasSection{
+			{ID: "temp:C:AAA1"},
+			{ID: "temp:C:BBB2"},
+			{ID: "temp:C:CCC3"},
+		}, sections)
+	})
+
+	t.Run("deduplicates repeated ids", func(t *testing.T) {
+		content := `<h1 id="temp:C:AAA1">A</h1><p id="temp:C:AAA1">A again</p>`
+
+		sections := parseSectionIDs(content)
+
+		assert.Equal(t, []CanvasSection{{ID: "temp:C:AAA1"}}, sections)
+	})
+
+	t.Run("ignores non-section ids", func(t *testing.T) {
+		content := `<div id="not-a-section"><h1 id="temp:C:AAA1">A</h1></div>`
+
+		sections := parseSectionIDs(content)
+
+		assert.Equal(t, []CanvasSection{{ID: "temp:C:AAA1"}}, sections)
+	})
+
+	t.Run("returns nil when there are no sections", func(t *testing.T) {
+		assert.Nil(t, parseSectionIDs("<div>no ids here</div>"))
+	})
+}
+
+func TestRequiresSection(t *testing.T) {
+	needs := []string{"insert_before", "insert_after", "replace", "delete"}
+	for _, op := range needs {
+		assert.True(t, requiresSection(op), "%s should require a section_id", op)
+	}
+
+	for _, op := range []string{"insert_at_start", "insert_at_end"} {
+		assert.False(t, requiresSection(op), "%s should not require a section_id", op)
+	}
+}

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -231,6 +231,12 @@ type SlackAPI interface {
 	GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*slack.File, []slack.Comment, *slack.Paging, error)
 	GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error
 
+	// Used to read and edit canvases. A canvas is a file, so its content is
+	// fetched with the file methods above; these cover section lookup and edits.
+	CreateCanvasContext(ctx context.Context, title string, documentContent slack.DocumentContent) (string, error)
+	LookupCanvasSectionsContext(ctx context.Context, params slack.LookupCanvasSectionsParams) ([]slack.CanvasSection, error)
+	EditCanvasContext(ctx context.Context, params slack.EditCanvasParams) error
+
 	// Used to get channel info (for unread counts with xoxp tokens)
 	GetConversationInfoContext(ctx context.Context, input *slack.GetConversationInfoInput) (*slack.Channel, error)
 
@@ -551,6 +557,18 @@ func (c *MCPSlackClient) GetFileContext(ctx context.Context, downloadURL string,
 
 func (c *MCPSlackClient) GetConversationInfoContext(ctx context.Context, input *slack.GetConversationInfoInput) (*slack.Channel, error) {
 	return c.slackClient.GetConversationInfoContext(ctx, input)
+}
+
+func (c *MCPSlackClient) CreateCanvasContext(ctx context.Context, title string, documentContent slack.DocumentContent) (string, error) {
+	return c.slackClient.CreateCanvasContext(ctx, title, documentContent)
+}
+
+func (c *MCPSlackClient) LookupCanvasSectionsContext(ctx context.Context, params slack.LookupCanvasSectionsParams) ([]slack.CanvasSection, error) {
+	return c.slackClient.LookupCanvasSectionsContext(ctx, params)
+}
+
+func (c *MCPSlackClient) EditCanvasContext(ctx context.Context, params slack.EditCanvasParams) error {
+	return c.slackClient.EditCanvasContext(ctx, params)
 }
 
 func (c *MCPSlackClient) ClientUserBoot(ctx context.Context) (*edge.ClientUserBootResponse, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -47,6 +47,9 @@ const (
 	ToolSavedList                   = "saved_list"
 	ToolSavedUpdate                 = "saved_update"
 	ToolSavedClearCompleted         = "saved_clear_completed"
+	ToolCanvasesRead                = "canvases_read"
+	ToolCanvasesCreate              = "canvases_create"
+	ToolCanvasesEdit                = "canvases_edit"
 )
 
 var ValidToolNames = []string{
@@ -72,6 +75,9 @@ var ValidToolNames = []string{
 	ToolSavedList,
 	ToolSavedUpdate,
 	ToolSavedClearCompleted,
+	ToolCanvasesRead,
+	ToolCanvasesCreate,
+	ToolCanvasesEdit,
 }
 
 func ValidateEnabledTools(tools []string) error {
@@ -588,6 +594,68 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.WithTitleAnnotation("Clear Completed Saved Items"),
 				mcp.WithDestructiveHintAnnotation(true),
 			), savedHandler.SavedClearCompletedHandler)
+		}
+	}
+
+	// Register canvas tools. Reading is gated behind the same opt-in flag as
+	// editing so that a single env var turns the feature on, matching how the
+	// other write-capable tools are enabled.
+	//
+	// Requires the canvases:read and canvases:write scopes on the token.
+	if shouldAddTool(ToolCanvasesRead, enabledTools, "SLACK_MCP_CANVAS_TOOL") {
+		canvasesHandler := handler.NewCanvasesHandler(provider, logger)
+
+		s.AddTool(mcp.NewTool(ToolCanvasesRead,
+			mcp.WithDescription("Read a Slack canvas along with the section IDs needed to target an edit with canvases_edit. Note that Slack returns canvas content as HTML, not markdown; each block carries the id attribute used as section_id. Requires the canvases:read scope."),
+			mcp.WithTitleAnnotation("Read Canvas"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithString("canvas_id",
+				mcp.Required(),
+				mcp.Description("ID of the canvas in format Fxxxxxxxxxx. A canvas is a file, so this is its file ID."),
+			),
+			mcp.WithBoolean("include_sections",
+				mcp.Description("If true (default), also returns section IDs, which canvases_edit needs to insert before/after or replace a specific section."),
+				mcp.DefaultBool(true),
+			),
+			mcp.WithString("contains_text",
+				mcp.Description("Only return sections whose text contains this string, via canvases.sections.lookup. Omit to return every section parsed from the content."),
+			),
+		), canvasesHandler.CanvasesReadHandler)
+
+		if shouldAddTool(ToolCanvasesCreate, enabledTools, "SLACK_MCP_CANVAS_TOOL") {
+			s.AddTool(mcp.NewTool(ToolCanvasesCreate,
+				mcp.WithDescription("Create a standalone Slack canvas from markdown. Returns the new canvas ID, which canvases_read and canvases_edit take as canvas_id. Requires the canvases:write scope."),
+				mcp.WithTitleAnnotation("Create Canvas"),
+				mcp.WithString("title",
+					mcp.Description("Title of the canvas, shown in the file list and the browser tab."),
+				),
+				mcp.WithString("markdown",
+					mcp.Required(),
+					mcp.Description("Initial canvas content as markdown. Headings become sections that canvases_edit can target."),
+				),
+			), canvasesHandler.CanvasesCreateHandler)
+		}
+
+		if shouldAddTool(ToolCanvasesEdit, enabledTools, "SLACK_MCP_CANVAS_TOOL") {
+			s.AddTool(mcp.NewTool(ToolCanvasesEdit,
+				mcp.WithDescription("Edit an existing Slack canvas by applying a markdown change: append or prepend content, insert relative to a section, replace a section, or delete one. Use canvases_read first to look up section IDs. Requires the canvases:write scope."),
+				mcp.WithTitleAnnotation("Edit Canvas"),
+				mcp.WithDestructiveHintAnnotation(true),
+				mcp.WithString("canvas_id",
+					mcp.Required(),
+					mcp.Description("ID of the canvas to edit, in format Fxxxxxxxxxx."),
+				),
+				mcp.WithString("operation",
+					mcp.Required(),
+					mcp.Description("One of: insert_at_end (append), insert_at_start (prepend), insert_after, insert_before, replace, delete. The last four act on section_id."),
+				),
+				mcp.WithString("markdown",
+					mcp.Description("Markdown content to apply. Required for every operation except delete."),
+				),
+				mcp.WithString("section_id",
+					mcp.Description("Section to act on, from canvases_read. Required for insert_after, insert_before, replace and delete."),
+				),
+			), canvasesHandler.CanvasesEditHandler)
 		}
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -116,6 +116,9 @@ func TestValidToolNames(t *testing.T) {
 			ToolSavedList:                   true,
 			ToolSavedUpdate:                 true,
 			ToolSavedClearCompleted:         true,
+			ToolCanvasesRead:                true,
+			ToolCanvasesCreate:              true,
+			ToolCanvasesEdit:                true,
 		}
 
 		assert.Equal(t, len(expectedTools), len(ValidToolNames), "ValidToolNames should have %d tools", len(expectedTools))
@@ -126,6 +129,9 @@ func TestValidToolNames(t *testing.T) {
 	})
 
 	t.Run("constants match their string values", func(t *testing.T) {
+		assert.Equal(t, "canvases_read", ToolCanvasesRead)
+		assert.Equal(t, "canvases_create", ToolCanvasesCreate)
+		assert.Equal(t, "canvases_edit", ToolCanvasesEdit)
 		assert.Equal(t, "conversations_history", ToolConversationsHistory)
 		assert.Equal(t, "conversations_replies", ToolConversationsReplies)
 		assert.Equal(t, "conversations_add_message", ToolConversationsAddMessage)
@@ -251,6 +257,44 @@ func TestShouldAddTool_WriteTool_AddMessage(t *testing.T) {
 
 		result := shouldAddTool(ToolConversationsAddMessage, []string{ToolConversationsHistory}, "SLACK_MCP_ADD_MESSAGE_TOOL")
 		assert.False(t, result, "write tool should NOT be registered when not in explicit enabledTools list")
+	})
+}
+
+func TestShouldAddTool_WriteTool_Canvases(t *testing.T) {
+	t.Run("empty enabledTools and no env var - not registered", func(t *testing.T) {
+		cleanup := setEnv("SLACK_MCP_CANVAS_TOOL", "")
+		defer cleanup()
+
+		result := shouldAddTool(ToolCanvasesRead, []string{}, "SLACK_MCP_CANVAS_TOOL")
+		assert.False(t, result, "canvases_read should NOT be registered when env var is not set")
+
+		result = shouldAddTool(ToolCanvasesCreate, []string{}, "SLACK_MCP_CANVAS_TOOL")
+		assert.False(t, result, "canvases_create should NOT be registered when env var is not set")
+
+		result = shouldAddTool(ToolCanvasesEdit, []string{}, "SLACK_MCP_CANVAS_TOOL")
+		assert.False(t, result, "canvases_edit should NOT be registered when env var is not set")
+	})
+
+	t.Run("empty enabledTools and env var set - registered", func(t *testing.T) {
+		cleanup := setEnv("SLACK_MCP_CANVAS_TOOL", "true")
+		defer cleanup()
+
+		result := shouldAddTool(ToolCanvasesRead, []string{}, "SLACK_MCP_CANVAS_TOOL")
+		assert.True(t, result, "canvases_read should be registered when env var is set")
+
+		result = shouldAddTool(ToolCanvasesCreate, []string{}, "SLACK_MCP_CANVAS_TOOL")
+		assert.True(t, result, "canvases_create should be registered when env var is set")
+
+		result = shouldAddTool(ToolCanvasesEdit, []string{}, "SLACK_MCP_CANVAS_TOOL")
+		assert.True(t, result, "canvases_edit should be registered when env var is set")
+	})
+
+	t.Run("explicit enabledTools includes tool - registered without env var", func(t *testing.T) {
+		cleanup := setEnv("SLACK_MCP_CANVAS_TOOL", "")
+		defer cleanup()
+
+		result := shouldAddTool(ToolCanvasesRead, []string{ToolCanvasesRead}, "SLACK_MCP_CANVAS_TOOL")
+		assert.True(t, result, "canvases_read should be registered when explicitly enabled")
 	})
 }
 


### PR DESCRIPTION
Closes #67 (open since July 2025).

Adds three tools: `canvases_read`, `canvases_create`, `canvases_edit`. Opt-in behind `SLACK_MCP_CANVAS_TOOL`, matching the `SLACK_MCP_ADD_MESSAGE_TOOL` / `SLACK_MCP_REACTION_TOOL` pattern. Requires `canvases:read` and `canvases:write`.

**Upfront:** I'm not a Go developer, and this was written with AI assistance. I've tried to compensate by matching your existing conventions closely and testing against a real workspace rather than trusting that it compiles. I'd rather say that plainly than have you discover it in review. Please be as blunt as you like about anything that isn't idiomatic.

## What I did to keep it reviewable

I read #123 and #125 before starting. Both were closed for mixing concerns, and you asked for "scoped PRs per feature", so this is canvas only, nothing else in the diff.

Followed the repo's existing patterns: `shouldAddTool` with an env var for opt-in, handler struct and preamble copied from `usergroups.go`, `h` receiver, `assert` + `t.Run` in tests, `slices.Contains` rather than a local helper, no doc comments on exported types (matching the other handlers, even though general Go style would add them). `gofmt` and `go vet` are clean.

**Deliberate omissions:** no `canvases_delete`, no `SetCanvasAccess` / `DeleteCanvasAccess`. The server currently has no hard-delete tool in any domain and doesn't manage permissions anywhere, so adding them felt like breaking your conventions rather than completing the feature. Happy to add them if you'd prefer.

## Two things the API forced

- `canvases.sections.lookup` returns `invalid_arguments` without a criteria filter, so it can't enumerate a canvas. Section IDs are parsed from the `id` attributes in the content instead, and the API is only called when `contains_text` is passed.
- Canvas content comes back as HTML, not markdown, though writes take markdown. The read field is named `content` rather than `markdown` so it isn't misleading, and the tool description states the asymmetry.

On the `xoxc`/`xoxd` question you raised in #123: reads go through the existing `GetFileContext` path, so both token types share one code path with no blob handling. Writes go through the SDK's `canvases.*` methods. I've only tested with `xoxp`, so `xoxc`/`xoxd` is unverified.

## Testing

Exercised through MCP against a real workspace, not just at the API level: create, read (content and section IDs), `insert_after` / `replace` / `insert_at_end`, and client-side validation for a missing `section_id`. That end-to-end testing caught two bugs that direct API testing missed (the section lookup failing silently, and the mislabelled `markdown` field), both fixed before this PR.

Test suite passes. `TestIntegrationConversations` in `pkg/handler` fails identically on unmodified `master` (needs `SLACK_MCP_OPENAI_API`).