### PR TITLE
ci: test the PR head, and stop skipping 55 of 73 tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ deps: ## Download dependencies
 	$(GO) mod download
 
 .PHONY: test
-test: ## Run the tests
-	$(GO) test -count=1 -v -run=".*Unit.*" ./...
+test: ## Run all tests except the integration ones
+	$(GO) test -count=1 -v -skip=".*Integration.*" ./...
 
 .PHONY: test-integration
 test-integration: ## Run integration tests


### PR DESCRIPTION
Fixes parts 2 and 3 of #341. Part 1 (the empty `#testcase-1` fixture) is deliberately **not** addressed here — see "Why part 1 is not in this PR" below.

Three files, four changed lines.

## 1. PR checks now test the PR (`ci:` commit)

Both test workflows triggered on `pull_request_target` with a ref-less `actions/checkout`. For that event `github.ref` is the **base** branch, so every PR check built and tested `master`, never the PR.

Evidence from run [`31907489580`](https://github.com/korotovsky/slack-mcp-server/actions/runs/31907489580) (unit tests on #339):

```
[command]/usr/bin/git checkout --progress --force -B master refs/remotes/origin/master
...
ok  github.com/korotovsky/slack-mcp-server/pkg/server  2.244s [no tests to run]
```

\#339 adds tests to `pkg/server/tools_test.go`. Had the PR head been checked out, `pkg/server` could not have printed `[no tests to run]`.

**`unit-tests.yaml`: `pull_request_target:` → `pull_request:`.** It uses no secrets, so running fork code is safe. This is the same trigger block `security-trivy.yaml` already uses in this repo:

```yaml
on:
  push:
    branches:
      - master
  pull_request:
  workflow_dispatch:
```

**`integration-tests.yaml`: the PR trigger is dropped** (`push: master` + `workflow_dispatch` remain).

I want to be explicit about why it is *dropped* rather than pointed at the PR head. That job holds `SLACK_MCP_XOXP_TOKEN`, `SLACK_MCP_OPENAI_API` and `NGROK_AUTH_TOKEN`. Adding `ref: ${{ github.event.pull_request.head.sha }}` under `pull_request_target` would execute fork-authored code with those secrets in scope — the [pwn request](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) pattern — and would hand a live Slack user token to anyone who opens a PR. The current config is useless for testing but is *not* vulnerable, and I did not want to trade one for the other.

Nothing is lost by dropping it: on PRs the job only ever re-tested `master`, which the `push` trigger already covers. What is gained is that the 31 open PRs stop carrying a red X they did not cause.

If you'd rather keep integration coverage on PRs, the safe shape is a `pull_request` trigger plus a GitHub Environment with required reviewers, so fork PRs wait for your approval before secrets are released. That needs an Environment created in repo settings, so it can't be done in a PR alone — happy to follow up if you set one up.

## 2. All tests actually run (`test:` commit)

`make test` used `-run=".*Unit.*"` and `make test-integration` uses `-run=".*Integration.*"`. Functions named after neither convention matched neither target: **55 of 73 test functions never ran in CI.**

| dead / total | file |
|---|---|
| 15 / 15 | `pkg/provider/cache_test.go` |
| 10 / 10 | `pkg/text/text_processor_test.go` |
| 9 / 10 | `pkg/server/server_test.go` |
| 8 / 8 | `pkg/limiter/retry_test.go` |
| 3 / 3 | `pkg/provider/edge/fasttime/fasttime_test.go` |
| 3 / 3 | `pkg/provider/api_edge_fallback_test.go` |
| 2 / 2 | `pkg/provider/api_channels_test.go` |
| 2 / 2 | `pkg/provider/api_cache_test.go` |
| 2 / 2 | `pkg/handler/slack_error_test.go` |
| 1 / 1 | `pkg/provider/edge/slacker_test.go` |

The fix inverts the selector rather than renaming functions:

```diff
-test: ## Run the tests
-	$(GO) test -count=1 -v -run=".*Unit.*" ./...
+test: ## Run all tests except the integration ones
+	$(GO) test -count=1 -v -skip=".*Integration.*" ./...
```

Renaming 55 functions to the `Unit` convention would work too, but it would conflict with essentially every open PR. This is one line and conflicts with none. `-skip` needs Go 1.21+; `go.mod` is at `go 1.25`. `test-integration` is untouched.

**This does change the naming contract**, and I'd rather flag it than have you find it later. Selection goes from a whitelist (`.*Unit.*`) to a blacklist (`.*Integration.*`), so a test that needs credentials but is *not* named `Integration` will now run under `make test` and fail there. Before, such a test was silently skipped by both targets. Concretely: a future `TestSlackAPIRoundtrip` that calls the Slack API would turn unit-tests red with `SLACK_MCP_XOXP_TOKEN not set`, where today it would simply never run. Failing loudly seems like the right default — silent skipping is what produced #341 in the first place — but it does mean anything needing credentials has to carry `Integration` in its name from here on. The target's help text states the rule (`Run all tests except the integration ones`).

## Verification

Run locally at `b88c0de` + these commits, Go 1.26.6:

**Before**
```
$ make test                          # exit 0
top-level PASS: 13
ok  .../pkg/limiter                  2.416s [no tests to run]
ok  .../pkg/provider/edge            6.613s [no tests to run]
ok  .../pkg/provider/edge/fasttime   1.213s [no tests to run]
ok  .../pkg/server                   5.753s [no tests to run]
ok  .../pkg/text                     4.997s [no tests to run]
```

**After**
```
$ make test                          # exit 0
top-level PASS: 68                   # 68 = 73 total - 5 integration
FAIL lines: 0
ok  .../pkg/handler                  2.253s
ok  .../pkg/limiter                  1.221s
ok  .../pkg/provider                 0.518s
ok  .../pkg/provider/edge            0.829s
ok  .../pkg/provider/edge/fasttime   1.413s
ok  .../pkg/server                   1.779s
ok  .../pkg/text                     2.539s
```

Every `[no tests to run]` is gone and all 55 previously-skipped tests pass — they were dead, not broken. No `TestIntegration*` leaks into `make test`.

`make test-integration` is unchanged: still matches exactly the 5 integration tests, still aborts on the missing-env-var guards without credentials.

Both workflow files were checked to still parse, with their trigger lists and all 4 steps intact.

Since this switches 55 dormant tests on in CI, I did not want to rely on "passes on my machine" — I'm on darwin/arm64 and CI is ubuntu-latest:

```
$ GOOS=linux GOARCH=amd64 go vet ./...                       # clean
$ go test -race -count=3 -skip=".*Integration.*" ./...        # exit 0, 0 data races
$ GOMAXPROCS=2 go test -count=5 -skip=".*Integration.*" ./... # exit 0 (runners are 2-core)
```

Eight repeated runs, no failures. This is worth checking because some of the newly-enabled tests are timing-sensitive — `pkg/limiter/retry_test.go:127` asserts `elapsed < 50ms` — and a `-race` build is 5-20x slower than a normal one, so it already over-approximates a slow runner. No `t.Parallel()` anywhere either, so the `os.Setenv` calls in `pkg/provider/cache_test.go` and `pkg/server/server_test.go` can't cross-contaminate.

### The workflow change is verified in CI, not just by inspection

I staged this branch as a PR on my own fork first ([dazebug/slack-mcp-server#2](https://github.com/dazebug/slack-mcp-server/pull/2) — now closed; it existed only to produce this run) so the workflow edit could actually execute somewhere before asking you to merge it. Under the new `pull_request` trigger, `unit-tests` checked out the PR instead of the base branch:

```
Unit Tests [pull_request] on b11d06e
[command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --depth=1 \
    origin +a22a444c03ea4fac5b1864f988b3189e39624657:refs/remotes/pull/2/merge
[command]/usr/bin/git checkout --progress --force refs/remotes/pull/2/merge
```

`refs/remotes/pull/2/merge` — compare with the `-B master refs/remotes/origin/master` that every PR check in this repo currently produces. The same run shows the Makefile change landing too: **zero** `[no tests to run]` lines where the equivalent run emits five. It passed.

That fork run also produced two failures, both expected and neither caused by this change:

- **`Integration Tests [pull_request_target]` failed.** `pull_request_target` resolves the workflow from the *base* branch, so my fork's old copy of the definition still fired; deleting the trigger only takes effect once merged. It failed with `SLACK_MCP_XOXP_TOKEN not set` because a fork has no access to those secrets — precisely the situation this PR stops pretending to test.
- **`Security (Trivy)` failed** on `golang.org/x/net` and `golang.org/x/text` CVEs. This PR touches two workflow files and the Makefile; `go.mod` and `go.sum` are untouched, so that is pre-existing dependency state.

### What to expect on *this* PR's checks

Worth setting expectations, since the checks here will look odd and that oddity is the bug being fixed:

- `unit-tests` and `integration-tests` will still fire via `pull_request_target` from **your** `master`, so they will check out `master` and report on it — not on this diff. That is exactly the behaviour described in #341 §2, visible one more time.
- The `pull_request` run this PR introduces resolves its workflow from the merge commit, so it should fire — but this repo shows `action_required` on fork-PR workflow runs (every `security-trivy` run on a fork branch since July sits in that state), so it will likely wait on your approval.

In other words, please don't read a green `unit-tests` here as this diff passing — it isn't testing this diff. The fork run above is.

## Why part 1 is not in this PR

\#341's first part — `#testcase-1` returning zero messages — cannot be fixed from the repo side:

- The test seeds nothing. `pkg/test/util/` is just `mcp.go` and `ngrok.go`; there is no `chat.postMessage` anywhere in the test tree. It asserts that `message 1/2/3` already exist in your workspace.
- Making it self-seeding via MCP is a dead end today: there is **no delete or update message tool** on master (`ValidToolNames` has 22 tools; the only mutating message ops are post, react, mark, join/leave). A seeding test could post but never clean up, so `#testcase-1` would grow by 3 messages on every CI run.
- Doing it properly means setup/teardown against the Slack SDK directly, which I cannot verify without workspace credentials — I'd be sending you unverifiable test code.

The immediate fix is on your side: re-seed `#testcase-1` with `message 1`, `message 2`, `message 3`. The OpenAI key already looks funded again as of the 2026-08-13 runs.

If you'd like the durable version, I'm happy to follow up with a PR that gives the test its own fixture lifecycle — but it likely wants a message-delete capability first, and that's a design call for you.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
