### PR TITLE
fix(auth): send OAuth tokens as bearer headers

### DIFF
--- a/pkg/transport/bearer_auth_test.go
+++ b/pkg/transport/bearer_auth_test.go
@@ -1,0 +1,76 @@
+package transport
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestUserAgentTransport_RoundTrip_movesOAuthTokenToBearerHeader(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{name: "user token", token: "xoxp-test-token"},
+		{name: "bot token", token: "xoxb-test-token"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given
+			request, err := http.NewRequest(http.MethodPost, "https://slack.com/api/auth.test", strings.NewReader("token="+test.token+"&team=T123"))
+			if err != nil {
+				t.Fatalf("create request: %v", err)
+			}
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			var authorization string
+			var body string
+			transport := NewUserAgentTransport(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				authorization = req.Header.Get("Authorization")
+				requestBody, readErr := io.ReadAll(req.Body)
+				if readErr != nil {
+					t.Fatalf("read request body: %v", readErr)
+				}
+				body = string(requestBody)
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			}), "test-agent", nil, zap.NewNop())
+
+			// When
+			response, err := transport.RoundTrip(request)
+			if err != nil {
+				t.Fatalf("round trip: %v", err)
+			}
+			defer response.Body.Close()
+
+			// Then
+			if authorization != "Bearer "+test.token {
+				t.Fatalf("authorization = %q, want bearer token", authorization)
+			}
+			form, err := url.ParseQuery(body)
+			if err != nil {
+				t.Fatalf("parse request body: %v", err)
+			}
+			if form.Get("token") != "" {
+				t.Fatalf("form token = %q, want empty", form.Get("token"))
+			}
+			if form.Get("team") != "T123" {
+				t.Fatalf("team = %q, want T123", form.Get("team"))
+			}
+		})
+	}
+}

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -2,12 +2,15 @@ package transport
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -65,6 +68,29 @@ func NewUserAgentTransport(roundTripper http.RoundTripper, userAgent string, coo
 func (t *UserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	clonedReq := req.Clone(req.Context())
 	clonedReq.Header.Set("User-Agent", t.userAgent)
+
+	if clonedReq.Body != nil && clonedReq.Header.Get("Authorization") == "" {
+		mediaType, _, err := mime.ParseMediaType(clonedReq.Header.Get("Content-Type"))
+		if err == nil && mediaType == "application/x-www-form-urlencoded" {
+			body, err := io.ReadAll(clonedReq.Body)
+			if err != nil {
+				return nil, fmt.Errorf("read request body: %w", err)
+			}
+			clonedReq.Body = io.NopCloser(bytes.NewReader(body))
+
+			form, err := url.ParseQuery(string(body))
+			if err == nil {
+				token := form.Get("token")
+				if strings.HasPrefix(token, "xoxp-") || strings.HasPrefix(token, "xoxb-") {
+					clonedReq.Header.Set("Authorization", "Bearer "+token)
+					form.Del("token")
+					body = []byte(form.Encode())
+					clonedReq.Body = io.NopCloser(bytes.NewReader(body))
+					clonedReq.ContentLength = int64(len(body))
+				}
+			}
+		}
+	}
 
 	for _, cookie := range t.cookies {
 		clonedReq.AddCookie(cookie)


### PR DESCRIPTION
## Summary

The Slack client sends OAuth user and bot tokens in the form `token` field. For the affected credential, `auth.test` succeeds with `Authorization: Bearer` and returns `invalid_auth` when the same token is sent as a form field.

Move `xoxp-` and `xoxb-` tokens from form-encoded requests into the bearer header in `UserAgentTransport`, preserving other form fields. Existing authorization headers and non-OAuth token types are unchanged.

## Verification

- Added a transport regression test for both `xoxp-` and `xoxb-` tokens. It verifies the bearer header, token removal from the form body, and preservation of other fields.
- `go test -race -shuffle=on -count=1 ./pkg/transport` passes.
- A fork release was installed with mise and used by a fresh MCP session to complete one read-only `channels_list` call without an authentication error.

The full suite also includes credential-dependent integration tests, which were not run with credentials.