### PR TITLE
feat(conversations): surface thread reply count and latest reply ts

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -59,6 +59,8 @@ type Message struct {
 	FileCount     int    `json:"fileCount,omitempty"`
 	AttachmentIDs string `json:"attachmentIDs,omitempty"`
 	HasMedia      bool   `json:"hasMedia,omitempty"`
+	ReplyCount    int    `json:"replyCount,omitempty"`
+	LatestReply   string `json:"latestReply,omitempty"`
 	Cursor        string `json:"cursor"`
 }
 
@@ -1608,6 +1610,8 @@ func (ch *ConversationsHandler) convertMessagesFromHistory(ctx context.Context, 
 			FileCount:     fileCount,
 			AttachmentIDs: attachmentIDsStr,
 			HasMedia:      hasMedia,
+			ReplyCount:    msg.ReplyCount,
+			LatestReply:   msg.LatestReply,
 		})
 	}
 

--- a/pkg/handler/conversations_test.go
+++ b/pkg/handler/conversations_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gocarina/gocsv"
 	"github.com/google/uuid"
 	"github.com/korotovsky/slack-mcp-server/pkg/test/util"
 	"github.com/openai/openai-go"
@@ -652,4 +653,38 @@ func TestUnitIsSlackUserIDPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnitMessageCSVIncludesThreadReplyFields(t *testing.T) {
+	messages := []Message{
+		{
+			MsgID:    "1772680334.954409",
+			UserID:   "U0123456789",
+			UserName: "john.doe",
+			Channel:  "C0AJMCRNH0U",
+			Text:     "thread parent",
+			Time:     "2026-03-03T12:00:00Z",
+			// A parent: replies exist, and LatestReply marks the newest one.
+			ReplyCount:  4,
+			LatestReply: "1772680900.111111",
+		},
+		{
+			MsgID:    "1772680500.222222",
+			UserID:   "U0123456789",
+			UserName: "john.doe",
+			Channel:  "C0AJMCRNH0U",
+			Text:     "standalone message",
+			Time:     "2026-03-03T12:05:00Z",
+			// Not a parent: both fields are zero and omitted from JSON.
+		},
+	}
+
+	csvBytes, err := gocsv.MarshalBytes(&messages)
+	require.NoError(t, err)
+	csvStr := string(csvBytes)
+
+	assert.Contains(t, csvStr, "ReplyCount")
+	assert.Contains(t, csvStr, "LatestReply")
+	assert.Contains(t, csvStr, "1772680900.111111")
+	assert.Contains(t, csvStr, "4")
 }


### PR DESCRIPTION
`conversations_history` and `conversations_replies` return a message's own fields but nothing about its thread, so a client cannot tell whether a message has replies — or whether any arrived recently — without issuing a `conversations_replies` call per message.

Slack already returns both values on the message payload. This exposes them as two optional columns:

- `ReplyCount` — number of replies on the message (0 when not a parent)
- `LatestReply` — ts of the most recent reply ("" when not a parent)

Both are `omitempty`, so non-parent messages are unchanged in the output.

This makes an incremental read cheap: fetch a window of history once, then fetch replies only for parents whose `LatestReply` is newer than the last timestamp already seen. Without it the only correct options are a replies call for every message, or missing replies that land on a parent older than the window.

Adds `TestUnitMessageCSVIncludesThreadReplyFields`. 4 lines of implementation.