### PR TITLE
feat(conversations): mark threads as read via conversations_mark thread_ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,10 @@ Mark a channel, DM or thread as read. Without `thread_ts` the channel/DM read cu
 
 - **Parameters:**
   - `channel_id` (string, required): ID of the channel in format `Cxxxxxxxxxx` or its name starting with `#...` or `@...` (e.g., `#general`, `@username`).
-  - `thread_ts` (string, optional): Timestamp of a thread's parent message in format `1234567890.123456`. If provided, the thread (not the channel) is marked as read.
-  - `ts` (string, optional): Timestamp of the message to mark as read up to (a channel message, or a reply within the thread when `thread_ts` is provided). If not provided, marks the whole channel/DM — or, with `thread_ts`, the whole thread up to its latest reply — as read.
+  - `thread_ts` (string, optional): Timestamp of a thread's parent message in format `1234567890.123456`. If provided, the thread (not the channel) is marked as read. Omit it entirely to mark the channel/DM; an empty or non-string value is rejected rather than silently falling back to marking the whole channel.
+  - `ts` (string, optional): Timestamp of the message to mark as read up to (a channel message, or a reply within the thread when `thread_ts` is provided — it must lie between `thread_ts` and the thread's latest reply). If not provided, marks the whole channel/DM — or, with `thread_ts`, the whole thread up to its latest reply — as read.
+
+- **Thread semantics:** a thread's read cursor only moves forward, so marking up to a `ts` that is already read changes nothing; the tool reports this explicitly (`... was already read up to <ts>; nothing changed`) instead of claiming a mark. `thread_ts` must be the parent message of a thread — passing a reply's timestamp returns an error.
 
 ### 16. saved_list
 List saved items from Slack's "Save for Later" panel. Returns items the user has saved, with optional message content. This replaces the deprecated `stars.list` API ([changelog](https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders)).

--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ Mark a channel, DM or thread as read. Without `thread_ts` the channel/DM read cu
 
 - **Parameters:**
   - `channel_id` (string, required): ID of the channel in format `Cxxxxxxxxxx` or its name starting with `#...` or `@...` (e.g., `#general`, `@username`).
-  - `thread_ts` (string, optional): Timestamp of a thread's parent message in format `1234567890.123456`. If provided, the thread (not the channel) is marked as read. Omit it entirely to mark the channel/DM; an empty or non-string value is rejected rather than silently falling back to marking the whole channel.
+  - `thread_ts` (string, optional): Timestamp of a thread's parent message in format `1234567890.123456`. If provided, the thread (not the channel) is marked as read. Omit it (or pass JSON `null`) to mark the channel/DM; an empty string or a non-string value is rejected rather than silently falling back to marking the whole channel.
   - `ts` (string, optional): Timestamp of the message to mark as read up to (a channel message, or a reply within the thread when `thread_ts` is provided — it must lie between `thread_ts` and the thread's latest reply). If not provided, marks the whole channel/DM — or, with `thread_ts`, the whole thread up to its latest reply — as read.
 
-- **Thread semantics:** a thread's read cursor only moves forward, so marking up to a `ts` that is already read changes nothing; the tool reports this explicitly (`... was already read up to <ts>; nothing changed`) instead of claiming a mark. `thread_ts` must be the parent message of a thread — passing a reply's timestamp returns an error.
+- **Thread semantics:** a thread's read cursor only moves forward, so marking up to a `ts` that is already read changes nothing; when Slack reports the thread's previous read position the tool says so explicitly (`... was already read up to <ts>; nothing changed`) instead of claiming a mark, and when it doesn't the result notes that the previous position is unknown. `thread_ts` must be the parent message of a thread — passing a reply's timestamp (the error names the real parent) or a plain message without replies returns an error.
 
 ### 16. saved_list
 List saved items from Slack's "Save for Later" panel. Returns items the user has saved, with optional message content. This replaces the deprecated `stars.list` API ([changelog](https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders)).

--- a/README.md
+++ b/README.md
@@ -199,13 +199,16 @@ Get unread messages across all channels efficiently. Uses a single API call to i
   - `mentions_only` (boolean, default: false): If true, only returns channels where you have @mentions. Note: This filter only works with browser tokens; OAuth tokens will return all unread channels.
 
 ### 15. conversations_mark
-Mark a channel or DM as read.
+Mark a channel, DM or thread as read. Without `thread_ts` the channel/DM read cursor is moved (`conversations.mark`); with `thread_ts` the thread's own read cursor is moved (`subscriptions.thread.mark`), which is what clears a thread's unread state in the "Threads" view.
 
 > **Note:** Marking messages as read is disabled by default for safety. To enable, set the `SLACK_MCP_MARK_TOOL` environment variable to `true` or `1`. See the Environment Variables section below for details.
 
+> **Note:** Marking **threads** as read requires browser session tokens (`xoxc`/`xoxd`). It is not available with standard OAuth (`xoxp`) or bot (`xoxb`) tokens; marking channels/DMs works with all token types.
+
 - **Parameters:**
   - `channel_id` (string, required): ID of the channel in format `Cxxxxxxxxxx` or its name starting with `#...` or `@...` (e.g., `#general`, `@username`).
-  - `ts` (string, optional): Timestamp of the message to mark as read up to. If not provided, marks all messages as read.
+  - `thread_ts` (string, optional): Timestamp of a thread's parent message in format `1234567890.123456`. If provided, the thread (not the channel) is marked as read.
+  - `ts` (string, optional): Timestamp of the message to mark as read up to (a channel message, or a reply within the thread when `thread_ts` is provided). If not provided, marks the whole channel/DM — or, with `thread_ts`, the whole thread up to its latest reply — as read.
 
 ### 16. saved_list
 List saved items from Slack's "Save for Later" panel. Returns items the user has saved, with optional message content. This replaces the deprecated `stars.list` API ([changelog](https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders)).

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -1347,14 +1347,18 @@ func (ch *ConversationsHandler) getChannelDisplayName(info *slack.Channel, chann
 func (ch *ConversationsHandler) ConversationsMarkHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	ch.logger.Debug("ConversationsMarkHandler called", zap.Any("params", request.Params))
 
-	params, err := ch.parseParamsToolMark(request)
+	params, err := ch.parseParamsToolMark(ctx, request)
 	if err != nil {
 		ch.logger.Error("Failed to parse mark params", zap.Error(err))
 		return nil, err
 	}
 
 	if params.threadTs != "" {
-		return ch.markThreadAsRead(ctx, params)
+		// Thread read state is only exposed to browser session tokens (xoxc/xoxd).
+		if ch.apiProvider.IsOAuth() {
+			return nil, errors.New("marking a thread as read requires browser session tokens (xoxc/xoxd); it is not available with OAuth (xoxp) or bot (xoxb) tokens")
+		}
+		return ch.markThreadAsRead(ctx, ch.apiProvider.Slack(), params)
 	}
 
 	channel := params.channel
@@ -1393,47 +1397,63 @@ func (ch *ConversationsHandler) ConversationsMarkHandler(ctx context.Context, re
 	return mcp.NewToolResultText(fmt.Sprintf("Marked %s as read up to %s", channel, ts)), nil
 }
 
-// markThreadAsRead marks a thread as read up to params.ts (or up to its latest
-// reply when ts is empty) via the subscriptions.thread.mark edge API. Thread read
-// state is only exposed to browser session tokens (xoxc/xoxd).
-func (ch *ConversationsHandler) markThreadAsRead(ctx context.Context, params *markParams) (*mcp.CallToolResult, error) {
-	if ch.apiProvider.IsOAuth() {
-		return nil, errors.New("marking a thread as read requires browser session tokens (xoxc/xoxd); it is not available with OAuth (xoxp) or bot (xoxb) tokens")
-	}
+// threadMarkAPI is the subset of provider.SlackAPI used by markThreadAsRead;
+// keeping it narrow lets unit tests drive the function with a fake.
+type threadMarkAPI interface {
+	GetConversationRepliesContext(ctx context.Context, params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error)
+	SubscriptionsThreadMark(ctx context.Context, channel, threadTs, ts string) error
+}
 
+// markThreadAsRead marks a thread as read up to params.ts, or up to its latest
+// reply when ts is empty, via subscriptions.thread.mark. The thread's parent
+// message is always fetched first so that (a) thread_ts is verified to be a
+// thread parent, (b) an explicit ts is checked against the thread's bounds,
+// and (c) the current read cursor (last_read) is known, so the result can say
+// whether anything actually changed — Slack's cursor only moves forward, so a
+// mark up to an already-read position is a no-op.
+func (ch *ConversationsHandler) markThreadAsRead(ctx context.Context, api threadMarkAPI, params *markParams) (*mcp.CallToolResult, error) {
 	channel := params.channel
 	threadTs := params.threadTs
-	ts := params.ts
 
-	if ts == "" {
-		// Fetch the parent message to find the latest reply timestamp.
-		replies, _, _, err := ch.apiProvider.Slack().GetConversationRepliesContext(ctx, &slack.GetConversationRepliesParameters{
-			ChannelID: channel,
-			Timestamp: threadTs,
-			Limit:     1,
-		})
-		if err != nil {
-			ch.logger.Error("Failed to get thread parent message", zap.Error(err))
-			return nil, fmt.Errorf("failed to get thread %s in %s: %v", threadTs, channel, err)
-		}
-		var parent *slack.Message
-		for i := range replies {
-			if replies[i].Timestamp == threadTs {
-				parent = &replies[i]
-				break
-			}
-		}
-		if parent == nil {
-			return nil, fmt.Errorf("thread %s not found in %s (thread_ts must be the timestamp of a thread's parent message)", threadTs, channel)
-		}
-		ts = parent.LatestReply
-		if ts == "" {
-			// No replies yet: mark the parent itself as read.
-			ts = threadTs
+	replies, _, _, err := api.GetConversationRepliesContext(ctx, &slack.GetConversationRepliesParameters{
+		ChannelID: channel,
+		Timestamp: threadTs,
+		Limit:     1,
+	})
+	if err != nil {
+		ch.logger.Error("Failed to get thread parent message", zap.Error(err))
+		return nil, fmt.Errorf("failed to get thread %s in %s: %v", threadTs, channel, err)
+	}
+	var parent *slack.Message
+	for i := range replies {
+		if replies[i].Timestamp == threadTs {
+			parent = &replies[i]
+			break
 		}
 	}
+	if parent == nil {
+		return nil, fmt.Errorf("%s is not the parent message of a thread in %s (if it is a reply, pass the thread's parent timestamp as thread_ts)", threadTs, channel)
+	}
+	// conversations.replies accepts a reply's ts too and then returns that reply
+	// (whose thread_ts points at the real parent) — refuse to guess.
+	if parent.ThreadTimestamp != "" && parent.ThreadTimestamp != threadTs {
+		return nil, fmt.Errorf("%s is a reply in thread %s, not a thread parent; pass thread_ts=%s (and optionally ts=%s to mark up to that reply)", threadTs, parent.ThreadTimestamp, parent.ThreadTimestamp, threadTs)
+	}
 
-	if err := ch.apiProvider.Slack().SubscriptionsThreadMark(ctx, channel, threadTs, ts); err != nil {
+	latest := parent.LatestReply
+	if latest == "" {
+		// No replies yet: the parent itself is the only thing to mark.
+		latest = threadTs
+	}
+
+	ts := params.ts
+	if ts == "" {
+		ts = latest
+	} else if compareSlackTs(ts, latest) > 0 {
+		return nil, fmt.Errorf("ts (%s) is newer than the thread's latest reply (%s); omit ts to mark the whole thread as read", ts, latest)
+	}
+
+	if err := api.SubscriptionsThreadMark(ctx, channel, threadTs, ts); err != nil {
 		ch.logger.Error("Failed to mark thread as read",
 			zap.String("channel", channel),
 			zap.String("thread_ts", threadTs),
@@ -1442,12 +1462,26 @@ func (ch *ConversationsHandler) markThreadAsRead(ctx context.Context, params *ma
 		return nil, fmt.Errorf("failed to mark thread as read: %v", err)
 	}
 
+	// last_read is the read cursor before this call. The cursor only moves
+	// forward, so if it was already at or beyond ts nothing changed.
+	if parent.LastRead != "" && messageTsRe.MatchString(parent.LastRead) && compareSlackTs(parent.LastRead, ts) >= 0 {
+		ch.logger.Info("Thread already read, mark was a no-op",
+			zap.String("channel", channel),
+			zap.String("thread_ts", threadTs),
+			zap.String("ts", ts),
+			zap.String("last_read", parent.LastRead))
+		return mcp.NewToolResultText(fmt.Sprintf("Thread %s in %s was already read up to %s (last_read=%s); nothing changed", threadTs, channel, ts, parent.LastRead)), nil
+	}
+
 	ch.logger.Info("Marked thread as read",
 		zap.String("channel", channel),
 		zap.String("thread_ts", threadTs),
 		zap.String("ts", ts))
 
-	return mcp.NewToolResultText(fmt.Sprintf("Marked thread %s in %s as read up to %s", threadTs, channel, ts)), nil
+	if ts == latest {
+		return mcp.NewToolResultText(fmt.Sprintf("Marked thread %s in %s as read up to its latest reply %s", threadTs, channel, ts)), nil
+	}
+	return mcp.NewToolResultText(fmt.Sprintf("Marked thread %s in %s as read up to %s (latest reply is %s)", threadTs, channel, ts, latest)), nil
 }
 
 func (ch *ConversationsHandler) ConversationsLeaveHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -2014,7 +2048,36 @@ func (ch *ConversationsHandler) parseParamsToolUnreads(request mcp.CallToolReque
 	}
 }
 
-func (ch *ConversationsHandler) parseParamsToolMark(request mcp.CallToolRequest) (*markParams, error) {
+// optionalStringArg reads an optional string argument from the raw request
+// arguments. It returns present=false when the argument is absent or JSON
+// null. Unlike request.GetString, a value of the wrong JSON type is an error
+// instead of being silently treated as absent — for conversations_mark the
+// mere presence of thread_ts decides whether a thread or the whole channel is
+// marked, so a mangled value must never fall back to the wider operation.
+func optionalStringArg(request mcp.CallToolRequest, name string) (value string, present bool, err error) {
+	raw, ok := request.GetArguments()[name]
+	if !ok || raw == nil {
+		return "", false, nil
+	}
+	str, ok := raw.(string)
+	if !ok {
+		kind := "value"
+		switch raw.(type) {
+		case float64, int, int64, json.Number:
+			kind = "number"
+		case bool:
+			kind = "boolean"
+		case map[string]any:
+			kind = "object"
+		case []any:
+			kind = "array"
+		}
+		return "", true, fmt.Errorf("%s must be a string in format 1234567890.123456, got a JSON %s", name, kind)
+	}
+	return strings.TrimSpace(str), true, nil
+}
+
+func (ch *ConversationsHandler) parseParamsToolMark(ctx context.Context, request mcp.CallToolRequest) (*markParams, error) {
 	toolConfig := os.Getenv("SLACK_MCP_MARK_TOOL")
 	if toolConfig == "" {
 		ch.logger.Error("Mark tool disabled by default")
@@ -2032,30 +2095,40 @@ func (ch *ConversationsHandler) parseParamsToolMark(request mcp.CallToolRequest)
 		)
 	}
 
-	channel := request.GetString("channel_id", "")
+	channel := strings.TrimSpace(request.GetString("channel_id", ""))
 	if channel == "" {
 		ch.logger.Error("channel_id missing in mark params")
 		return nil, errors.New("channel_id is required")
 	}
 
-	// Resolve channel name to ID if needed
-	if strings.HasPrefix(channel, "#") || strings.HasPrefix(channel, "@") {
-		channelsMaps := ch.apiProvider.ProvideChannelsMaps()
-		chn, ok := channelsMaps.ChannelsInv[channel]
-		if !ok {
-			ch.logger.Error("Channel not found", zap.String("channel", channel))
-			return nil, fmt.Errorf("channel %q not found", channel)
-		}
-		channel = channelsMaps.Channels[chn].ID
+	// Resolve #channel / @user names to IDs (refreshes the cache once on a miss).
+	channel, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		ch.logger.Error("Channel not found", zap.String("channel", channel), zap.Error(err))
+		return nil, err
 	}
 
-	ts := strings.TrimSpace(request.GetString("ts", ""))
-	threadTs := strings.TrimSpace(request.GetString("thread_ts", ""))
+	threadTs, threadPresent, err := optionalStringArg(request, "thread_ts")
+	if err != nil {
+		return nil, err
+	}
+	if threadPresent && threadTs == "" {
+		// Never let an empty thread_ts silently widen the operation to the whole channel.
+		return nil, errors.New("thread_ts is empty: omit it to mark the whole channel/DM as read, or pass the thread's parent message timestamp (format 1234567890.123456) to mark a thread")
+	}
 	if threadTs != "" && !messageTsRe.MatchString(threadTs) {
 		return nil, fmt.Errorf("thread_ts must be a Slack message timestamp in format 1234567890.123456, got %q", threadTs)
 	}
+
+	ts, _, err := optionalStringArg(request, "ts")
+	if err != nil {
+		return nil, err
+	}
 	if ts != "" && !messageTsRe.MatchString(ts) {
 		return nil, fmt.Errorf("ts must be a Slack message timestamp in format 1234567890.123456, got %q", ts)
+	}
+	if threadTs != "" && ts != "" && compareSlackTs(ts, threadTs) < 0 {
+		return nil, fmt.Errorf("ts (%s) is older than thread_ts (%s); ts must be the timestamp of a reply within the thread", ts, threadTs)
 	}
 
 	return &markParams{
@@ -2063,6 +2136,41 @@ func (ch *ConversationsHandler) parseParamsToolMark(request mcp.CallToolRequest)
 		ts:       ts,
 		threadTs: threadTs,
 	}, nil
+}
+
+// compareSlackTs compares two Slack timestamps ("1234567890.123456") without
+// going through floating point (16 significant digits would lose precision).
+// It returns -1, 0 or 1. Inputs are expected to match messageTsRe.
+func compareSlackTs(a, b string) int {
+	aSec, aFrac, _ := strings.Cut(a, ".")
+	bSec, bFrac, _ := strings.Cut(b, ".")
+	aSec, bSec = strings.TrimLeft(aSec, "0"), strings.TrimLeft(bSec, "0")
+	if len(aSec) != len(bSec) {
+		if len(aSec) < len(bSec) {
+			return -1
+		}
+		return 1
+	}
+	if aSec != bSec {
+		if aSec < bSec {
+			return -1
+		}
+		return 1
+	}
+	// Right-pad the fractional parts so "1.5" and "1.500000" compare equal.
+	for len(aFrac) < len(bFrac) {
+		aFrac += "0"
+	}
+	for len(bFrac) < len(aFrac) {
+		bFrac += "0"
+	}
+	switch {
+	case aFrac < bFrac:
+		return -1
+	case aFrac > bFrac:
+		return 1
+	}
+	return 0
 }
 func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req mcp.CallToolRequest) (*searchParams, error) {
 	rawQuery := strings.TrimSpace(req.GetString("search_query", ""))

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -127,9 +127,13 @@ type unreadsParams struct {
 	mutedUnavailable      bool            // true when muted channels could not be fetched (e.g. xoxp token)
 }
 
+// messageTsRe matches a Slack message timestamp, e.g. "1234567890.123456".
+var messageTsRe = regexp.MustCompile(`^\d+\.\d+$`)
+
 type markParams struct {
-	channel string
-	ts      string
+	channel  string
+	ts       string
+	threadTs string
 }
 type ConversationsHandler struct {
 	apiProvider *provider.ApiProvider
@@ -1349,6 +1353,10 @@ func (ch *ConversationsHandler) ConversationsMarkHandler(ctx context.Context, re
 		return nil, err
 	}
 
+	if params.threadTs != "" {
+		return ch.markThreadAsRead(ctx, params)
+	}
+
 	channel := params.channel
 	ts := params.ts
 
@@ -1383,6 +1391,63 @@ func (ch *ConversationsHandler) ConversationsMarkHandler(ctx context.Context, re
 		zap.String("ts", ts))
 
 	return mcp.NewToolResultText(fmt.Sprintf("Marked %s as read up to %s", channel, ts)), nil
+}
+
+// markThreadAsRead marks a thread as read up to params.ts (or up to its latest
+// reply when ts is empty) via the subscriptions.thread.mark edge API. Thread read
+// state is only exposed to browser session tokens (xoxc/xoxd).
+func (ch *ConversationsHandler) markThreadAsRead(ctx context.Context, params *markParams) (*mcp.CallToolResult, error) {
+	if ch.apiProvider.IsOAuth() {
+		return nil, errors.New("marking a thread as read requires browser session tokens (xoxc/xoxd); it is not available with OAuth (xoxp) or bot (xoxb) tokens")
+	}
+
+	channel := params.channel
+	threadTs := params.threadTs
+	ts := params.ts
+
+	if ts == "" {
+		// Fetch the parent message to find the latest reply timestamp.
+		replies, _, _, err := ch.apiProvider.Slack().GetConversationRepliesContext(ctx, &slack.GetConversationRepliesParameters{
+			ChannelID: channel,
+			Timestamp: threadTs,
+			Limit:     1,
+		})
+		if err != nil {
+			ch.logger.Error("Failed to get thread parent message", zap.Error(err))
+			return nil, fmt.Errorf("failed to get thread %s in %s: %v", threadTs, channel, err)
+		}
+		var parent *slack.Message
+		for i := range replies {
+			if replies[i].Timestamp == threadTs {
+				parent = &replies[i]
+				break
+			}
+		}
+		if parent == nil {
+			return nil, fmt.Errorf("thread %s not found in %s (thread_ts must be the timestamp of a thread's parent message)", threadTs, channel)
+		}
+		ts = parent.LatestReply
+		if ts == "" {
+			// No replies yet: mark the parent itself as read.
+			ts = threadTs
+		}
+	}
+
+	if err := ch.apiProvider.Slack().SubscriptionsThreadMark(ctx, channel, threadTs, ts); err != nil {
+		ch.logger.Error("Failed to mark thread as read",
+			zap.String("channel", channel),
+			zap.String("thread_ts", threadTs),
+			zap.String("ts", ts),
+			zap.Error(err))
+		return nil, fmt.Errorf("failed to mark thread as read: %v", err)
+	}
+
+	ch.logger.Info("Marked thread as read",
+		zap.String("channel", channel),
+		zap.String("thread_ts", threadTs),
+		zap.String("ts", ts))
+
+	return mcp.NewToolResultText(fmt.Sprintf("Marked thread %s in %s as read up to %s", threadTs, channel, ts)), nil
 }
 
 func (ch *ConversationsHandler) ConversationsLeaveHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -1984,11 +2049,19 @@ func (ch *ConversationsHandler) parseParamsToolMark(request mcp.CallToolRequest)
 		channel = channelsMaps.Channels[chn].ID
 	}
 
-	ts := request.GetString("ts", "")
+	ts := strings.TrimSpace(request.GetString("ts", ""))
+	threadTs := strings.TrimSpace(request.GetString("thread_ts", ""))
+	if threadTs != "" && !messageTsRe.MatchString(threadTs) {
+		return nil, fmt.Errorf("thread_ts must be a Slack message timestamp in format 1234567890.123456, got %q", threadTs)
+	}
+	if ts != "" && !messageTsRe.MatchString(ts) {
+		return nil, fmt.Errorf("ts must be a Slack message timestamp in format 1234567890.123456, got %q", ts)
+	}
 
 	return &markParams{
-		channel: channel,
-		ts:      ts,
+		channel:  channel,
+		ts:       ts,
+		threadTs: threadTs,
 	}, nil
 }
 func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req mcp.CallToolRequest) (*searchParams, error) {

--- a/pkg/handler/conversations.go
+++ b/pkg/handler/conversations.go
@@ -128,7 +128,9 @@ type unreadsParams struct {
 }
 
 // messageTsRe matches a Slack message timestamp, e.g. "1234567890.123456".
-var messageTsRe = regexp.MustCompile(`^\d+\.\d+$`)
+// Slack requires exactly six fractional digits (anything else is rejected with
+// invalid_timestamp), so that is enforced here for a clearer error.
+var messageTsRe = regexp.MustCompile(`^\d+\.\d{6}$`)
 
 type markParams struct {
 	channel  string
@@ -1343,7 +1345,7 @@ func (ch *ConversationsHandler) getChannelDisplayName(info *slack.Channel, chann
 	}
 }
 
-// ConversationsMarkHandler marks a channel as read up to a specific timestamp
+// ConversationsMarkHandler marks a channel/DM (or, with thread_ts, a thread) as read up to a specific timestamp
 func (ch *ConversationsHandler) ConversationsMarkHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	ch.logger.Debug("ConversationsMarkHandler called", zap.Any("params", request.Params))
 
@@ -1426,7 +1428,7 @@ func (ch *ConversationsHandler) markThreadAsRead(ctx context.Context, api thread
 	}
 	var parent *slack.Message
 	for i := range replies {
-		if replies[i].Timestamp == threadTs {
+		if replies[i].Timestamp != "" && messageTsRe.MatchString(replies[i].Timestamp) && compareSlackTs(replies[i].Timestamp, threadTs) == 0 {
 			parent = &replies[i]
 			break
 		}
@@ -1434,23 +1436,37 @@ func (ch *ConversationsHandler) markThreadAsRead(ctx context.Context, api thread
 	if parent == nil {
 		return nil, fmt.Errorf("%s is not the parent message of a thread in %s (if it is a reply, pass the thread's parent timestamp as thread_ts)", threadTs, channel)
 	}
-	// conversations.replies accepts a reply's ts too and then returns that reply
-	// (whose thread_ts points at the real parent) — refuse to guess.
-	if parent.ThreadTimestamp != "" && parent.ThreadTimestamp != threadTs {
+	// Use Slack's canonical form of the timestamp from here on (the caller may
+	// have passed e.g. a shorter fractional part).
+	threadTs = parent.Timestamp
+
+	// conversations.replies also accepts a reply's ts (and then returns that
+	// reply, whose thread_ts points at the real parent) and a plain message's
+	// ts (returned without thread_ts). Only a thread parent is acceptable.
+	switch {
+	case parent.ThreadTimestamp == "":
+		return nil, fmt.Errorf("%s in %s is not a thread (the message has no replies), so there is no thread read state to mark; to mark the channel/DM as read call conversations_mark without thread_ts", threadTs, channel)
+	case parent.ThreadTimestamp != threadTs:
 		return nil, fmt.Errorf("%s is a reply in thread %s, not a thread parent; pass thread_ts=%s (and optionally ts=%s to mark up to that reply)", threadTs, parent.ThreadTimestamp, parent.ThreadTimestamp, threadTs)
 	}
 
+	hasReplies := parent.LatestReply != ""
 	latest := parent.LatestReply
-	if latest == "" {
-		// No replies yet: the parent itself is the only thing to mark.
+	if !hasReplies {
+		// A thread parent whose replies are gone: the parent itself is all there is to mark.
 		latest = threadTs
 	}
 
 	ts := params.ts
-	if ts == "" {
+	switch {
+	case ts == "":
 		ts = latest
-	} else if compareSlackTs(ts, latest) > 0 {
+	case compareSlackTs(ts, latest) > 0 && hasReplies:
 		return nil, fmt.Errorf("ts (%s) is newer than the thread's latest reply (%s); omit ts to mark the whole thread as read", ts, latest)
+	case compareSlackTs(ts, latest) > 0:
+		return nil, fmt.Errorf("thread %s in %s has no replies; omit ts or pass ts=%s", threadTs, channel, threadTs)
+	case compareSlackTs(ts, latest) == 0:
+		ts = latest // canonical form
 	}
 
 	if err := api.SubscriptionsThreadMark(ctx, channel, threadTs, ts); err != nil {
@@ -1462,9 +1478,11 @@ func (ch *ConversationsHandler) markThreadAsRead(ctx context.Context, api thread
 		return nil, fmt.Errorf("failed to mark thread as read: %v", err)
 	}
 
-	// last_read is the read cursor before this call. The cursor only moves
-	// forward, so if it was already at or beyond ts nothing changed.
-	if parent.LastRead != "" && messageTsRe.MatchString(parent.LastRead) && compareSlackTs(parent.LastRead, ts) >= 0 {
+	// last_read (when Slack reports it) is the read cursor before this call.
+	// The cursor only moves forward, so if it was already at or beyond ts
+	// nothing changed.
+	lastReadKnown := parent.LastRead != "" && messageTsRe.MatchString(parent.LastRead)
+	if lastReadKnown && compareSlackTs(parent.LastRead, ts) >= 0 {
 		ch.logger.Info("Thread already read, mark was a no-op",
 			zap.String("channel", channel),
 			zap.String("thread_ts", threadTs),
@@ -1476,12 +1494,22 @@ func (ch *ConversationsHandler) markThreadAsRead(ctx context.Context, api thread
 	ch.logger.Info("Marked thread as read",
 		zap.String("channel", channel),
 		zap.String("thread_ts", threadTs),
-		zap.String("ts", ts))
+		zap.String("ts", ts),
+		zap.Bool("last_read_known", lastReadKnown))
 
-	if ts == latest {
-		return mcp.NewToolResultText(fmt.Sprintf("Marked thread %s in %s as read up to its latest reply %s", threadTs, channel, ts)), nil
+	var msg string
+	switch {
+	case !hasReplies:
+		msg = fmt.Sprintf("Marked thread %s in %s as read (it has no replies)", threadTs, channel)
+	case ts == latest:
+		msg = fmt.Sprintf("Marked thread %s in %s as read up to its latest reply %s", threadTs, channel, ts)
+	default:
+		msg = fmt.Sprintf("Marked thread %s in %s as read up to %s (latest reply is %s)", threadTs, channel, ts, latest)
 	}
-	return mcp.NewToolResultText(fmt.Sprintf("Marked thread %s in %s as read up to %s (latest reply is %s)", threadTs, channel, ts, latest)), nil
+	if !lastReadKnown {
+		msg += " (Slack did not report the previous read position, so it may already have been read)"
+	}
+	return mcp.NewToolResultText(msg), nil
 }
 
 func (ch *ConversationsHandler) ConversationsLeaveHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -2063,7 +2091,7 @@ func optionalStringArg(request mcp.CallToolRequest, name string) (value string, 
 	if !ok {
 		kind := "value"
 		switch raw.(type) {
-		case float64, int, int64, json.Number:
+		case float64: // encoding/json decodes every JSON number as float64
 			kind = "number"
 		case bool:
 			kind = "boolean"
@@ -2101,13 +2129,7 @@ func (ch *ConversationsHandler) parseParamsToolMark(ctx context.Context, request
 		return nil, errors.New("channel_id is required")
 	}
 
-	// Resolve #channel / @user names to IDs (refreshes the cache once on a miss).
-	channel, err := ch.resolveChannelID(ctx, channel)
-	if err != nil {
-		ch.logger.Error("Channel not found", zap.String("channel", channel), zap.Error(err))
-		return nil, err
-	}
-
+	// Validate the cheap arguments first; name resolution below may hit the API.
 	threadTs, threadPresent, err := optionalStringArg(request, "thread_ts")
 	if err != nil {
 		return nil, err
@@ -2128,11 +2150,18 @@ func (ch *ConversationsHandler) parseParamsToolMark(ctx context.Context, request
 		return nil, fmt.Errorf("ts must be a Slack message timestamp in format 1234567890.123456, got %q", ts)
 	}
 	if threadTs != "" && ts != "" && compareSlackTs(ts, threadTs) < 0 {
-		return nil, fmt.Errorf("ts (%s) is older than thread_ts (%s); ts must be the timestamp of a reply within the thread", ts, threadTs)
+		return nil, fmt.Errorf("ts (%s) is older than thread_ts (%s); ts must be thread_ts itself or the timestamp of a reply within the thread", ts, threadTs)
+	}
+
+	// Resolve #channel / @user names to IDs (refreshes the cache once on a miss).
+	channelID, err := ch.resolveChannelID(ctx, channel)
+	if err != nil {
+		ch.logger.Error("Channel not found", zap.String("channel", channel), zap.Error(err))
+		return nil, err
 	}
 
 	return &markParams{
-		channel:  channel,
+		channel:  channelID,
 		ts:       ts,
 		threadTs: threadTs,
 	}, nil
@@ -2172,6 +2201,7 @@ func compareSlackTs(a, b string) int {
 	}
 	return 0
 }
+
 func (ch *ConversationsHandler) parseParamsToolSearch(ctx context.Context, req mcp.CallToolRequest) (*searchParams, error) {
 	rawQuery := strings.TrimSpace(req.GetString("search_query", ""))
 	freeText, filters := splitQuery(rawQuery)

--- a/pkg/handler/conversations_test.go
+++ b/pkg/handler/conversations_test.go
@@ -734,13 +734,25 @@ func TestUnitParseParamsToolMarkThread(t *testing.T) {
 	})
 
 	t.Run("malformed ts is rejected", func(t *testing.T) {
-		_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "ts": "1700000000"}))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "ts must be a Slack message timestamp")
+		for _, v := range []string{"1700000000", "1700000000.0002", "1700000000.00020000", "1700000000.", ".000200"} {
+			_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "ts": v}))
+			require.Error(t, err, "value %q must be rejected", v)
+			assert.Contains(t, err.Error(), "ts must be a Slack message timestamp")
+		}
 	})
 
 	t.Run("ts older than thread_ts is rejected", func(t *testing.T) {
 		_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "thread_ts": "1700000000.000100", "ts": "1699999999.999999"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "older than thread_ts")
+	})
+
+	t.Run("argument type/format errors are raised before channel name resolution", func(t *testing.T) {
+		// With a nil API provider, resolving "#name" would panic; a clean error proves the ordering.
+		_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "#nope", "thread_ts": 1700000000.0001}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "thread_ts must be a string")
+		_, err = ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "#nope", "thread_ts": "1700000000.000100", "ts": "1699999999.999999"}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "older than thread_ts")
 	})
@@ -869,12 +881,55 @@ func TestUnitMarkThreadAsRead(t *testing.T) {
 		assert.Contains(t, toolResultText(t, res), "nothing changed")
 	})
 
-	t.Run("no replies yet: marks the parent itself", func(t *testing.T) {
+	t.Run("thread parent without replies: marks the parent itself", func(t *testing.T) {
 		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, "", "")}}
 		res, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs})
 		require.NoError(t, err)
 		assert.Equal(t, []string{chID + "|" + parentTs + "|" + parentTs}, api.markCalls)
-		assert.Contains(t, toolResultText(t, res), "as read up to its latest reply "+parentTs)
+		assert.Contains(t, toolResultText(t, res), "as read (it has no replies)")
+	})
+
+	t.Run("thread parent without replies: explicit ts must equal thread_ts", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, "", "")}}
+		_, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs, ts: midTs})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "has no replies; omit ts or pass ts="+parentTs)
+		assert.Empty(t, api.markCalls)
+
+		res, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs, ts: parentTs})
+		require.NoError(t, err)
+		assert.Contains(t, toolResultText(t, res), "as read (it has no replies)")
+	})
+
+	t.Run("plain message that is not a thread: error, no mark", func(t *testing.T) {
+		plain := slack.Message{}
+		plain.Timestamp = parentTs // no thread_ts, no replies: an ordinary channel message
+		api := &fakeThreadMarkAPI{replies: []slack.Message{plain}}
+		_, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a thread")
+		assert.Empty(t, api.markCalls)
+	})
+
+	t.Run("last_read not reported: marked, but result says the previous position is unknown", func(t *testing.T) {
+		for _, lr := range []string{"", "abc"} {
+			api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, latestTs, lr)}}
+			res, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs})
+			require.NoError(t, err)
+			assert.Len(t, api.markCalls, 1)
+			txt := toolResultText(t, res)
+			assert.Contains(t, txt, "Marked thread")
+			assert.Contains(t, txt, "did not report the previous read position")
+			assert.NotContains(t, txt, "nothing changed")
+		}
+	})
+
+	t.Run("numerically-equal thread_ts/ts are matched and sent in Slack's canonical form", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, latestTs, parentTs)}}
+		res, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: "0" + parentTs, ts: "0" + latestTs})
+		require.NoError(t, err)
+		assert.Equal(t, []string{chID + "|" + parentTs + "|" + latestTs}, api.markCalls)
+		assert.Contains(t, toolResultText(t, res), "up to its latest reply "+latestTs)
 	})
 
 	t.Run("thread_ts is a reply: error names the real parent, no mark", func(t *testing.T) {

--- a/pkg/handler/conversations_test.go
+++ b/pkg/handler/conversations_test.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/korotovsky/slack-mcp-server/pkg/test/util"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/responses"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestIntegrationConversations(t *testing.T) {
@@ -652,4 +654,66 @@ func TestUnitIsSlackUserIDPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestUnitParseParamsToolMarkThread covers the thread_ts / ts parsing and
+// validation of conversations_mark. Channel IDs (not names) are used so the
+// parser never touches the (nil) API provider.
+func TestUnitParseParamsToolMarkThread(t *testing.T) {
+	t.Setenv("SLACK_MCP_MARK_TOOL", "true")
+	ch := &ConversationsHandler{logger: zap.NewNop()}
+
+	newReq := func(args map[string]any) mcp.CallToolRequest {
+		req := mcp.CallToolRequest{}
+		req.Params.Name = "conversations_mark"
+		req.Params.Arguments = args
+		return req
+	}
+
+	t.Run("channel-only request has empty threadTs", func(t *testing.T) {
+		p, err := ch.parseParamsToolMark(newReq(map[string]any{"channel_id": "C0123456789"}))
+		require.NoError(t, err)
+		assert.Equal(t, "C0123456789", p.channel)
+		assert.Empty(t, p.ts)
+		assert.Empty(t, p.threadTs)
+	})
+
+	t.Run("thread_ts and ts are parsed and trimmed", func(t *testing.T) {
+		p, err := ch.parseParamsToolMark(newReq(map[string]any{
+			"channel_id": "C0123456789",
+			"thread_ts":  " 1700000000.000100 ",
+			"ts":         "1700000500.000200",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "1700000000.000100", p.threadTs)
+		assert.Equal(t, "1700000500.000200", p.ts)
+	})
+
+	t.Run("malformed thread_ts is rejected", func(t *testing.T) {
+		_, err := ch.parseParamsToolMark(newReq(map[string]any{"channel_id": "C0123456789", "thread_ts": "p1700000000000100"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "thread_ts must be a Slack message timestamp")
+	})
+
+	t.Run("malformed ts is rejected", func(t *testing.T) {
+		_, err := ch.parseParamsToolMark(newReq(map[string]any{"channel_id": "C0123456789", "ts": "1700000000"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ts must be a Slack message timestamp")
+	})
+
+	t.Run("channel_id is still required", func(t *testing.T) {
+		_, err := ch.parseParamsToolMark(newReq(map[string]any{"thread_ts": "1700000000.000100"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "channel_id is required")
+	})
+}
+
+func TestUnitParseParamsToolMarkDisabled(t *testing.T) {
+	t.Setenv("SLACK_MCP_MARK_TOOL", "")
+	ch := &ConversationsHandler{logger: zap.NewNop()}
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"channel_id": "C0123456789", "thread_ts": "1700000000.000100"}
+	_, err := ch.parseParamsToolMark(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SLACK_MCP_MARK_TOOL")
 }

--- a/pkg/handler/conversations_test.go
+++ b/pkg/handler/conversations_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -18,6 +19,7 @@ import (
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/responses"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -662,6 +664,7 @@ func TestUnitIsSlackUserIDPrefix(t *testing.T) {
 func TestUnitParseParamsToolMarkThread(t *testing.T) {
 	t.Setenv("SLACK_MCP_MARK_TOOL", "true")
 	ch := &ConversationsHandler{logger: zap.NewNop()}
+	ctx := context.Background()
 
 	newReq := func(args map[string]any) mcp.CallToolRequest {
 		req := mcp.CallToolRequest{}
@@ -671,49 +674,251 @@ func TestUnitParseParamsToolMarkThread(t *testing.T) {
 	}
 
 	t.Run("channel-only request has empty threadTs", func(t *testing.T) {
-		p, err := ch.parseParamsToolMark(newReq(map[string]any{"channel_id": "C0123456789"}))
+		p, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789"}))
 		require.NoError(t, err)
 		assert.Equal(t, "C0123456789", p.channel)
 		assert.Empty(t, p.ts)
 		assert.Empty(t, p.threadTs)
 	})
 
-	t.Run("thread_ts and ts are parsed and trimmed", func(t *testing.T) {
-		p, err := ch.parseParamsToolMark(newReq(map[string]any{
-			"channel_id": "C0123456789",
+	t.Run("thread_ts and ts are parsed and trimmed, channel_id trimmed", func(t *testing.T) {
+		p, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{
+			"channel_id": " C0123456789 ",
 			"thread_ts":  " 1700000000.000100 ",
 			"ts":         "1700000500.000200",
 		}))
 		require.NoError(t, err)
+		assert.Equal(t, "C0123456789", p.channel)
 		assert.Equal(t, "1700000000.000100", p.threadTs)
 		assert.Equal(t, "1700000500.000200", p.ts)
 	})
 
+	t.Run("null thread_ts means channel mode", func(t *testing.T) {
+		p, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "thread_ts": nil}))
+		require.NoError(t, err)
+		assert.Empty(t, p.threadTs)
+	})
+
+	t.Run("non-string thread_ts is rejected, never treated as absent", func(t *testing.T) {
+		for _, v := range []any{1700000000.0001, true, map[string]any{"ts": "1"}, []any{"1700000000.000100"}} {
+			_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "thread_ts": v}))
+			require.Error(t, err, "value %v (%T) must be rejected", v, v)
+			assert.Contains(t, err.Error(), "thread_ts must be a string")
+		}
+	})
+
+	t.Run("blank thread_ts is rejected, never treated as absent", func(t *testing.T) {
+		for _, v := range []string{"", "   "} {
+			_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "thread_ts": v}))
+			require.Error(t, err, "value %q must be rejected", v)
+			assert.Contains(t, err.Error(), "thread_ts is empty")
+		}
+	})
+
 	t.Run("malformed thread_ts is rejected", func(t *testing.T) {
-		_, err := ch.parseParamsToolMark(newReq(map[string]any{"channel_id": "C0123456789", "thread_ts": "p1700000000000100"}))
+		_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "thread_ts": "p1700000000000100"}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "thread_ts must be a Slack message timestamp")
 	})
 
+	t.Run("non-string ts is rejected", func(t *testing.T) {
+		_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "thread_ts": "1700000000.000100", "ts": 1700000500.0002}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ts must be a string")
+	})
+
+	t.Run("blank ts is treated as omitted (documented: mark everything)", func(t *testing.T) {
+		p, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "ts": ""}))
+		require.NoError(t, err)
+		assert.Empty(t, p.ts)
+	})
+
 	t.Run("malformed ts is rejected", func(t *testing.T) {
-		_, err := ch.parseParamsToolMark(newReq(map[string]any{"channel_id": "C0123456789", "ts": "1700000000"}))
+		_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "ts": "1700000000"}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "ts must be a Slack message timestamp")
 	})
 
+	t.Run("ts older than thread_ts is rejected", func(t *testing.T) {
+		_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"channel_id": "C0123456789", "thread_ts": "1700000000.000100", "ts": "1699999999.999999"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "older than thread_ts")
+	})
+
 	t.Run("channel_id is still required", func(t *testing.T) {
-		_, err := ch.parseParamsToolMark(newReq(map[string]any{"thread_ts": "1700000000.000100"}))
+		_, err := ch.parseParamsToolMark(ctx, newReq(map[string]any{"thread_ts": "1700000000.000100"}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "channel_id is required")
 	})
 }
 
 func TestUnitParseParamsToolMarkDisabled(t *testing.T) {
-	t.Setenv("SLACK_MCP_MARK_TOOL", "")
 	ch := &ConversationsHandler{logger: zap.NewNop()}
 	req := mcp.CallToolRequest{}
 	req.Params.Arguments = map[string]any{"channel_id": "C0123456789", "thread_ts": "1700000000.000100"}
-	_, err := ch.parseParamsToolMark(req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "SLACK_MCP_MARK_TOOL")
+
+	t.Run("unset env: disabled by default", func(t *testing.T) {
+		t.Setenv("SLACK_MCP_MARK_TOOL", "")
+		_, err := ch.parseParamsToolMark(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "disabled to prevent accidental marking")
+	})
+
+	t.Run("explicitly false: disabled by config", func(t *testing.T) {
+		t.Setenv("SLACK_MCP_MARK_TOOL", "false")
+		_, err := ch.parseParamsToolMark(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "the conversations_mark tool is disabled")
+	})
+}
+
+func TestUnitCompareSlackTs(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1700000000.000100", "1700000000.000100", 0},
+		{"1700000000.000100", "1700000000.000101", -1},
+		{"1700000000.000101", "1700000000.000100", 1},
+		{"1699999999.999999", "1700000000.000000", -1},
+		{"1787049702.000000", "1787049701.503059", 1},
+		{"1.5", "1.500000", 0},
+		{"01700000000.000100", "1700000000.000100", 0}, // leading zeros in seconds
+		{"999.999999", "1000.000000", -1},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, compareSlackTs(tt.a, tt.b), "compare(%s, %s)", tt.a, tt.b)
+	}
+}
+
+// fakeThreadMarkAPI implements threadMarkAPI for markThreadAsRead tests.
+type fakeThreadMarkAPI struct {
+	replies    []slack.Message
+	repliesErr error
+	markErr    error
+
+	repliesCalls int
+	markCalls    []string // "channel|thread_ts|ts"
+}
+
+func (f *fakeThreadMarkAPI) GetConversationRepliesContext(ctx context.Context, params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error) {
+	f.repliesCalls++
+	return f.replies, false, "", f.repliesErr
+}
+
+func (f *fakeThreadMarkAPI) SubscriptionsThreadMark(ctx context.Context, channel, threadTs, ts string) error {
+	f.markCalls = append(f.markCalls, channel+"|"+threadTs+"|"+ts)
+	return f.markErr
+}
+
+func threadParent(ts, latestReply, lastRead string) slack.Message {
+	m := slack.Message{}
+	m.Timestamp = ts
+	m.ThreadTimestamp = ts
+	m.LatestReply = latestReply
+	m.LastRead = lastRead
+	return m
+}
+
+func TestUnitMarkThreadAsRead(t *testing.T) {
+	ch := &ConversationsHandler{logger: zap.NewNop()}
+	ctx := context.Background()
+	const chID, parentTs, midTs, latestTs = "C0123456789", "1700000000.000100", "1700000300.000150", "1700000500.000200"
+
+	t.Run("no ts: marks up to latest reply", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, latestTs, parentTs)}}
+		res, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs})
+		require.NoError(t, err)
+		assert.Equal(t, 1, api.repliesCalls)
+		assert.Equal(t, []string{chID + "|" + parentTs + "|" + latestTs}, api.markCalls)
+		assert.Contains(t, toolResultText(t, res), "as read up to its latest reply "+latestTs)
+	})
+
+	t.Run("explicit ts within bounds: marks up to ts and mentions latest", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, latestTs, parentTs)}}
+		res, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs, ts: midTs})
+		require.NoError(t, err)
+		assert.Equal(t, []string{chID + "|" + parentTs + "|" + midTs}, api.markCalls)
+		txt := toolResultText(t, res)
+		assert.Contains(t, txt, "as read up to "+midTs)
+		assert.Contains(t, txt, "latest reply is "+latestTs)
+	})
+
+	t.Run("explicit ts newer than latest reply: error, no mark", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, latestTs, parentTs)}}
+		_, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs, ts: "1700009999.000000"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "newer than the thread's latest reply")
+		assert.Empty(t, api.markCalls)
+	})
+
+	t.Run("already read: mark still sent (forward-only), result says nothing changed", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, latestTs, latestTs)}}
+		res, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs})
+		require.NoError(t, err)
+		assert.Len(t, api.markCalls, 1)
+		txt := toolResultText(t, res)
+		assert.Contains(t, txt, "already read up to "+latestTs)
+		assert.Contains(t, txt, "nothing changed")
+	})
+
+	t.Run("older explicit ts than last_read: reported as no change", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, latestTs, latestTs)}}
+		res, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs, ts: midTs})
+		require.NoError(t, err)
+		assert.Contains(t, toolResultText(t, res), "nothing changed")
+	})
+
+	t.Run("no replies yet: marks the parent itself", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, "", "")}}
+		res, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs})
+		require.NoError(t, err)
+		assert.Equal(t, []string{chID + "|" + parentTs + "|" + parentTs}, api.markCalls)
+		assert.Contains(t, toolResultText(t, res), "as read up to its latest reply "+parentTs)
+	})
+
+	t.Run("thread_ts is a reply: error names the real parent, no mark", func(t *testing.T) {
+		// conversations.replies for a reply ts returns that reply itself, whose thread_ts is the parent.
+		reply := slack.Message{}
+		reply.Timestamp = midTs
+		reply.ThreadTimestamp = parentTs
+		api := &fakeThreadMarkAPI{replies: []slack.Message{reply}}
+		_, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: midTs})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is a reply in thread "+parentTs)
+		assert.Contains(t, err.Error(), "pass thread_ts="+parentTs)
+		assert.Empty(t, api.markCalls)
+	})
+
+	t.Run("no message matches thread_ts: clear error, no mark", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, latestTs, parentTs)}}
+		_, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: "1700000000.000999"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not the parent message of a thread")
+		assert.Empty(t, api.markCalls)
+	})
+
+	t.Run("replies API error is propagated, no mark", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{repliesErr: errors.New("thread_not_found")}
+		_, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "thread_not_found")
+		assert.Empty(t, api.markCalls)
+	})
+
+	t.Run("mark API error is propagated", func(t *testing.T) {
+		api := &fakeThreadMarkAPI{replies: []slack.Message{threadParent(parentTs, latestTs, parentTs)}, markErr: errors.New("not_allowed_token_type")}
+		_, err := ch.markThreadAsRead(ctx, api, &markParams{channel: chID, threadTs: parentTs})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not_allowed_token_type")
+	})
+}
+
+func toolResultText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	require.NotNil(t, res)
+	require.NotEmpty(t, res.Content)
+	tc, ok := res.Content[0].(mcp.TextContent)
+	require.True(t, ok, "expected TextContent, got %T", res.Content[0])
+	return tc.Text
 }

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -250,6 +250,7 @@ type SlackAPI interface {
 	SavedList(ctx context.Context, filter string, limit int, cursor string) (edge.SavedListResponse, error)
 	SavedUpdate(ctx context.Context, itemType, itemID, ts, mark string, dateDue int64) error
 	SavedClearCompleted(ctx context.Context) error
+	SubscriptionsThreadMark(ctx context.Context, channel, threadTs, ts string) error
 
 	// User groups API methods
 	GetUserGroupsContext(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error)
@@ -579,6 +580,10 @@ func (c *MCPSlackClient) SavedUpdate(ctx context.Context, itemType, itemID, ts, 
 
 func (c *MCPSlackClient) SavedClearCompleted(ctx context.Context) error {
 	return c.edgeClient.SavedClearCompleted(ctx)
+}
+
+func (c *MCPSlackClient) SubscriptionsThreadMark(ctx context.Context, channel, threadTs, ts string) error {
+	return c.edgeClient.SubscriptionsThreadMark(ctx, channel, threadTs, ts)
 }
 
 func (c *MCPSlackClient) GetUserGroupsContext(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error) {

--- a/pkg/provider/edge/subscriptions.go
+++ b/pkg/provider/edge/subscriptions.go
@@ -1,0 +1,55 @@
+package edge
+
+import (
+	"context"
+	"runtime/trace"
+)
+
+// subscriptions.thread.* API — internal Slack APIs backing the "Threads" view
+// (thread subscriptions and per-thread read state).
+// Only accessible with browser session tokens (xoxc/xoxd).
+//
+// Known endpoints:
+//   - subscriptions.thread.mark     — set the read cursor of a thread (channel, thread_ts, ts)
+//   - subscriptions.thread.get      — list subscribed thread_ts values in a channel
+//   - subscriptions.thread.getView  — the "Threads" view (threads with unread counts)
+//   - subscriptions.thread.add / remove — follow / unfollow a thread
+//   - subscriptions.thread.clearAll — mark ALL threads as read (dangerous: no required params)
+
+type subscriptionsThreadMarkForm struct {
+	BaseRequest
+	Channel  string `json:"channel"`
+	ThreadTs string `json:"thread_ts"`
+	Ts       string `json:"ts"`
+	WebClientFields
+}
+
+// SubscriptionsThreadMark marks a thread as read up to ts (subscriptions.thread.mark),
+// i.e. sets the thread's last_read cursor to ts. The cursor only moves forward:
+// passing a ts older than the current last_read is a no-op. To mark a whole
+// thread as read, pass the ts of its latest reply.
+func (cl *Client) SubscriptionsThreadMark(ctx context.Context, channel, threadTs, ts string) error {
+	ctx, task := trace.NewTask(ctx, "SubscriptionsThreadMark")
+	defer task.End()
+
+	form := subscriptionsThreadMarkForm{
+		BaseRequest:     BaseRequest{Token: cl.token},
+		Channel:         channel,
+		ThreadTs:        threadTs,
+		Ts:              ts,
+		WebClientFields: webclientReason("subscriptions-thread-api/markThreadRead"),
+	}
+
+	resp, err := cl.PostForm(ctx, "subscriptions.thread.mark", values(form, true))
+	if err != nil {
+		return err
+	}
+	r := baseResponse{}
+	if err := cl.ParseResponse(&r, resp); err != nil {
+		return err
+	}
+	if err := r.validate("subscriptions.thread.mark"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/provider/edge/subscriptions_test.go
+++ b/pkg/provider/edge/subscriptions_test.go
@@ -1,0 +1,98 @@
+package edge
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingHTTPClient captures the last request's form body and returns a
+// canned JSON response.
+type recordingHTTPClient struct {
+	lastReq  *http.Request
+	lastForm url.Values
+	body     string
+	status   int
+}
+
+func (f *recordingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	f.lastReq = req
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if f.lastForm, err = url.ParseQuery(string(raw)); err != nil {
+		return nil, err
+	}
+	status := f.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func newTestSubscriptionsClient(body string) (*Client, *recordingHTTPClient) {
+	f := &recordingHTTPClient{body: body}
+	cl := &Client{
+		cl:           f,
+		token:        "xoxc-test-token",
+		teamID:       "T0TEST",
+		webclientAPI: "https://example.slack.com/api/",
+		tape:         nopTape{},
+	}
+	return cl, f
+}
+
+func TestUnitSubscriptionsThreadMark(t *testing.T) {
+	t.Run("posts channel/thread_ts/ts to subscriptions.thread.mark", func(t *testing.T) {
+		cl, f := newTestSubscriptionsClient(`{"ok":true}`)
+
+		err := cl.SubscriptionsThreadMark(context.Background(), "C0123456789", "1700000000.000100", "1700000500.000200")
+		require.NoError(t, err)
+
+		require.NotNil(t, f.lastReq)
+		assert.Equal(t, http.MethodPost, f.lastReq.Method)
+		assert.Equal(t, "https://example.slack.com/api/subscriptions.thread.mark", f.lastReq.URL.String())
+		assert.Equal(t, "application/x-www-form-urlencoded", f.lastReq.Header.Get("Content-Type"))
+
+		assert.Equal(t, "xoxc-test-token", f.lastForm.Get("token"))
+		assert.Equal(t, "C0123456789", f.lastForm.Get("channel"))
+		assert.Equal(t, "1700000000.000100", f.lastForm.Get("thread_ts"))
+		assert.Equal(t, "1700000500.000200", f.lastForm.Get("ts"))
+		assert.Equal(t, "subscriptions-thread-api/markThreadRead", f.lastForm.Get("_x_reason"))
+		// Never send the "read" flag: read=false would mark the thread UNREAD.
+		assert.False(t, f.lastForm.Has("read"))
+	})
+
+	t.Run("returns APIError with endpoint on ok=false", func(t *testing.T) {
+		cl, _ := newTestSubscriptionsClient(`{"ok":false,"error":"invalid_arguments","response_metadata":{"messages":["[ERROR] missing required field: ts"]}}`)
+
+		err := cl.SubscriptionsThreadMark(context.Background(), "C0123456789", "1700000000.000100", "")
+		require.Error(t, err)
+
+		apiErr, ok := err.(*APIError)
+		require.True(t, ok, "expected *APIError, got %T", err)
+		assert.Equal(t, "subscriptions.thread.mark", apiErr.Endpoint)
+		assert.Equal(t, "invalid_arguments", apiErr.Err)
+		assert.Contains(t, err.Error(), "missing required field: ts")
+	})
+
+	t.Run("returns error for non-2xx status", func(t *testing.T) {
+		cl, f := newTestSubscriptionsClient(`gateway error`)
+		f.status = http.StatusBadGateway
+
+		err := cl.SubscriptionsThreadMark(context.Background(), "C0123456789", "1700000000.000100", "1700000500.000200")
+		require.Error(t, err)
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -352,7 +352,7 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 	// Register mark tool - marks a channel as read
 	if shouldAddTool(ToolConversationsMark, enabledTools, "") {
 		s.AddTool(mcp.NewTool(ToolConversationsMark,
-			mcp.WithDescription("Mark a channel, DM or thread as read. Without thread_ts it marks the channel/DM as read up to ts (or all messages if ts is omitted). With thread_ts it marks that thread as read up to ts (or up to its latest reply if ts is omitted); marking threads requires browser session tokens (xoxc/xoxd)."),
+			mcp.WithDescription("Mark a channel, DM or thread as read. Without thread_ts it marks the channel/DM as read up to ts (or all messages if ts is omitted). With thread_ts it marks that thread as read up to ts (or up to its latest reply if ts is omitted). A thread's read cursor only moves forward: marking up to a ts that is already read changes nothing and the result says so. Marking threads requires browser session tokens (xoxc/xoxd)."),
 			mcp.WithTitleAnnotation("Mark as Read"),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("channel_id",
@@ -360,10 +360,10 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... (e.g., #general, @username)."),
 			),
 			mcp.WithString("thread_ts",
-				mcp.Description("Timestamp of a thread's parent message in format 1234567890.123456. If provided, the thread (not the channel) is marked as read."),
+				mcp.Description("Timestamp of a thread's parent message in format 1234567890.123456. If provided, the thread (not the channel) is marked as read. Omit it entirely to mark the channel/DM; an empty value is rejected."),
 			),
 			mcp.WithString("ts",
-				mcp.Description("Timestamp of the message to mark as read up to (channel message, or reply within the thread when thread_ts is provided). If not provided, marks the whole channel/DM or thread as read."),
+				mcp.Description("Timestamp of the message to mark as read up to (a channel message, or a reply within the thread when thread_ts is provided — must lie between thread_ts and the thread's latest reply). If not provided, marks the whole channel/DM or thread as read."),
 			),
 		), conversationsHandler.ConversationsMarkHandler)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -352,15 +352,18 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 	// Register mark tool - marks a channel as read
 	if shouldAddTool(ToolConversationsMark, enabledTools, "") {
 		s.AddTool(mcp.NewTool(ToolConversationsMark,
-			mcp.WithDescription("Mark a channel or DM as read. If no timestamp is provided, marks all messages as read."),
+			mcp.WithDescription("Mark a channel, DM or thread as read. Without thread_ts it marks the channel/DM as read up to ts (or all messages if ts is omitted). With thread_ts it marks that thread as read up to ts (or up to its latest reply if ts is omitted); marking threads requires browser session tokens (xoxc/xoxd)."),
 			mcp.WithTitleAnnotation("Mark as Read"),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("channel_id",
 				mcp.Required(),
 				mcp.Description("ID of the channel in format Cxxxxxxxxxx or its name starting with #... or @... (e.g., #general, @username)."),
 			),
+			mcp.WithString("thread_ts",
+				mcp.Description("Timestamp of a thread's parent message in format 1234567890.123456. If provided, the thread (not the channel) is marked as read."),
+			),
 			mcp.WithString("ts",
-				mcp.Description("Timestamp of the message to mark as read up to. If not provided, marks all messages as read."),
+				mcp.Description("Timestamp of the message to mark as read up to (channel message, or reply within the thread when thread_ts is provided). If not provided, marks the whole channel/DM or thread as read."),
 			),
 		), conversationsHandler.ConversationsMarkHandler)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -352,7 +352,7 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 	// Register mark tool - marks a channel as read
 	if shouldAddTool(ToolConversationsMark, enabledTools, "") {
 		s.AddTool(mcp.NewTool(ToolConversationsMark,
-			mcp.WithDescription("Mark a channel, DM or thread as read. Without thread_ts it marks the channel/DM as read up to ts (or all messages if ts is omitted). With thread_ts it marks that thread as read up to ts (or up to its latest reply if ts is omitted). A thread's read cursor only moves forward: marking up to a ts that is already read changes nothing and the result says so. Marking threads requires browser session tokens (xoxc/xoxd)."),
+			mcp.WithDescription("Mark a channel, DM or thread as read. Without thread_ts it marks the channel/DM as read up to ts (or all messages if ts is omitted). With thread_ts it marks that thread as read up to ts (or up to its latest reply if ts is omitted). A thread's read cursor only moves forward: marking up to a ts that is already read changes nothing and the result says so (when Slack reports the previous read position). thread_ts must be a thread parent (not a reply, not a message without replies). Marking threads requires browser session tokens (xoxc/xoxd)."),
 			mcp.WithTitleAnnotation("Mark as Read"),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithString("channel_id",


### PR DESCRIPTION
## Summary

`conversations_mark` gains an optional **`thread_ts`** parameter. When set, the tool marks that **thread** as read (up to `ts`, or up to the thread's latest reply when `ts` is omitted) instead of moving the channel's read cursor.

Until now the server could only mark channels/DMs as read (`conversations.mark`). Thread unread state lives in a separate per-thread cursor, so threads kept showing as unread in the "Threads" view no matter what — there was no thread-mark endpoint in the server at all.

### Design

- New edge call `SubscriptionsThreadMark` → Slack's `subscriptions.thread.mark` (the API behind the "Threads" view) with `channel`, `thread_ts`, `ts`. Same undocumented browser-session family as `client.counts` / `saved.*`.
- The handler always fetches the thread's parent (`conversations.replies`, limit 1) first, so it can (a) verify `thread_ts` is a thread parent — a reply's ts yields an error naming the real parent, a plain message without replies is refused (`… is not a thread`), a non-existent one yields `thread_not_found`; (b) check an explicit `ts` lies between `thread_ts` and the thread's latest reply; and (c) read the current cursor (`last_read`).
- With `ts` omitted it marks up to `latest_reply` (falls back to `thread_ts` for a thread without replies).
- Slack's per-thread cursor is **forward-only** (`last_read = max(current, ts)`), so a mark up to an already-read position is a no-op — when Slack reports the previous position the tool says so explicitly (`… was already read up to <ts>; nothing changed`) rather than claiming a mark, and when it doesn't the result notes that the previous position is unknown. The endpoint's `read` flag is deliberately never sent (`read=false` marks a thread *unread*).
- Strict argument handling: `thread_ts` / `ts` are read from the raw arguments — a non-string value (e.g. an unquoted JSON number) or a present-but-empty `thread_ts` is rejected instead of silently falling back to marking the whole channel (mcp-go does not validate arguments against the schema). JSON `null` / absent still means channel mode; an empty `ts` still means "mark everything" as before.
- Thread marking is only available to browser session tokens (`xoxc`/`xoxd`); OAuth (`xoxp`) and bot (`xoxb`) tokens get a clear error from the thread path, while channel/DM marking is unchanged for all token types. Both paths remain governed by `SLACK_MCP_MARK_TOOL`.
- `thread_ts` / `ts` must have exactly six fractional digits (what Slack accepts; anything else is `invalid_timestamp`), so malformed values fail fast client-side; numerically-equal values are forwarded in Slack's canonical form. `#channel` / `@user` names are resolved via `resolveChannelID` (cache refresh + retry) instead of a single cache lookup, after the cheap argument checks; `channel_id` is trimmed. Slack timestamps are compared without floating point.
- `markThreadAsRead` takes the API through a narrow interface so it is unit-tested with a fake (parent lookup, latest-reply fallback, bounds, already-read reporting, error propagation).

| File | Change |
|------|--------|
| `pkg/provider/edge/subscriptions.go` | **NEW** — `SubscriptionsThreadMark` (`subscriptions.thread.mark`) |
| `pkg/provider/edge/subscriptions_test.go` | **NEW** — HTTP-level unit tests (endpoint, form fields, `ok=false` / non-2xx handling) |
| `pkg/provider/api.go` | Added to `SlackAPI` + `MCPSlackClient` wrapper |
| `pkg/handler/conversations.go` | strict `thread_ts`/`ts` parsing, `markThreadAsRead` (parent lookup, bounds, truthful result), `compareSlackTs` |
| `pkg/handler/conversations_test.go` | Parser tests (types, blank/null, bounds, both `SLACK_MCP_MARK_TOOL` branches), `compareSlackTs`, `markThreadAsRead` via a fake API |
| `pkg/server/server.go` | `thread_ts` parameter + updated descriptions for `conversations_mark` |
| `README.md` | Documented thread marking and its forward-only / no-change semantics |

### Token compatibility

| Token | channel/DM (`conversations.mark`) | thread (`subscriptions.thread.mark`) |
|-------|-----------------------------------|--------------------------------------|
| `xoxc`/`xoxd` | unchanged | Tested, works |
| `xoxp` | unchanged | Clear error (not available) |
| `xoxb` | unchanged | Clear error (not available) |

### Testing

- `make test` / `go vet` pass; unit tests added as listed above.
- Endpoint contract verified against the live API: `subscriptions.thread.mark` requires `channel`, `thread_ts`, `ts`; the cursor is forward-only.
- End-to-end through the MCP server over stdio with `xoxc`/`xoxd`, each step read back via the parent's `last_read` in `conversations.replies`: numeric / blank `thread_ts`, numeric `ts` and an 8-fractional-digit `ts` are rejected without touching the channel; `ts` beyond the latest reply rejected; a reply's ts as `thread_ts` → error naming the parent; a plain DM message as `thread_ts` → "is not a thread"; mark to an explicit reply `ts`; mark to the latest reply; older `ts` and re-mark → "nothing changed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
