### PR TITLE
feat(conversations): add scheduled-message tools

### DIFF
--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -101,6 +101,24 @@ type addMessageParams struct {
 	blocks      []slack.Block
 }
 
+type scheduleMessageParams struct {
+	channel     string
+	text        string
+	postAt      string // unix epoch seconds as string, as required by ScheduleMessageContext
+	contentType string
+	threadTs    string
+}
+
+type scheduledMessagesListParams struct {
+	channel string
+	limit   int
+}
+
+type deleteScheduledMessageParams struct {
+	channel            string
+	scheduledMessageID string
+}
+
 type addReactionParams struct {
 	channel   string
 	timestamp string
@@ -497,6 +515,178 @@ func (ch *ConversationsHandler) FilesGetHandler(ctx context.Context, request mcp
 
 func isImageMimetype(mimetype string) bool {
 	return strings.HasPrefix(mimetype, "image/")
+}
+
+// ScheduledMessageRow is the CSV output row for scheduled messages
+type ScheduledMessageRow struct {
+	ID      string `csv:"ID"`
+	Channel string `csv:"Channel"`
+	PostAt  string `csv:"PostAt"`
+	Text    string `csv:"Text"`
+}
+
+// ConversationsScheduleMessageHandler schedules a message for future delivery
+func (ch *ConversationsHandler) ConversationsScheduleMessageHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsScheduleMessageHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	params, err := ch.parseParamsToolScheduleMessage(ctx, request)
+	if err != nil {
+		ch.logger.Error("Failed to parse schedule-message params", zap.Error(err))
+		return nil, err
+	}
+
+	var options []slack.MsgOption
+	if params.threadTs != "" {
+		options = append(options, slack.MsgOptionTS(params.threadTs))
+	}
+
+	switch params.contentType {
+	case "text/plain":
+		options = append(options, slack.MsgOptionDisableMarkdown())
+		options = append(options, slack.MsgOptionText(params.text, false))
+	case "text/markdown":
+		blocks, err := slackGoUtil.ConvertMarkdownTextToBlocks(params.text)
+		if err != nil {
+			ch.logger.Warn("Markdown parsing error, falling back to plain text", zap.Error(err))
+			options = append(options, slack.MsgOptionDisableMarkdown())
+			options = append(options, slack.MsgOptionText(params.text, false))
+		} else {
+			options = append(options, slack.MsgOptionBlocks(blocks...))
+		}
+	default:
+		return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")
+	}
+
+	ch.logger.Debug("Scheduling Slack message",
+		zap.String("channel", params.channel),
+		zap.String("post_at", params.postAt),
+		zap.String("thread_ts", params.threadTs),
+		zap.String("content_type", params.contentType),
+	)
+
+	respChannel, scheduledMessageID, err := ch.apiProvider.Slack().ScheduleMessageContext(ctx, params.channel, params.postAt, options...)
+	if err != nil {
+		ch.logger.Error("Slack ScheduleMessageContext failed", zap.Error(err))
+		return nil, err
+	}
+
+	postAtInt, _ := strconv.Atoi(params.postAt)
+	postAtUTC := time.Unix(int64(postAtInt), 0).UTC().Format(time.RFC3339)
+
+	rows := []ScheduledMessageRow{
+		{
+			ID:      scheduledMessageID,
+			Channel: respChannel,
+			PostAt:  postAtUTC,
+			Text:    params.text,
+		},
+	}
+
+	csvBytes, err := gocsv.MarshalBytes(&rows)
+	if err != nil {
+		ch.logger.Error("Failed to marshal scheduled message to CSV", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(csvBytes)), nil
+}
+
+// ConversationsScheduledMessagesListHandler lists pending scheduled messages
+func (ch *ConversationsHandler) ConversationsScheduledMessagesListHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsScheduledMessagesListHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	params := ch.parseParamsToolScheduledMessagesList(request)
+
+	listParams := &slack.GetScheduledMessagesParameters{
+		Limit: params.limit,
+	}
+	if params.channel != "" {
+		resolvedChannel, err := ch.resolveChannelID(ctx, params.channel)
+		if err != nil {
+			ch.logger.Error("Channel not found", zap.String("channel", params.channel), zap.Error(err))
+			return nil, err
+		}
+		listParams.Channel = resolvedChannel
+	}
+
+	messages, _, err := ch.apiProvider.Slack().GetScheduledMessagesContext(ctx, listParams)
+	if err != nil {
+		ch.logger.Error("Slack GetScheduledMessagesContext failed", zap.Error(err))
+		return nil, err
+	}
+
+	if len(messages) == 0 {
+		return mcp.NewToolResultText("No scheduled messages found."), nil
+	}
+
+	rows := make([]ScheduledMessageRow, 0, len(messages))
+	for _, msg := range messages {
+		postAtUTC := time.Unix(int64(msg.PostAt), 0).UTC().Format(time.RFC3339)
+		preview := msg.Text
+		if len(preview) > 100 {
+			preview = preview[:100] + "..."
+		}
+		rows = append(rows, ScheduledMessageRow{
+			ID:      msg.ID,
+			Channel: msg.Channel,
+			PostAt:  postAtUTC,
+			Text:    preview,
+		})
+	}
+
+	csvBytes, err := gocsv.MarshalBytes(&rows)
+	if err != nil {
+		ch.logger.Error("Failed to marshal scheduled messages to CSV", zap.Error(err))
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(string(csvBytes)), nil
+}
+
+// ConversationsDeleteScheduledMessageHandler cancels a pending scheduled message
+func (ch *ConversationsHandler) ConversationsDeleteScheduledMessageHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ch.logger.Debug("ConversationsDeleteScheduledMessageHandler called", zap.Any("params", request.Params))
+
+	if ready, err := ch.apiProvider.IsReady(); !ready {
+		ch.logger.Error("API provider not ready", zap.Error(err))
+		return nil, err
+	}
+
+	params, err := ch.parseParamsToolDeleteScheduledMessage(ctx, request)
+	if err != nil {
+		ch.logger.Error("Failed to parse delete-scheduled-message params", zap.Error(err))
+		return nil, err
+	}
+
+	deleteParams := &slack.DeleteScheduledMessageParameters{
+		Channel:            params.channel,
+		ScheduledMessageID: params.scheduledMessageID,
+	}
+
+	ok, err := ch.apiProvider.Slack().DeleteScheduledMessageContext(ctx, deleteParams)
+	if err != nil {
+		ch.logger.Error("Slack DeleteScheduledMessageContext failed", zap.Error(err))
+		return nil, err
+	}
+	if !ok {
+		return mcp.NewToolResultText(fmt.Sprintf("Failed to delete scheduled message %s (not found or already sent)", params.scheduledMessageID)), nil
+	}
+
+	ch.logger.Info("Deleted scheduled message",
+		zap.String("channel", params.channel),
+		zap.String("scheduled_message_id", params.scheduledMessageID))
+
+	return mcp.NewToolResultText(fmt.Sprintf("Successfully deleted scheduled message %s from channel %s", params.scheduledMessageID, params.channel)), nil
 }
 
 func isTextMimetype(mimetype string) bool {
@@ -2457,4 +2647,108 @@ func hasImageBlocks(blocks slack.Blocks) bool {
 		}
 	}
 	return false
+}
+
+func (ch *ConversationsHandler) parseParamsToolScheduleMessage(ctx context.Context, request mcp.CallToolRequest) (*scheduleMessageParams, error) {
+	toolConfig := os.Getenv("SLACK_MCP_SCHEDULE_TOOL")
+	enabledTools := os.Getenv("SLACK_MCP_ENABLED_TOOLS")
+
+	if toolConfig == "" {
+		if !strings.Contains(enabledTools, "conversations_schedule_message") {
+			ch.logger.Error("Schedule-message tool disabled by default")
+			return nil, errors.New(
+				"by default, the conversations_schedule_message tool is disabled to guard Slack workspaces against accidental scheduled sends. " +
+					"To enable it, set the SLACK_MCP_SCHEDULE_TOOL environment variable to true, 1, or comma separated list of channels " +
+					"to limit where the MCP can schedule messages, e.g. 'SLACK_MCP_SCHEDULE_TOOL=C1234567890,D0987654321', " +
+					"'SLACK_MCP_SCHEDULE_TOOL=!C1234567890' to enable all except one, or 'SLACK_MCP_SCHEDULE_TOOL=true' for all channels and DMs",
+			)
+		}
+		toolConfig = "true"
+	}
+
+	channel := request.GetString("channel_id", "")
+	if channel == "" {
+		ch.logger.Error("channel_id missing in schedule-message params")
+		return nil, errors.New("channel_id must be a string")
+	}
+	resolvedChannel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		ch.logger.Error("Channel not found", zap.String("channel", channel), zap.Error(err))
+		return nil, err
+	}
+	if !isChannelAllowedForConfig(resolvedChannel, toolConfig) {
+		ch.logger.Warn("Schedule-message tool not allowed for channel", zap.String("channel", resolvedChannel), zap.String("policy", toolConfig))
+		return nil, fmt.Errorf("conversations_schedule_message tool is not allowed for channel %q, applied policy: %s", resolvedChannel, toolConfig)
+	}
+
+	msgText := request.GetString("text", "")
+	if msgText == "" {
+		ch.logger.Error("Message text missing")
+		return nil, errors.New("text must be a string")
+	}
+
+	postAtInt := request.GetInt("post_at", 0)
+	if postAtInt <= 0 {
+		ch.logger.Error("Invalid post_at value", zap.Int("post_at", postAtInt))
+		return nil, errors.New("post_at must be a positive unix epoch timestamp (seconds)")
+	}
+	postAt := strconv.Itoa(postAtInt)
+
+	contentType := request.GetString("content_type", "text/markdown")
+	if contentType != "text/plain" && contentType != "text/markdown" {
+		ch.logger.Error("Invalid content_type", zap.String("content_type", contentType))
+		return nil, errors.New("content_type must be either 'text/plain' or 'text/markdown'")
+	}
+
+	threadTs := request.GetString("thread_ts", "")
+	if threadTs != "" && !strings.Contains(threadTs, ".") {
+		ch.logger.Error("Invalid thread_ts format", zap.String("thread_ts", threadTs))
+		return nil, errors.New("thread_ts must be a valid timestamp in format 1234567890.123456")
+	}
+
+	return &scheduleMessageParams{
+		channel:     resolvedChannel,
+		text:        msgText,
+		postAt:      postAt,
+		contentType: contentType,
+		threadTs:    threadTs,
+	}, nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolScheduledMessagesList(request mcp.CallToolRequest) *scheduledMessagesListParams {
+	limit := request.GetInt("limit", 100)
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	return &scheduledMessagesListParams{
+		channel: request.GetString("channel_id", ""),
+		limit:   limit,
+	}
+}
+
+func (ch *ConversationsHandler) parseParamsToolDeleteScheduledMessage(ctx context.Context, request mcp.CallToolRequest) (*deleteScheduledMessageParams, error) {
+	channel := request.GetString("channel_id", "")
+	if channel == "" {
+		ch.logger.Error("channel_id missing in delete-scheduled-message params")
+		return nil, errors.New("channel_id is required")
+	}
+	resolvedChannel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		ch.logger.Error("Channel not found", zap.String("channel", channel), zap.Error(err))
+		return nil, err
+	}
+
+	scheduledMessageID := request.GetString("scheduled_message_id", "")
+	if scheduledMessageID == "" {
+		ch.logger.Error("scheduled_message_id missing")
+		return nil, errors.New("scheduled_message_id is required")
+	}
+
+	return &deleteScheduledMessageParams{
+		channel:            resolvedChannel,
+		scheduledMessageID: scheduledMessageID,
+	}, nil
 }

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -257,6 +257,11 @@ type SlackAPI interface {
 	CreateUserGroupContext(ctx context.Context, userGroup slack.UserGroup, options ...slack.CreateUserGroupOption) (slack.UserGroup, error)
 	UpdateUserGroupContext(ctx context.Context, userGroupID string, options ...slack.UpdateUserGroupsOption) (slack.UserGroup, error)
 	UpdateUserGroupMembersContext(ctx context.Context, userGroup string, members string, options ...slack.UpdateUserGroupMembersOption) (slack.UserGroup, error)
+
+	// Scheduled message API methods
+	ScheduleMessageContext(ctx context.Context, channelID, postAt string, options ...slack.MsgOption) (string, string, error)
+	GetScheduledMessagesContext(ctx context.Context, params *slack.GetScheduledMessagesParameters) ([]slack.ScheduledMessage, string, error)
+	DeleteScheduledMessageContext(ctx context.Context, params *slack.DeleteScheduledMessageParameters) (bool, error)
 }
 
 type MCPSlackClient struct {
@@ -599,6 +604,18 @@ func (c *MCPSlackClient) UpdateUserGroupContext(ctx context.Context, userGroupID
 
 func (c *MCPSlackClient) UpdateUserGroupMembersContext(ctx context.Context, userGroup string, members string, options ...slack.UpdateUserGroupMembersOption) (slack.UserGroup, error) {
 	return c.slackClient.UpdateUserGroupMembersContext(ctx, userGroup, members, options...)
+}
+
+func (c *MCPSlackClient) ScheduleMessageContext(ctx context.Context, channelID, postAt string, options ...slack.MsgOption) (string, string, error) {
+	return c.slackClient.ScheduleMessageContext(ctx, channelID, postAt, options...)
+}
+
+func (c *MCPSlackClient) GetScheduledMessagesContext(ctx context.Context, params *slack.GetScheduledMessagesParameters) ([]slack.ScheduledMessage, string, error) {
+	return c.slackClient.GetScheduledMessagesContext(ctx, params)
+}
+
+func (c *MCPSlackClient) DeleteScheduledMessageContext(ctx context.Context, params *slack.DeleteScheduledMessageParameters) (bool, error) {
+	return c.slackClient.DeleteScheduledMessageContext(ctx, params)
 }
 
 func (c *MCPSlackClient) IsEnterprise() bool {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,28 +25,31 @@ type MCPServer struct {
 }
 
 const (
-	ToolConversationsHistory        = "conversations_history"
-	ToolConversationsReplies        = "conversations_replies"
-	ToolConversationsAddMessage     = "conversations_add_message"
-	ToolReactionsAdd                = "reactions_add"
-	ToolReactionsRemove             = "reactions_remove"
-	ToolAttachmentGetData           = "attachment_get_data"
-	ToolConversationsSearchMessages = "conversations_search_messages"
-	ToolConversationsUnreads        = "conversations_unreads"
-	ToolConversationsMark           = "conversations_mark"
-	ToolConversationsLeave          = "conversations_leave"
-	ToolConversationsJoin           = "conversations_join"
-	ToolChannelsList                = "channels_list"
-	ToolChannelsMe                  = "channels_me"
-	ToolUsergroupsList              = "usergroups_list"
-	ToolUsergroupsMe                = "usergroups_me"
-	ToolUsergroupsCreate            = "usergroups_create"
-	ToolUsergroupsUpdate            = "usergroups_update"
-	ToolUsergroupsUsersUpdate       = "usergroups_users_update"
-	ToolUsersSearch                 = "users_search"
-	ToolSavedList                   = "saved_list"
-	ToolSavedUpdate                 = "saved_update"
-	ToolSavedClearCompleted         = "saved_clear_completed"
+	ToolConversationsHistory               = "conversations_history"
+	ToolConversationsReplies               = "conversations_replies"
+	ToolConversationsAddMessage            = "conversations_add_message"
+	ToolReactionsAdd                       = "reactions_add"
+	ToolReactionsRemove                    = "reactions_remove"
+	ToolAttachmentGetData                  = "attachment_get_data"
+	ToolConversationsSearchMessages        = "conversations_search_messages"
+	ToolConversationsUnreads               = "conversations_unreads"
+	ToolConversationsMark                  = "conversations_mark"
+	ToolConversationsLeave                 = "conversations_leave"
+	ToolConversationsJoin                  = "conversations_join"
+	ToolChannelsList                       = "channels_list"
+	ToolChannelsMe                         = "channels_me"
+	ToolUsergroupsList                     = "usergroups_list"
+	ToolUsergroupsMe                       = "usergroups_me"
+	ToolUsergroupsCreate                   = "usergroups_create"
+	ToolUsergroupsUpdate                   = "usergroups_update"
+	ToolUsergroupsUsersUpdate              = "usergroups_users_update"
+	ToolUsersSearch                        = "users_search"
+	ToolSavedList                          = "saved_list"
+	ToolSavedUpdate                        = "saved_update"
+	ToolSavedClearCompleted                = "saved_clear_completed"
+	ToolConversationsScheduleMessage       = "conversations_schedule_message"
+	ToolConversationsScheduledMessagesList = "conversations_scheduled_messages_list"
+	ToolConversationsDeleteScheduledMsg    = "conversations_delete_scheduled_message"
 )
 
 var ValidToolNames = []string{
@@ -72,6 +75,9 @@ var ValidToolNames = []string{
 	ToolSavedList,
 	ToolSavedUpdate,
 	ToolSavedClearCompleted,
+	ToolConversationsScheduleMessage,
+	ToolConversationsScheduledMessagesList,
+	ToolConversationsDeleteScheduledMsg,
 }
 
 func ValidateEnabledTools(tools []string) error {
@@ -589,6 +595,65 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.WithDestructiveHintAnnotation(true),
 			), savedHandler.SavedClearCompletedHandler)
 		}
+	}
+
+	// Scheduled message tools (gated behind SLACK_MCP_SCHEDULE_TOOL for send, always-on for read/delete)
+	if shouldAddTool(ToolConversationsScheduleMessage, enabledTools, "SLACK_MCP_SCHEDULE_TOOL") {
+		s.AddTool(mcp.NewTool(ToolConversationsScheduleMessage,
+			mcp.WithDescription("Schedule a message for future delivery to a public channel, private channel, or direct message (DM). The message will be sent at the specified unix epoch time. Requires SLACK_MCP_SCHEDULE_TOOL to be enabled."),
+			mcp.WithTitleAnnotation("Schedule Message"),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... aka #general or @username_dm."),
+			),
+			mcp.WithString("text",
+				mcp.Required(),
+				mcp.Description("Message text in specified content_type format. Example: 'Hello, world!' for text/plain or '# Hello, world!' for text/markdown."),
+			),
+			mcp.WithNumber("post_at",
+				mcp.Required(),
+				mcp.Description("Unix epoch timestamp (seconds) when the message should be delivered. Must be in the future. Example: 1735689600 for 2025-01-01 00:00:00 UTC."),
+			),
+			mcp.WithString("content_type",
+				mcp.DefaultString("text/markdown"),
+				mcp.Description("Content type of the message. Default is 'text/markdown'. Allowed values: 'text/markdown', 'text/plain'."),
+			),
+			mcp.WithString("thread_ts",
+				mcp.Description("Unique identifier of a thread's parent message if posting as a reply. Optional."),
+			),
+		), conversationsHandler.ConversationsScheduleMessageHandler)
+	}
+
+	if shouldAddTool(ToolConversationsScheduledMessagesList, enabledTools, "") {
+		s.AddTool(mcp.NewTool(ToolConversationsScheduledMessagesList,
+			mcp.WithDescription("List pending scheduled messages. Returns CSV with id, channel, post_at (UTC), and text preview. Optionally filter by channel."),
+			mcp.WithTitleAnnotation("List Scheduled Messages"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithString("channel_id",
+				mcp.Description("Optional channel ID to filter scheduled messages. If not provided, returns all scheduled messages."),
+			),
+			mcp.WithNumber("limit",
+				mcp.DefaultNumber(100),
+				mcp.Description("Maximum number of scheduled messages to return. Default is 100."),
+			),
+		), conversationsHandler.ConversationsScheduledMessagesListHandler)
+	}
+
+	if shouldAddTool(ToolConversationsDeleteScheduledMsg, enabledTools, "") {
+		s.AddTool(mcp.NewTool(ToolConversationsDeleteScheduledMsg,
+			mcp.WithDescription("Cancel a pending scheduled message before it is delivered. Get the scheduled_message_id from conversations_scheduled_messages_list."),
+			mcp.WithTitleAnnotation("Delete Scheduled Message"),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithString("channel_id",
+				mcp.Required(),
+				mcp.Description("ID of the channel the scheduled message was sent to, in format Cxxxxxxxxxx."),
+			),
+			mcp.WithString("scheduled_message_id",
+				mcp.Required(),
+				mcp.Description("ID of the scheduled message to cancel. Get this from conversations_scheduled_messages_list."),
+			),
+		), conversationsHandler.ConversationsDeleteScheduledMessageHandler)
 	}
 
 	logger.Info("Authenticating with Slack API...",

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -116,6 +116,10 @@ func TestValidToolNames(t *testing.T) {
 			ToolSavedList:                   true,
 			ToolSavedUpdate:                 true,
 			ToolSavedClearCompleted:         true,
+
+			ToolConversationsScheduleMessage:       true,
+			ToolConversationsScheduledMessagesList: true,
+			ToolConversationsDeleteScheduledMsg:    true,
 		}
 
 		assert.Equal(t, len(expectedTools), len(ValidToolNames), "ValidToolNames should have %d tools", len(expectedTools))


### PR DESCRIPTION
Adds three tools wrapping Slack's scheduled-message API, so a message can be composed now and delivered later:

| Tool | Slack method |
|---|---|
| `conversations_schedule_message` | `chat.scheduleMessage` |
| `conversations_scheduled_messages_list` | `chat.scheduledMessages.list` |
| `conversations_delete_scheduled_message` | `chat.deleteScheduledMessage` |

Motivation: messaging a colleague in another timezone currently means either sending at a bad local hour or a human remembering to send later. Slack supports scheduling natively; the server had no way to reach it.

- `schedule` takes the same channel/text/content_type/thread_ts shape as `conversations_add_message`, plus `post_at` (unix epoch seconds).
- `list` and `delete` are the read and reversal halves, so a scheduled send is inspectable and cancellable rather than fire-and-forget.
- `schedule` and `delete` are gated behind `SLACK_MCP_SCHEDULE_TOOL`, matching the existing pattern for `conversations_add_message`. `list` is read-only and always available.

Also adds the three tool names to `server_test.go`'s `expectedTools` map, which `TestValidToolNames` asserts against exhaustively.