### PR TITLE
fix: keep the tree gofmt-clean so builds stop stamping -dirty

### DIFF
--- a/pkg/handler/channels.go
+++ b/pkg/handler/channels.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/gocarina/gocsv"
 	"github.com/korotovsky/slack-mcp-server/pkg/provider"
-	"github.com/slack-go/slack"
 	"github.com/korotovsky/slack-mcp-server/pkg/server/auth"
 	"github.com/korotovsky/slack-mcp-server/pkg/text"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/slack-go/slack"
 	"go.uber.org/zap"
 )
 

--- a/pkg/provider/cache_test.go
+++ b/pkg/provider/cache_test.go
@@ -259,12 +259,12 @@ func TestChannelIDPatterns(t *testing.T) {
 		channel string
 		needs   bool
 	}{
-		{"C1234567890", false},  // Standard channel ID
-		{"G1234567890", false},  // Private channel ID (legacy)
-		{"D1234567890", false},  // DM ID
-		{"#general", true},      // Channel name - needs lookup
-		{"@john.doe", true},     // User DM name - needs lookup
-		{"", false},             // Empty - no lookup
+		{"C1234567890", false}, // Standard channel ID
+		{"G1234567890", false}, // Private channel ID (legacy)
+		{"D1234567890", false}, // DM ID
+		{"#general", true},     // Channel name - needs lookup
+		{"@john.doe", true},    // User DM name - needs lookup
+		{"", false},            // Empty - no lookup
 	}
 
 	for _, tt := range tests {

--- a/pkg/text/text_processor_test.go
+++ b/pkg/text/text_processor_test.go
@@ -371,8 +371,8 @@ func TestAttachmentToText(t *testing.T) {
 		{
 			name: "fields_with_all_parts",
 			att: slack.Attachment{
-				Title:  "Alert",
-				Text:   "Failed workflow",
+				Title: "Alert",
+				Text:  "Failed workflow",
 				Fields: []slack.AttachmentField{
 					{Title: "Env", Value: "prod"},
 					{Title: "Version", Value: "v1.9.0"},
@@ -918,4 +918,3 @@ func TestFilesToTextProcessTextPipeline(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
Fixes #342. Three files, pure gofmt output, no behaviour change.

## The problem

`make build` and `make build-all-platforms` depend on the `format` target, which runs `go fmt ./...`. Three files committed on `master` are not gofmt-clean, so `format` rewrites them in the middle of the build.

`GIT_VERSION = $(shell git describe --tags --always --dirty)` is a *recursively* expanded variable, so the `$(shell …)` runs when the build recipe expands — after the `clean tidy format` prerequisites have already completed, and therefore after `go fmt` has dirtied the tree. Every binary picks up a `-dirty` suffix.

Reproduced from a pristine clone of `master`, before this change:

```console
$ git status --porcelain          # clean
$ git describe --tags --always --dirty
v1.3.0-3-gb88c0de

$ make build
go fmt ./...
pkg/handler/channels.go
pkg/provider/cache_test.go
pkg/text/text_processor_test.go
go build -ldflags "-s -w -X '.../pkg/version.Version=v1.3.0-3-gb88c0de-dirty' ..." ...

$ strings build/slack-mcp-server | grep -m1 v1.3.0
v1.3.0-3-gb88c0de-dirty
```

`release.yaml` runs `make build-all-platforms`, so this reaches the published binaries, the npm packages and the DXT extension. A `-dirty` suffix normally means "built from uncommitted local changes", which makes it hard to tell an official artifact from someone's local build when triaging an issue report. As a side effect, `make build` also mutates a contributor's working tree, which is surprising for a build command.

## The fix

Run gofmt on the three files. `format` becomes a no-op, so the tree stays clean through the build and the version stamps correctly:

```console
$ git status --porcelain          # clean
$ make build
go fmt ./...                      # prints nothing — no files rewritten
go build -ldflags "..." -o ./build/slack-mcp-server ./cmd/slack-mcp-server

$ git status --porcelain          # still clean
$ strings build/slack-mcp-server | grep -m1 v1.3.0
v1.3.0-4-g03555b4                 # no -dirty
```

## It really is only formatting

```console
$ git diff master...HEAD --numstat     # 9 insertions, 10 deletions
$ git diff master...HEAD -w --numstat  # 1 insertion, 2 deletions
```

Ignoring whitespace, the entire diff collapses to two lines that gofmt moved rather than reindented:

- `pkg/handler/channels.go` — `github.com/slack-go/slack` sorted into place in the import block. All imports are named; there is no blank or dot import, so nothing changes about initialisation order.
- `pkg/text/text_processor_test.go` — a trailing blank line at EOF removed.

Everything else is comment alignment in `pkg/provider/cache_test.go` and struct-field alignment in `pkg/text/text_processor_test.go`.

Checked: `make test` exit 0 with no failures, `go vet ./...` clean, `GOOS=linux GOARCH=amd64 go vet ./...` clean (CI is ubuntu-latest), `git diff --check` clean.

## A note on this PR's checks

Please don't read a green `unit-tests` here as this diff passing. Both test workflows trigger on `pull_request_target` with a ref-less checkout, so they check out `master` and report on it rather than on the PR — I staged this branch on my fork first and its `unit-tests` run logged exactly that:

```
[command]/usr/bin/git checkout --progress --force -B master refs/remotes/origin/master
```

The real evidence for this change is the local before/after above. (That checkout behaviour is #341 §2, and #343 fixes it; the two PRs are independent and touch disjoint files, so they merge in either order.)

## On preventing recurrence

This fixes it today but does not make it structural — the next commit that lands unformatted code brings the `-dirty` stamp back. Two follow-ups are possible and I deliberately left both out, since each is a judgement call that's yours:

- Making `GIT_VERSION` immediately expanded (`:=`) would evaluate it at parse time, before `format` runs, so the stamp would be correct regardless. I tested it and it does work, but it adds a second `fatal: not a git repository` line to stderr when make is invoked outside a git checkout (the Makefile already emits one via `CLEAN_TARGETS := … $(NPM_VERSION)`). Small, but it is a new regression in exchange for a case this PR already covers.
- A gofmt check in CI would prevent recurrence outright, but this repo has no lint or format gate today, and adding one is a policy change that would immediately apply to every open PR.

Happy to do either if you'd like one.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
