### PR TITLE
feat(conversations): add conversations_threads tool (Slack "Threads" view)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,17 +237,17 @@ Clear all completed saved items from the "Save for Later" panel. This is a bulk 
 - **Parameters:** None.
 
 ### 19. conversations_threads
-List the threads you are subscribed to — Slack's "Threads" view — newest activity first, with each thread's unread reply count and the unread (or latest) replies. By default only threads with unread replies from the last 30 days are returned. Combine with `conversations_mark` (`channel_id` + `thread_ts`) to mark a listed thread as read.
+List the threads you are subscribed to — Slack's "Threads" view — newest activity first, with each thread's unread reply count and the unread (or latest) replies. By default only threads with unread replies from the last 30 days are returned.
 
 > **Note:** This tool requires browser session tokens (`xoxc`/`xoxd`). It is not available with standard OAuth (`xoxp`) or bot (`xoxb`) tokens. Slack serves this view 10 threads per page, so one call scans at most 500 threads; the last row's `Cursor` column is non-empty when more are available.
 
 - **Parameters:**
   - `filter` (string, default `"unread"`): `"unread"` returns only threads with unread replies; `"all"` returns every subscribed thread in the time window.
   - `channel_id` (string, optional): Only threads in this channel or DM, in format `Cxxxxxxxxxx` / `Dxxxxxxxxxx` or its name starting with `#...` or `@...`.
-  - `since` (string, default `"30d"`): How far back to look, by a thread's latest activity: a duration like `1d`, `7d`, `2w`, `1m`, or `"all"` for no time bound.
+  - `since` (string, default `"30d"`): How far back to look, by a thread's latest activity: a duration like `1d`, `7d`, `2w`, `1m` (`d` = days, `w` = weeks, `m` = months), or `"all"` for no time bound.
   - `limit` (number, default `20`, max `200`): Maximum number of threads to return.
   - `include_replies` (number, default `3`, max `20`): How many replies to include per thread in the `Replies` column — the unread ones when the thread has unread replies, otherwise the latest ones; `0` omits reply text.
-  - `cursor` (string, optional): The value of the last row's `Cursor` column from the previous call, to continue where that call stopped.
+  - `cursor` (string, optional): The value of the last row's `Cursor` column from the previous call, to continue where that call stopped (repeat the same `filter`, `channel_id` and `since`).
 
 - **Returns:** CSV with columns `Channel`, `ChannelID`, `ThreadTs`, `RootUser`, `RootTime`, `RootText`, `ReplyCount`, `UnreadReplies`, `LatestReplyTime`, `LastRead`, `Replies`, `Cursor`.
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,21 @@ Clear all completed saved items from the "Save for Later" panel. This is a bulk 
 
 - **Parameters:** None.
 
+### 19. conversations_threads
+List the threads you are subscribed to — Slack's "Threads" view — newest activity first, with each thread's unread reply count and the unread (or latest) replies. By default only threads with unread replies from the last 30 days are returned. Combine with `conversations_mark` (`channel_id` + `thread_ts`) to mark a listed thread as read.
+
+> **Note:** This tool requires browser session tokens (`xoxc`/`xoxd`). It is not available with standard OAuth (`xoxp`) or bot (`xoxb`) tokens. Slack serves this view 10 threads per page, so one call scans at most 500 threads; the last row's `Cursor` column is non-empty when more are available.
+
+- **Parameters:**
+  - `filter` (string, default `"unread"`): `"unread"` returns only threads with unread replies; `"all"` returns every subscribed thread in the time window.
+  - `channel_id` (string, optional): Only threads in this channel or DM, in format `Cxxxxxxxxxx` / `Dxxxxxxxxxx` or its name starting with `#...` or `@...`.
+  - `since` (string, default `"30d"`): How far back to look, by a thread's latest activity: a duration like `1d`, `7d`, `2w`, `1m`, or `"all"` for no time bound.
+  - `limit` (number, default `20`, max `200`): Maximum number of threads to return.
+  - `include_replies` (number, default `3`, max `20`): How many replies to include per thread in the `Replies` column — the unread ones when the thread has unread replies, otherwise the latest ones; `0` omits reply text.
+  - `cursor` (string, optional): The value of the last row's `Cursor` column from the previous call, to continue where that call stopped.
+
+- **Returns:** CSV with columns `Channel`, `ChannelID`, `ThreadTs`, `RootUser`, `RootTime`, `RootText`, `ReplyCount`, `UnreadReplies`, `LatestReplyTime`, `LastRead`, `Replies`, `Cursor`.
+
 ## Resources
 
 The Slack MCP Server exposes two special directory resources for easy access to workspace metadata:

--- a/pkg/handler/threads.go
+++ b/pkg/handler/threads.go
@@ -1,0 +1,355 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gocarina/gocsv"
+	"github.com/korotovsky/slack-mcp-server/pkg/limiter"
+	"github.com/korotovsky/slack-mcp-server/pkg/provider"
+	"github.com/korotovsky/slack-mcp-server/pkg/provider/edge"
+	"github.com/korotovsky/slack-mcp-server/pkg/text"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/slack-go/slack"
+	"go.uber.org/zap"
+)
+
+const (
+	threadsFilterUnread = "unread"
+	threadsFilterAll    = "all"
+
+	// threadsPageSize is what subscriptions.thread.getView returns per page
+	// regardless of the requested limit.
+	threadsPageSize = 10
+	// threadsMaxPages bounds one tool call; the caller continues with the cursor.
+	threadsMaxPages = 50
+
+	threadsDefaultLimit   = 20
+	threadsMaxLimit       = 200
+	threadsDefaultReplies = 3
+	threadsMaxReplies     = 20
+	threadsDefaultSince   = "30d"
+	threadsSinceUnbounded = "all"
+	threadsRepliesJoin    = " || "
+)
+
+// ThreadRow is one thread of Slack's "Threads" view as returned by conversations_threads.
+type ThreadRow struct {
+	Channel         string `csv:"Channel"`
+	ChannelID       string `csv:"ChannelID"`
+	ThreadTs        string `csv:"ThreadTs"`
+	RootUser        string `csv:"RootUser"`
+	RootTime        string `csv:"RootTime"`
+	RootText        string `csv:"RootText"`
+	ReplyCount      int    `csv:"ReplyCount"`
+	UnreadReplies   int    `csv:"UnreadReplies"`
+	LatestReplyTime string `csv:"LatestReplyTime"`
+	LastRead        string `csv:"LastRead"`
+	Replies         string `csv:"Replies"`
+	Cursor          string `csv:"Cursor"`
+}
+
+type ThreadsHandler struct {
+	apiProvider *provider.ApiProvider
+	logger      *zap.Logger
+	convHandler *ConversationsHandler
+}
+
+func NewThreadsHandler(apiProvider *provider.ApiProvider, logger *zap.Logger, convHandler *ConversationsHandler) *ThreadsHandler {
+	return &ThreadsHandler{apiProvider: apiProvider, logger: logger, convHandler: convHandler}
+}
+
+type threadsParams struct {
+	filter         string
+	channelID      string
+	oldest         string // Slack ts; threads whose latest activity is older stop the scan ("" = unbounded)
+	limit          int
+	includeReplies int
+	cursor         string
+}
+
+// threadsPageFetcher fetches one page of the Threads view for a cursor.
+type threadsPageFetcher func(ctx context.Context, cursor string) (edge.ThreadsViewResponse, error)
+
+// threadsScan is the outcome of collectThreads.
+type threadsScan struct {
+	threads    []edge.ThreadView
+	nextCursor string // "" when the scan is exhausted (no more pages, or the time bound was reached)
+	scanned    int    // threads looked at, matched or not
+	pages      int
+	hitPageCap bool
+}
+
+func (h *ThreadsHandler) ConversationsThreadsHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	h.logger.Debug("ConversationsThreadsHandler called", zap.Any("params", request.Params))
+
+	params, err := h.parseThreadsParams(ctx, request)
+	if err != nil {
+		h.logger.Error("Failed to parse threads params", zap.Error(err))
+		return nil, err
+	}
+
+	rl := limiter.Tier3.Limiter()
+	first := true
+	fetch := func(ctx context.Context, cursor string) (edge.ThreadsViewResponse, error) {
+		if !first {
+			if err := rl.Wait(ctx); err != nil {
+				return edge.ThreadsViewResponse{}, err
+			}
+		}
+		first = false
+		return h.apiProvider.Slack().SubscriptionsThreadGetView(ctx, cursor, threadsPageSize, params.channelID)
+	}
+
+	scan, err := collectThreads(ctx, fetch, params)
+	if err != nil {
+		h.logger.Error("Threads view fetch failed", zap.Error(err))
+		return nil, fmt.Errorf("failed to list threads: %v", err)
+	}
+
+	if len(scan.threads) == 0 {
+		msg := fmt.Sprintf("No matching threads (scanned %d threads", scan.scanned)
+		if scan.nextCursor != "" {
+			msg += fmt.Sprintf("; more may follow, continue with cursor=%s", scan.nextCursor)
+		}
+		return mcp.NewToolResultText(msg + ")"), nil
+	}
+
+	rows := h.renderThreadRows(ctx, scan.threads, params.includeReplies)
+	if len(rows) > 0 {
+		rows[len(rows)-1].Cursor = scan.nextCursor
+	}
+
+	csvBytes, err := gocsv.MarshalBytes(&rows)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal threads: %v", err)
+	}
+	return mcp.NewToolResultText(string(csvBytes)), nil
+}
+
+func (h *ThreadsHandler) parseThreadsParams(ctx context.Context, request mcp.CallToolRequest) (*threadsParams, error) {
+	filter := strings.ToLower(strings.TrimSpace(request.GetString("filter", threadsFilterUnread)))
+	if filter == "" {
+		filter = threadsFilterUnread
+	}
+	if filter != threadsFilterUnread && filter != threadsFilterAll {
+		return nil, fmt.Errorf("filter must be %q or %q, got %q", threadsFilterUnread, threadsFilterAll, filter)
+	}
+
+	limit := request.GetInt("limit", threadsDefaultLimit)
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be a positive number, got %d", limit)
+	}
+	if limit > threadsMaxLimit {
+		limit = threadsMaxLimit
+	}
+
+	includeReplies := request.GetInt("include_replies", threadsDefaultReplies)
+	if includeReplies < 0 {
+		return nil, fmt.Errorf("include_replies must be zero or positive, got %d", includeReplies)
+	}
+	if includeReplies > threadsMaxReplies {
+		includeReplies = threadsMaxReplies
+	}
+
+	since := strings.ToLower(strings.TrimSpace(request.GetString("since", threadsDefaultSince)))
+	if since == "" {
+		since = threadsDefaultSince
+	}
+	oldest := ""
+	if since != threadsSinceUnbounded {
+		var err error
+		if _, oldest, _, err = limitByExpression(since, threadsDefaultSince); err != nil {
+			return nil, fmt.Errorf("since must be a duration like 1d, 7d, 2w, 1m or %q: %v", threadsSinceUnbounded, err)
+		}
+	}
+
+	cursor := strings.TrimSpace(request.GetString("cursor", ""))
+	if cursor != "" && !isSlackTimestamp(cursor) {
+		return nil, fmt.Errorf("cursor must be a value from the Cursor column of a previous conversations_threads result, got %q", cursor)
+	}
+
+	channelID := ""
+	if channel := strings.TrimSpace(request.GetString("channel_id", "")); channel != "" {
+		resolved, err := h.convHandler.resolveChannelID(ctx, channel)
+		if err != nil {
+			h.logger.Error("Channel not found", zap.String("channel", channel), zap.Error(err))
+			return nil, err
+		}
+		channelID = resolved
+	}
+
+	return &threadsParams{
+		filter:         filter,
+		channelID:      channelID,
+		oldest:         oldest,
+		limit:          limit,
+		includeReplies: includeReplies,
+		cursor:         cursor,
+	}, nil
+}
+
+// collectThreads pages through the Threads view (newest activity first) and
+// returns up to params.limit threads matching params.filter, stopping at the
+// time bound (params.oldest), the end of the view, or threadsMaxPages. The
+// returned cursor lets the caller continue exactly where the scan stopped.
+func collectThreads(ctx context.Context, fetch threadsPageFetcher, params *threadsParams) (*threadsScan, error) {
+	scan := &threadsScan{}
+	cursor := params.cursor
+
+	for scan.pages < threadsMaxPages {
+		resp, err := fetch(ctx, cursor)
+		if err != nil {
+			return nil, err
+		}
+		scan.pages++
+		if len(resp.Threads) == 0 {
+			scan.nextCursor = ""
+			return scan, nil
+		}
+
+		for _, t := range resp.Threads {
+			latest := threadLatestActivity(t)
+
+			// Threads are ordered by latest activity descending; once we are
+			// past the time bound nothing further can match.
+			if params.oldest != "" && latest < params.oldest {
+				scan.nextCursor = ""
+				return scan, nil
+			}
+			scan.scanned++
+
+			if params.filter == threadsFilterUnread && len(t.UnreadReplies) == 0 {
+				continue
+			}
+			scan.threads = append(scan.threads, t)
+			if len(scan.threads) >= params.limit {
+				// Continue from this thread's activity timestamp: getView returns
+				// threads strictly older than current_ts.
+				scan.nextCursor = latest
+				return scan, nil
+			}
+		}
+
+		if !resp.HasMore {
+			scan.nextCursor = ""
+			return scan, nil
+		}
+		next := threadLatestActivity(resp.Threads[len(resp.Threads)-1])
+		for _, t := range resp.Threads {
+			if l := threadLatestActivity(t); l < next {
+				next = l
+			}
+		}
+		if next == cursor {
+			// Defensive: no progress possible.
+			scan.nextCursor = ""
+			return scan, nil
+		}
+		cursor = next
+	}
+
+	scan.hitPageCap = true
+	scan.nextCursor = cursor
+	return scan, nil
+}
+
+// threadLatestActivity is the timestamp the Threads view orders by.
+func threadLatestActivity(t edge.ThreadView) string {
+	if t.RootMsg.LatestReply != "" {
+		return t.RootMsg.LatestReply
+	}
+	return t.RootMsg.Timestamp
+}
+
+// renderThreadRows converts threads into CSV rows, resolving user names and
+// message text through the same pipeline as the other conversation tools.
+func (h *ThreadsHandler) renderThreadRows(ctx context.Context, threads []edge.ThreadView, includeReplies int) []ThreadRow {
+	channelsMaps := h.apiProvider.ProvideChannelsMaps()
+	rows := make([]ThreadRow, 0, len(threads))
+
+	for _, t := range threads {
+		channelID := t.RootMsg.Channel
+		channelName := channelID
+		if cached, ok := channelsMaps.Channels[channelID]; ok {
+			channelName = cached.Name
+		}
+
+		row := ThreadRow{
+			Channel:         channelName,
+			ChannelID:       channelID,
+			ThreadTs:        t.RootMsg.Timestamp,
+			ReplyCount:      t.RootMsg.ReplyCount,
+			UnreadReplies:   len(t.UnreadReplies),
+			LatestReplyTime: slackTsToISO(t.RootMsg.LatestReply),
+			LastRead:        slackTsToISO(t.RootMsg.LastRead),
+		}
+
+		if root := h.convHandler.convertMessagesFromHistory(ctx, []slack.Message{t.RootMsg}, channelID, true); len(root) > 0 {
+			row.RootUser = messageAuthor(root[0])
+			row.RootTime = root[0].Time
+			row.RootText = root[0].Text
+		} else {
+			row.RootTime = slackTsToISO(t.RootMsg.Timestamp)
+		}
+
+		if includeReplies > 0 {
+			replies := t.UnreadReplies
+			if len(replies) == 0 {
+				replies = t.LatestReplies
+			}
+			if len(replies) > includeReplies {
+				replies = replies[len(replies)-includeReplies:]
+			}
+			rendered := h.convHandler.convertMessagesFromHistory(ctx, replies, channelID, true)
+			parts := make([]string, 0, len(rendered))
+			for _, m := range rendered {
+				parts = append(parts, fmt.Sprintf("%s %s: %s", m.Time, messageAuthor(m), m.Text))
+			}
+			row.Replies = strings.Join(parts, threadsRepliesJoin)
+		}
+
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func messageAuthor(m Message) string {
+	switch {
+	case m.RealName != "":
+		return m.RealName
+	case m.UserName != "":
+		return m.UserName
+	case m.BotName != "":
+		return m.BotName
+	default:
+		return m.UserID
+	}
+}
+
+// slackTsToISO formats a Slack timestamp as RFC3339, or "" when empty/invalid.
+func slackTsToISO(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	iso, err := text.TimestampToIsoRFC3339(ts)
+	if err != nil {
+		return ""
+	}
+	return iso
+}
+
+// isSlackTimestamp reports whether s looks like a Slack timestamp ("1234567890.123456").
+func isSlackTimestamp(s string) bool {
+	sec, frac, ok := strings.Cut(s, ".")
+	if !ok || sec == "" || frac == "" {
+		return false
+	}
+	for _, r := range sec + frac {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/handler/threads.go
+++ b/pkg/handler/threads.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/gocarina/gocsv"
@@ -63,6 +64,7 @@ func NewThreadsHandler(apiProvider *provider.ApiProvider, logger *zap.Logger, co
 type threadsParams struct {
 	filter         string
 	channelID      string
+	since          string // as given/defaulted, for messages ("all" = unbounded)
 	oldest         string // Slack ts; threads whose latest activity is older stop the scan ("" = unbounded)
 	limit          int
 	includeReplies int
@@ -74,11 +76,12 @@ type threadsPageFetcher func(ctx context.Context, cursor string) (edge.ThreadsVi
 
 // threadsScan is the outcome of collectThreads.
 type threadsScan struct {
-	threads    []edge.ThreadView
-	nextCursor string // "" when the scan is exhausted (no more pages, or the time bound was reached)
-	scanned    int    // threads looked at, matched or not
-	pages      int
-	hitPageCap bool
+	threads      []edge.ThreadView
+	nextCursor   string // "" when the scan is exhausted (no more pages, or the time bound was reached)
+	scanned      int    // threads looked at within the time window, matched or not
+	pages        int
+	hitPageCap   bool // stopped after threadsMaxPages; nextCursor continues the scan
+	hitTimeBound bool // stopped because the next thread's latest activity is older than params.oldest
 }
 
 func (h *ThreadsHandler) ConversationsThreadsHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -109,23 +112,46 @@ func (h *ThreadsHandler) ConversationsThreadsHandler(ctx context.Context, reques
 	}
 
 	if len(scan.threads) == 0 {
-		msg := fmt.Sprintf("No matching threads (scanned %d threads", scan.scanned)
-		if scan.nextCursor != "" {
-			msg += fmt.Sprintf("; more may follow, continue with cursor=%s", scan.nextCursor)
-		}
-		return mcp.NewToolResultText(msg + ")"), nil
+		return mcp.NewToolResultText(noThreadsMessage(scan, params)), nil
 	}
 
-	rows := h.renderThreadRows(ctx, scan.threads, params.includeReplies)
-	if len(rows) > 0 {
-		rows[len(rows)-1].Cursor = scan.nextCursor
+	channelsMaps := h.apiProvider.ProvideChannelsMaps()
+	channelName := func(id string) string {
+		if cached, ok := channelsMaps.Channels[id]; ok {
+			return cached.Name
+		}
+		return id
 	}
+	render := func(ctx context.Context, msgs []slack.Message, channelID string) []Message {
+		return h.convHandler.convertMessagesFromHistory(ctx, msgs, channelID, true)
+	}
+	rows := buildThreadRows(ctx, scan.threads, params, scan.nextCursor, channelName, render)
 
 	csvBytes, err := gocsv.MarshalBytes(&rows)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal threads: %v", err)
 	}
 	return mcp.NewToolResultText(string(csvBytes)), nil
+}
+
+// noThreadsMessage explains an empty result: what was scanned and why the scan stopped.
+func noThreadsMessage(scan *threadsScan, params *threadsParams) string {
+	what := "threads with unread replies"
+	if params.filter == threadsFilterAll {
+		what = "threads"
+	}
+	msg := fmt.Sprintf("No %s found (scanned %d threads", what, scan.scanned)
+	switch {
+	case scan.hitTimeBound:
+		msg += fmt.Sprintf("; the time window since=%s ended the scan — use a larger since, or since=all", params.since)
+	case scan.hitPageCap:
+		msg += fmt.Sprintf("; stopped after %d threads, continue with cursor=%s", scan.scanned, scan.nextCursor)
+	case scan.nextCursor != "":
+		msg += fmt.Sprintf("; more may follow, continue with cursor=%s", scan.nextCursor)
+	default:
+		msg += "; end of the Threads view reached"
+	}
+	return msg + ")"
 }
 
 func (h *ThreadsHandler) parseThreadsParams(ctx context.Context, request mcp.CallToolRequest) (*threadsParams, error) {
@@ -161,7 +187,7 @@ func (h *ThreadsHandler) parseThreadsParams(ctx context.Context, request mcp.Cal
 	if since != threadsSinceUnbounded {
 		var err error
 		if _, oldest, _, err = limitByExpression(since, threadsDefaultSince); err != nil {
-			return nil, fmt.Errorf("since must be a duration like 1d, 7d, 2w, 1m or %q: %v", threadsSinceUnbounded, err)
+			return nil, fmt.Errorf("since must be a duration like 1d, 7d, 2w, 1m (d=days, w=weeks, m=months) or %q: %v", threadsSinceUnbounded, err)
 		}
 	}
 
@@ -183,6 +209,7 @@ func (h *ThreadsHandler) parseThreadsParams(ctx context.Context, request mcp.Cal
 	return &threadsParams{
 		filter:         filter,
 		channelID:      channelID,
+		since:          since,
 		oldest:         oldest,
 		limit:          limit,
 		includeReplies: includeReplies,
@@ -209,12 +236,17 @@ func collectThreads(ctx context.Context, fetch threadsPageFetcher, params *threa
 			return scan, nil
 		}
 
-		for _, t := range resp.Threads {
+		for i, t := range resp.Threads {
 			latest := threadLatestActivity(t)
+			if latest == "" {
+				// Malformed entry (no timestamps at all): nothing to order or filter on.
+				continue
+			}
 
 			// Threads are ordered by latest activity descending; once we are
 			// past the time bound nothing further can match.
-			if params.oldest != "" && latest < params.oldest {
+			if params.oldest != "" && slackTsBefore(latest, params.oldest) {
+				scan.hitTimeBound = true
 				scan.nextCursor = ""
 				return scan, nil
 			}
@@ -225,9 +257,14 @@ func collectThreads(ctx context.Context, fetch threadsPageFetcher, params *threa
 			}
 			scan.threads = append(scan.threads, t)
 			if len(scan.threads) >= params.limit {
-				// Continue from this thread's activity timestamp: getView returns
-				// threads strictly older than current_ts.
-				scan.nextCursor = latest
+				if i == len(resp.Threads)-1 && !resp.HasMore {
+					// Nothing left in the view.
+					scan.nextCursor = ""
+				} else {
+					// Continue from this thread's activity timestamp: getView
+					// returns threads strictly older than current_ts.
+					scan.nextCursor = latest
+				}
 				return scan, nil
 			}
 		}
@@ -236,13 +273,13 @@ func collectThreads(ctx context.Context, fetch threadsPageFetcher, params *threa
 			scan.nextCursor = ""
 			return scan, nil
 		}
-		next := threadLatestActivity(resp.Threads[len(resp.Threads)-1])
+		next := ""
 		for _, t := range resp.Threads {
-			if l := threadLatestActivity(t); l < next {
+			if l := threadLatestActivity(t); l != "" && (next == "" || slackTsBefore(l, next)) {
 				next = l
 			}
 		}
-		if next == cursor {
+		if next == "" || next == cursor {
 			// Defensive: no progress possible.
 			scan.nextCursor = ""
 			return scan, nil
@@ -255,6 +292,29 @@ func collectThreads(ctx context.Context, fetch threadsPageFetcher, params *threa
 	return scan, nil
 }
 
+// slackTsBefore reports whether Slack timestamp a is strictly older than b,
+// comparing numerically (seconds, then fraction) rather than as strings, so
+// timestamps of different widths compare correctly.
+func slackTsBefore(a, b string) bool {
+	aSec, aFrac, _ := strings.Cut(a, ".")
+	bSec, bFrac, _ := strings.Cut(b, ".")
+	as, aErr := strconv.ParseInt(aSec, 10, 64)
+	bs, bErr := strconv.ParseInt(bSec, 10, 64)
+	if aErr != nil || bErr != nil {
+		return a < b // not Slack timestamps; fall back to string order
+	}
+	if as != bs {
+		return as < bs
+	}
+	for len(aFrac) < len(bFrac) {
+		aFrac += "0"
+	}
+	for len(bFrac) < len(aFrac) {
+		bFrac += "0"
+	}
+	return aFrac < bFrac
+}
+
 // threadLatestActivity is the timestamp the Threads view orders by.
 func threadLatestActivity(t edge.ThreadView) string {
 	if t.RootMsg.LatestReply != "" {
@@ -263,46 +323,49 @@ func threadLatestActivity(t edge.ThreadView) string {
 	return t.RootMsg.Timestamp
 }
 
-// renderThreadRows converts threads into CSV rows, resolving user names and
-// message text through the same pipeline as the other conversation tools.
-func (h *ThreadsHandler) renderThreadRows(ctx context.Context, threads []edge.ThreadView, includeReplies int) []ThreadRow {
-	channelsMaps := h.apiProvider.ProvideChannelsMaps()
+// threadMessageRenderer converts raw Slack messages of one channel into Message
+// rows (user names resolved, text processed) — in production this is
+// ConversationsHandler.convertMessagesFromHistory.
+type threadMessageRenderer func(ctx context.Context, msgs []slack.Message, channelID string) []Message
+
+// buildThreadRows converts threads into CSV rows. channelName maps a channel ID
+// to its display name; the last row carries nextCursor.
+func buildThreadRows(ctx context.Context, threads []edge.ThreadView, params *threadsParams, nextCursor string, channelName func(string) string, render threadMessageRenderer) []ThreadRow {
 	rows := make([]ThreadRow, 0, len(threads))
 
 	for _, t := range threads {
 		channelID := t.RootMsg.Channel
-		channelName := channelID
-		if cached, ok := channelsMaps.Channels[channelID]; ok {
-			channelName = cached.Name
+		if channelID == "" {
+			// Slack normally sets root_msg.channel; fall back to the requested channel.
+			channelID = params.channelID
 		}
 
 		row := ThreadRow{
-			Channel:         channelName,
+			Channel:         channelName(channelID),
 			ChannelID:       channelID,
 			ThreadTs:        t.RootMsg.Timestamp,
 			ReplyCount:      t.RootMsg.ReplyCount,
 			UnreadReplies:   len(t.UnreadReplies),
 			LatestReplyTime: slackTsToISO(t.RootMsg.LatestReply),
 			LastRead:        slackTsToISO(t.RootMsg.LastRead),
+			RootTime:        slackTsToISO(t.RootMsg.Timestamp),
 		}
 
-		if root := h.convHandler.convertMessagesFromHistory(ctx, []slack.Message{t.RootMsg}, channelID, true); len(root) > 0 {
+		if root := render(ctx, []slack.Message{t.RootMsg}, channelID); len(root) > 0 {
 			row.RootUser = messageAuthor(root[0])
 			row.RootTime = root[0].Time
 			row.RootText = root[0].Text
-		} else {
-			row.RootTime = slackTsToISO(t.RootMsg.Timestamp)
 		}
 
-		if includeReplies > 0 {
+		if params.includeReplies > 0 {
 			replies := t.UnreadReplies
 			if len(replies) == 0 {
 				replies = t.LatestReplies
 			}
-			if len(replies) > includeReplies {
-				replies = replies[len(replies)-includeReplies:]
+			if len(replies) > params.includeReplies {
+				replies = replies[len(replies)-params.includeReplies:]
 			}
-			rendered := h.convHandler.convertMessagesFromHistory(ctx, replies, channelID, true)
+			rendered := render(ctx, replies, channelID)
 			parts := make([]string, 0, len(rendered))
 			for _, m := range rendered {
 				parts = append(parts, fmt.Sprintf("%s %s: %s", m.Time, messageAuthor(m), m.Text))
@@ -311,6 +374,9 @@ func (h *ThreadsHandler) renderThreadRows(ctx context.Context, threads []edge.Th
 		}
 
 		rows = append(rows, row)
+	}
+	if len(rows) > 0 {
+		rows[len(rows)-1].Cursor = nextCursor
 	}
 	return rows
 }
@@ -340,10 +406,11 @@ func slackTsToISO(ts string) string {
 	return iso
 }
 
-// isSlackTimestamp reports whether s looks like a Slack timestamp ("1234567890.123456").
+// isSlackTimestamp reports whether s is a Slack timestamp ("1234567890.123456":
+// digits, a dot, exactly six fractional digits — anything else Slack rejects).
 func isSlackTimestamp(s string) bool {
 	sec, frac, ok := strings.Cut(s, ".")
-	if !ok || sec == "" || frac == "" {
+	if !ok || sec == "" || len(frac) != 6 {
 		return false
 	}
 	for _, r := range sec + frac {

--- a/pkg/handler/threads_test.go
+++ b/pkg/handler/threads_test.go
@@ -1,0 +1,226 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/korotovsky/slack-mcp-server/pkg/provider/edge"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// mkThread builds a Threads-view entry with the given latest activity and unread count.
+func mkThread(channel, ts, latestReply string, unread int) edge.ThreadView {
+	t := edge.ThreadView{}
+	t.RootMsg.Channel = channel
+	t.RootMsg.Timestamp = ts
+	t.RootMsg.ThreadTimestamp = ts
+	t.RootMsg.LatestReply = latestReply
+	t.RootMsg.ReplyCount = unread + 1
+	for i := 0; i < unread; i++ {
+		t.UnreadReplies = append(t.UnreadReplies, slack.Message{})
+	}
+	return t
+}
+
+// fakePager serves pre-built pages keyed by cursor ("" = first page) and records the cursors requested.
+type fakePager struct {
+	pages   map[string]edge.ThreadsViewResponse
+	err     error
+	cursors []string
+}
+
+func (p *fakePager) fetch(ctx context.Context, cursor string) (edge.ThreadsViewResponse, error) {
+	p.cursors = append(p.cursors, cursor)
+	if p.err != nil {
+		return edge.ThreadsViewResponse{}, p.err
+	}
+	resp, ok := p.pages[cursor]
+	if !ok {
+		return edge.ThreadsViewResponse{}, fmt.Errorf("unexpected cursor %q", cursor)
+	}
+	return resp, nil
+}
+
+func TestUnitCollectThreads(t *testing.T) {
+	ctx := context.Background()
+	// Two pages, newest first. Page 1 ends at latest 1700000600; page 2 is older.
+	page1 := edge.ThreadsViewResponse{HasMore: true, Threads: []edge.ThreadView{
+		mkThread("C1", "1700000100.000001", "1700000900.000000", 2),
+		mkThread("C1", "1700000200.000001", "1700000800.000000", 0),
+		mkThread("C2", "1700000300.000001", "1700000700.000000", 1),
+		mkThread("C2", "1700000400.000001", "1700000600.000000", 0),
+	}}
+	page2 := edge.ThreadsViewResponse{HasMore: false, Threads: []edge.ThreadView{
+		mkThread("C3", "1600000100.000001", "1600000500.000000", 3),
+		mkThread("C3", "1600000200.000001", "", 0), // never replied: activity = its own ts
+	}}
+	pages := map[string]edge.ThreadsViewResponse{"": page1, "1700000600.000000": page2}
+
+	t.Run("unread filter across pages, exhausted view clears cursor", func(t *testing.T) {
+		p := &fakePager{pages: pages}
+		scan, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterUnread, limit: 20})
+		require.NoError(t, err)
+		require.Len(t, scan.threads, 3)
+		assert.Equal(t, "C1", scan.threads[0].RootMsg.Channel)
+		assert.Equal(t, "C3", scan.threads[2].RootMsg.Channel)
+		assert.Equal(t, 6, scan.scanned)
+		assert.Equal(t, 2, scan.pages)
+		assert.Empty(t, scan.nextCursor)
+		assert.False(t, scan.hitPageCap)
+		assert.Equal(t, []string{"", "1700000600.000000"}, p.cursors, "second page must be requested with the oldest activity of page 1")
+	})
+
+	t.Run("filter all returns every thread", func(t *testing.T) {
+		p := &fakePager{pages: pages}
+		scan, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterAll, limit: 20})
+		require.NoError(t, err)
+		assert.Len(t, scan.threads, 6)
+	})
+
+	t.Run("limit reached mid-page: cursor continues from that thread's activity", func(t *testing.T) {
+		p := &fakePager{pages: pages}
+		scan, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterUnread, limit: 1})
+		require.NoError(t, err)
+		require.Len(t, scan.threads, 1)
+		assert.Equal(t, "1700000900.000000", scan.nextCursor)
+		assert.Equal(t, 1, scan.pages)
+	})
+
+	t.Run("since bound stops the scan and clears the cursor", func(t *testing.T) {
+		p := &fakePager{pages: pages}
+		scan, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterAll, limit: 20, oldest: "1700000650.000000"})
+		require.NoError(t, err)
+		assert.Len(t, scan.threads, 3, "threads with activity older than the bound are not returned")
+		assert.Equal(t, 3, scan.scanned)
+		assert.Empty(t, scan.nextCursor)
+		assert.Equal(t, 1, scan.pages, "the bound was hit on page 1, page 2 must not be fetched")
+	})
+
+	t.Run("cursor param is used for the first fetch", func(t *testing.T) {
+		p := &fakePager{pages: pages}
+		scan, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterAll, limit: 20, cursor: "1700000600.000000"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"1700000600.000000"}, p.cursors)
+		assert.Len(t, scan.threads, 2)
+	})
+
+	t.Run("empty page ends the scan", func(t *testing.T) {
+		p := &fakePager{pages: map[string]edge.ThreadsViewResponse{"": {HasMore: true}}}
+		scan, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterAll, limit: 20})
+		require.NoError(t, err)
+		assert.Empty(t, scan.threads)
+		assert.Empty(t, scan.nextCursor)
+	})
+
+	t.Run("fetch error is propagated", func(t *testing.T) {
+		p := &fakePager{err: errors.New("not_allowed_token_type")}
+		_, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterAll, limit: 20})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not_allowed_token_type")
+	})
+
+	t.Run("page cap: stops with a cursor to continue", func(t *testing.T) {
+		// Endless view: every page has one read thread and says has_more.
+		endless := &fakePager{pages: map[string]edge.ThreadsViewResponse{}}
+		ts := int64(1700000000)
+		cursor := ""
+		for i := 0; i <= threadsMaxPages; i++ {
+			latest := fmt.Sprintf("%d.000000", ts-int64(i))
+			endless.pages[cursor] = edge.ThreadsViewResponse{HasMore: true, Threads: []edge.ThreadView{mkThread("C1", "1600000000.000001", latest, 0)}}
+			cursor = latest
+		}
+		scan, err := collectThreads(ctx, endless.fetch, &threadsParams{filter: threadsFilterUnread, limit: 20})
+		require.NoError(t, err)
+		assert.True(t, scan.hitPageCap)
+		assert.Equal(t, threadsMaxPages, scan.pages)
+		assert.NotEmpty(t, scan.nextCursor)
+		assert.Empty(t, scan.threads)
+		assert.Equal(t, threadsMaxPages, scan.scanned)
+	})
+}
+
+func TestUnitThreadsParseParams(t *testing.T) {
+	h := &ThreadsHandler{logger: zap.NewNop()}
+	ctx := context.Background()
+	newReq := func(args map[string]any) mcp.CallToolRequest {
+		req := mcp.CallToolRequest{}
+		req.Params.Name = "conversations_threads"
+		req.Params.Arguments = args
+		return req
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		p, err := h.parseThreadsParams(ctx, newReq(map[string]any{}))
+		require.NoError(t, err)
+		assert.Equal(t, threadsFilterUnread, p.filter)
+		assert.Equal(t, threadsDefaultLimit, p.limit)
+		assert.Equal(t, threadsDefaultReplies, p.includeReplies)
+		assert.NotEmpty(t, p.oldest, "default since=30d must produce a time bound")
+		assert.Empty(t, p.channelID)
+		assert.Empty(t, p.cursor)
+	})
+
+	t.Run("since=all removes the time bound; durations are accepted", func(t *testing.T) {
+		p, err := h.parseThreadsParams(ctx, newReq(map[string]any{"since": "all"}))
+		require.NoError(t, err)
+		assert.Empty(t, p.oldest)
+		for _, v := range []string{"1d", "7d", "2w", "1m", " 3D "} {
+			p, err := h.parseThreadsParams(ctx, newReq(map[string]any{"since": v}))
+			require.NoError(t, err, "since=%q", v)
+			assert.NotEmpty(t, p.oldest)
+		}
+	})
+
+	t.Run("invalid values are rejected", func(t *testing.T) {
+		cases := []map[string]any{
+			{"filter": "starred"},
+			{"limit": 0},
+			{"limit": -3},
+			{"include_replies": -1},
+			{"since": "yesterday"},
+			{"since": "7x"},
+			{"cursor": "not-a-ts"},
+		}
+		for _, args := range cases {
+			_, err := h.parseThreadsParams(ctx, newReq(args))
+			require.Error(t, err, "args %v must be rejected", args)
+		}
+	})
+
+	t.Run("limits are clamped, filter is case-insensitive, cursor accepted", func(t *testing.T) {
+		p, err := h.parseThreadsParams(ctx, newReq(map[string]any{"filter": "ALL", "limit": 5000, "include_replies": 99, "cursor": "1700000600.000000"}))
+		require.NoError(t, err)
+		assert.Equal(t, threadsFilterAll, p.filter)
+		assert.Equal(t, threadsMaxLimit, p.limit)
+		assert.Equal(t, threadsMaxReplies, p.includeReplies)
+		assert.Equal(t, "1700000600.000000", p.cursor)
+	})
+}
+
+func TestUnitThreadsHelpers(t *testing.T) {
+	assert.True(t, isSlackTimestamp("1700000600.000000"))
+	assert.False(t, isSlackTimestamp("1700000600"))
+	assert.False(t, isSlackTimestamp("abc.def"))
+	assert.False(t, isSlackTimestamp("1700000600."))
+	assert.False(t, isSlackTimestamp(".000000"))
+
+	assert.Equal(t, "", slackTsToISO(""))
+	assert.Equal(t, "", slackTsToISO("garbage"))
+	assert.NotEmpty(t, slackTsToISO("1700000600.000000"))
+
+	assert.Equal(t, "Real", messageAuthor(Message{RealName: "Real", UserName: "user", UserID: "U1"}))
+	assert.Equal(t, "user", messageAuthor(Message{UserName: "user", UserID: "U1"}))
+	assert.Equal(t, "bot", messageAuthor(Message{BotName: "bot", UserID: "B1"}))
+	assert.Equal(t, "U1", messageAuthor(Message{UserID: "U1"}))
+
+	withReply := mkThread("C1", "1.000000", "2.000000", 0)
+	assert.Equal(t, "2.000000", threadLatestActivity(withReply))
+	noReply := mkThread("C1", "1.000000", "", 0)
+	assert.Equal(t, "1.000000", threadLatestActivity(noReply))
+}

--- a/pkg/handler/threads_test.go
+++ b/pkg/handler/threads_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gocarina/gocsv"
 	"github.com/korotovsky/slack-mcp-server/pkg/provider/edge"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/slack-go/slack"
@@ -99,7 +100,38 @@ func TestUnitCollectThreads(t *testing.T) {
 		assert.Len(t, scan.threads, 3, "threads with activity older than the bound are not returned")
 		assert.Equal(t, 3, scan.scanned)
 		assert.Empty(t, scan.nextCursor)
+		assert.True(t, scan.hitTimeBound)
 		assert.Equal(t, 1, scan.pages, "the bound was hit on page 1, page 2 must not be fetched")
+	})
+
+	t.Run("since bound compares numerically, not lexicographically", func(t *testing.T) {
+		// A 9-digit "oldest" (windows reaching before 2001) must not stop the scan.
+		p := &fakePager{pages: pages}
+		scan, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterAll, limit: 20, oldest: "998082000.000000"})
+		require.NoError(t, err)
+		assert.Len(t, scan.threads, 6)
+		assert.False(t, scan.hitTimeBound)
+	})
+
+	t.Run("limit reached on the last thread of the last page: no cursor", func(t *testing.T) {
+		p := &fakePager{pages: pages}
+		scan, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterAll, limit: 6})
+		require.NoError(t, err)
+		assert.Len(t, scan.threads, 6)
+		assert.Empty(t, scan.nextCursor, "the view is exhausted; no continuation cursor")
+	})
+
+	t.Run("malformed entries without timestamps are skipped, not counted, and do not break the cursor", func(t *testing.T) {
+		broken := edge.ThreadsViewResponse{HasMore: true, Threads: []edge.ThreadView{
+			mkThread("C1", "", "", 1),
+			mkThread("C1", "1700000100.000001", "1700000900.000000", 1),
+		}}
+		p := &fakePager{pages: map[string]edge.ThreadsViewResponse{"": broken, "1700000900.000000": {HasMore: false}}}
+		scan, err := collectThreads(ctx, p.fetch, &threadsParams{filter: threadsFilterUnread, limit: 20, oldest: "1600000000.000000"})
+		require.NoError(t, err)
+		assert.Len(t, scan.threads, 1)
+		assert.Equal(t, 1, scan.scanned)
+		assert.Equal(t, []string{"", "1700000900.000000"}, p.cursors)
 	})
 
 	t.Run("cursor param is used for the first fetch", func(t *testing.T) {
@@ -209,6 +241,14 @@ func TestUnitThreadsHelpers(t *testing.T) {
 	assert.False(t, isSlackTimestamp("abc.def"))
 	assert.False(t, isSlackTimestamp("1700000600."))
 	assert.False(t, isSlackTimestamp(".000000"))
+	assert.False(t, isSlackTimestamp("1700000600.0002"), "Slack requires exactly six fractional digits")
+	assert.False(t, isSlackTimestamp("1700000600.00020000"))
+
+	assert.True(t, slackTsBefore("998082000.000000", "1700000900.000000"), "9-digit seconds are older, not lexicographically greater")
+	assert.False(t, slackTsBefore("1700000900.000000", "998082000.000000"))
+	assert.True(t, slackTsBefore("1700000900.000000", "1700000900.000001"))
+	assert.False(t, slackTsBefore("1700000900.000000", "1700000900.000000"))
+	assert.False(t, slackTsBefore("1700000900.000000", "1700000900.0"), "equal values with different fraction widths")
 
 	assert.Equal(t, "", slackTsToISO(""))
 	assert.Equal(t, "", slackTsToISO("garbage"))
@@ -223,4 +263,108 @@ func TestUnitThreadsHelpers(t *testing.T) {
 	assert.Equal(t, "2.000000", threadLatestActivity(withReply))
 	noReply := mkThread("C1", "1.000000", "", 0)
 	assert.Equal(t, "1.000000", threadLatestActivity(noReply))
+}
+
+func TestUnitBuildThreadRows(t *testing.T) {
+	ctx := context.Background()
+	msg := func(ts, user, text string) slack.Message {
+		m := slack.Message{}
+		m.Timestamp = ts
+		m.User = user
+		m.Text = text
+		return m
+	}
+	// A renderer that mimics the production pipeline closely enough: RFC3339-ish time, resolved names, text passthrough.
+	render := func(ctx context.Context, msgs []slack.Message, channelID string) []Message {
+		out := make([]Message, 0, len(msgs))
+		for _, m := range msgs {
+			out = append(out, Message{MsgID: m.Timestamp, UserID: m.User, RealName: "Name " + m.User, Text: m.Text, Time: "T" + m.Timestamp, Channel: channelID})
+		}
+		return out
+	}
+	channelName := func(id string) string {
+		if id == "C1" {
+			return "#general"
+		}
+		return id
+	}
+
+	unreadThread := edge.ThreadView{}
+	unreadThread.RootMsg = msg("1700000100.000001", "UROOT", "root, with \"quotes\"\nand a newline")
+	unreadThread.RootMsg.Channel = "C1"
+	unreadThread.RootMsg.ThreadTimestamp = "1700000100.000001"
+	unreadThread.RootMsg.ReplyCount = 5
+	unreadThread.RootMsg.LatestReply = "1700000500.000000"
+	unreadThread.RootMsg.LastRead = "1700000200.000000"
+	unreadThread.LatestReplies = []slack.Message{msg("1700000150.000000", "UA", "read reply")}
+	unreadThread.UnreadReplies = []slack.Message{
+		msg("1700000300.000000", "UB", "unread 1"),
+		msg("1700000400.000000", "UC", "unread 2, with, commas"),
+		msg("1700000500.000000", "UD", "unread 3"),
+	}
+
+	readThread := edge.ThreadView{}
+	readThread.RootMsg = msg("1600000100.000001", "UROOT2", "read root")
+	readThread.RootMsg.Channel = "" // missing channel: falls back to the requested one
+	readThread.RootMsg.ReplyCount = 1
+	readThread.RootMsg.LatestReply = "1600000200.000000"
+	readThread.LatestReplies = []slack.Message{msg("1600000200.000000", "UE", "latest only")}
+
+	params := &threadsParams{includeReplies: 2, channelID: "C9"}
+	rows := buildThreadRows(ctx, []edge.ThreadView{unreadThread, readThread}, params, "1600000200.000000", channelName, render)
+	require.Len(t, rows, 2)
+
+	r0 := rows[0]
+	assert.Equal(t, "#general", r0.Channel)
+	assert.Equal(t, "C1", r0.ChannelID)
+	assert.Equal(t, "1700000100.000001", r0.ThreadTs)
+	assert.Equal(t, "Name UROOT", r0.RootUser)
+	assert.Equal(t, "T1700000100.000001", r0.RootTime)
+	assert.Contains(t, r0.RootText, "quotes")
+	assert.Equal(t, 5, r0.ReplyCount)
+	assert.Equal(t, 3, r0.UnreadReplies)
+	assert.NotEmpty(t, r0.LatestReplyTime)
+	assert.NotEmpty(t, r0.LastRead)
+	// unread replies preferred over latest, and only the last include_replies of them
+	assert.Equal(t, "T1700000400.000000 Name UC: unread 2, with, commas || T1700000500.000000 Name UD: unread 3", r0.Replies)
+	assert.Empty(t, r0.Cursor, "only the last row carries the cursor")
+
+	r1 := rows[1]
+	assert.Equal(t, "C9", r1.ChannelID, "missing root_msg.channel falls back to the requested channel_id")
+	assert.Equal(t, "C9", r1.Channel)
+	assert.Equal(t, 0, r1.UnreadReplies)
+	assert.Equal(t, "T1600000200.000000 Name UE: latest only", r1.Replies, "read thread shows latest replies")
+	assert.Equal(t, "1600000200.000000", r1.Cursor)
+
+	t.Run("include_replies=0 omits reply text; renderer dropping the root keeps ts-derived time", func(t *testing.T) {
+		none := func(ctx context.Context, msgs []slack.Message, channelID string) []Message { return nil }
+		rows := buildThreadRows(ctx, []edge.ThreadView{unreadThread}, &threadsParams{includeReplies: 0}, "", channelName, none)
+		require.Len(t, rows, 1)
+		assert.Empty(t, rows[0].Replies)
+		assert.Empty(t, rows[0].RootUser)
+		assert.NotEmpty(t, rows[0].RootTime, "falls back to the root ts when the renderer returns nothing")
+		assert.Empty(t, rows[0].Cursor)
+	})
+
+	t.Run("CSV round-trips quotes, commas and newlines", func(t *testing.T) {
+		out, err := gocsv.MarshalString(&rows)
+		require.NoError(t, err)
+		back := []ThreadRow{}
+		require.NoError(t, gocsv.UnmarshalString(out, &back))
+		require.Len(t, back, 2)
+		assert.Equal(t, rows[0].RootText, back[0].RootText)
+		assert.Equal(t, rows[0].Replies, back[0].Replies)
+		assert.Equal(t, rows[1].Cursor, back[1].Cursor)
+	})
+}
+
+func TestUnitNoThreadsMessage(t *testing.T) {
+	p := &threadsParams{filter: threadsFilterUnread, since: "30d"}
+	assert.Equal(t, "No threads with unread replies found (scanned 12 threads; the time window since=30d ended the scan — use a larger since, or since=all)",
+		noThreadsMessage(&threadsScan{scanned: 12, hitTimeBound: true}, p))
+	assert.Equal(t, "No threads with unread replies found (scanned 500 threads; stopped after 500 threads, continue with cursor=1700000000.000000)",
+		noThreadsMessage(&threadsScan{scanned: 500, hitPageCap: true, nextCursor: "1700000000.000000"}, p))
+	assert.Equal(t, "No threads found (scanned 3 threads; end of the Threads view reached)",
+		noThreadsMessage(&threadsScan{scanned: 3}, &threadsParams{filter: threadsFilterAll, since: "all"}))
+	assert.Contains(t, noThreadsMessage(&threadsScan{scanned: 1, nextCursor: "1.000000"}, p), "continue with cursor=1.000000")
 }

--- a/pkg/provider/api.go
+++ b/pkg/provider/api.go
@@ -247,6 +247,7 @@ type SlackAPI interface {
 	UsersSearch(ctx context.Context, query string, count int) ([]slack.User, error)
 	ClientCounts(ctx context.Context) (edge.ClientCountsResponse, error)
 	GetMutedChannels(ctx context.Context) (map[string]bool, error)
+	SubscriptionsThreadGetView(ctx context.Context, currentTs string, limit int, channelID string) (edge.ThreadsViewResponse, error)
 	SavedList(ctx context.Context, filter string, limit int, cursor string) (edge.SavedListResponse, error)
 	SavedUpdate(ctx context.Context, itemType, itemID, ts, mark string, dateDue int64) error
 	SavedClearCompleted(ctx context.Context) error
@@ -567,6 +568,10 @@ func (c *MCPSlackClient) ClientCounts(ctx context.Context) (edge.ClientCountsRes
 
 func (c *MCPSlackClient) GetMutedChannels(ctx context.Context) (map[string]bool, error) {
 	return c.edgeClient.GetMutedChannels(ctx)
+}
+
+func (c *MCPSlackClient) SubscriptionsThreadGetView(ctx context.Context, currentTs string, limit int, channelID string) (edge.ThreadsViewResponse, error) {
+	return c.edgeClient.SubscriptionsThreadGetView(ctx, currentTs, limit, channelID)
 }
 
 func (c *MCPSlackClient) SavedList(ctx context.Context, filter string, limit int, cursor string) (edge.SavedListResponse, error) {

--- a/pkg/provider/edge/threads.go
+++ b/pkg/provider/edge/threads.go
@@ -1,0 +1,76 @@
+package edge
+
+import (
+	"context"
+	"runtime/trace"
+
+	"github.com/slack-go/slack"
+)
+
+// subscriptions.thread.getView — the internal Slack API behind the "Threads"
+// view: threads the user is subscribed to, newest activity first, with the
+// user's unread state per thread. Only accessible with browser session tokens
+// (xoxc/xoxd).
+//
+// Observed behaviour (2026-08): the page size is capped at 10 threads whatever
+// `limit` says; `current_ts` is the pagination cursor (threads with latest
+// activity strictly older than it are returned); `channel_id` filters
+// server-side; there is no server-side "unread only" filter.
+
+type subscriptionsThreadGetViewForm struct {
+	BaseRequest
+	Limit     int    `json:"limit"`
+	CurrentTs string `json:"current_ts,omitempty"`
+	ChannelID string `json:"channel_id,omitempty"`
+	WebClientFields
+}
+
+// ThreadsViewResponse is the response of subscriptions.thread.getView.
+type ThreadsViewResponse struct {
+	baseResponse
+	Threads            []ThreadView `json:"threads"`
+	TotalUnreadReplies int          `json:"total_unread_replies"`
+	NewThreadsCount    int          `json:"new_threads_count"`
+	HasMore            bool         `json:"has_more"`
+	MaxTs              string       `json:"max_ts"`
+}
+
+// ThreadView is one thread of the "Threads" view. RootMsg carries the thread's
+// parent message including the user's per-thread read state (LastRead,
+// LatestReply, ReplyCount, Subscribed). UnreadReplies are the replies the user
+// has not read yet (empty when the thread is fully read); LatestReplies are the
+// most recent replies Slack includes for context.
+type ThreadView struct {
+	RootMsg       slack.Message   `json:"root_msg"`
+	LatestReplies []slack.Message `json:"latest_replies"`
+	UnreadReplies []slack.Message `json:"unread_replies"`
+}
+
+// SubscriptionsThreadGetView fetches one page of the "Threads" view. Pass the
+// previous page's cursor (the smallest latest-activity timestamp seen) as
+// currentTs to get older threads, and channelID to restrict to one channel.
+func (cl *Client) SubscriptionsThreadGetView(ctx context.Context, currentTs string, limit int, channelID string) (ThreadsViewResponse, error) {
+	ctx, task := trace.NewTask(ctx, "SubscriptionsThreadGetView")
+	defer task.End()
+
+	form := subscriptionsThreadGetViewForm{
+		BaseRequest:     BaseRequest{Token: cl.token},
+		Limit:           limit,
+		CurrentTs:       currentTs,
+		ChannelID:       channelID,
+		WebClientFields: webclientReason("fetch-threads-view"),
+	}
+
+	resp, err := cl.PostForm(ctx, "subscriptions.thread.getView", values(form, true))
+	if err != nil {
+		return ThreadsViewResponse{}, err
+	}
+	r := ThreadsViewResponse{}
+	if err := cl.ParseResponse(&r, resp); err != nil {
+		return ThreadsViewResponse{}, err
+	}
+	if err := r.validate("subscriptions.thread.getView"); err != nil {
+		return ThreadsViewResponse{}, err
+	}
+	return r, nil
+}

--- a/pkg/provider/edge/threads_test.go
+++ b/pkg/provider/edge/threads_test.go
@@ -1,0 +1,157 @@
+package edge
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubHTTPClient records the last request's form body and returns a canned response.
+type stubHTTPClient struct {
+	lastReq  *http.Request
+	lastForm url.Values
+	body     string
+	status   int
+}
+
+func (f *stubHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	f.lastReq = req
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if f.lastForm, err = url.ParseQuery(string(raw)); err != nil {
+		return nil, err
+	}
+	status := f.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func newTestThreadsClient(body string) (*Client, *stubHTTPClient) {
+	f := &stubHTTPClient{body: body}
+	cl := &Client{
+		cl:           f,
+		token:        "xoxc-test-token",
+		teamID:       "T0TEST",
+		webclientAPI: "https://example.slack.com/api/",
+		tape:         nopTape{},
+	}
+	return cl, f
+}
+
+// threadsViewFixture mirrors the shape observed from the live endpoint.
+const threadsViewFixture = `{
+  "ok": true,
+  "total_unread_replies": 57,
+  "new_threads_count": 10,
+  "has_more": true,
+  "max_ts": "1787062266.000000",
+  "threads": [
+    {
+      "root_msg": {
+        "user": "U0ROOT", "type": "message", "ts": "1786021681.497329", "thread_ts": "1786021681.497329",
+        "channel": "C0CHAN", "text": "root text", "reply_count": 3, "reply_users_count": 2,
+        "latest_reply": "1787049849.098909", "last_read": "1787048594.264689", "subscribed": true,
+        "reply_users": ["U0A", "U0B"]
+      },
+      "latest_replies": [],
+      "unread_replies": [
+        {"user": "U0A", "type": "message", "ts": "1787049849.098909", "thread_ts": "1786021681.497329", "text": "unread reply"}
+      ]
+    },
+    {
+      "root_msg": {
+        "user": "U0ROOT2", "type": "message", "ts": "1785750757.443489", "thread_ts": "1785750757.443489",
+        "channel": "C0OTHER", "text": "read thread", "reply_count": 7,
+        "latest_reply": "1787049701.503059", "last_read": "1787049702.000000", "subscribed": true
+      },
+      "latest_replies": [
+        {"user": "U0C", "type": "message", "ts": "1787049701.503059", "thread_ts": "1785750757.443489", "text": "latest reply"}
+      ]
+    }
+  ]
+}`
+
+func TestUnitSubscriptionsThreadGetView(t *testing.T) {
+	t.Run("posts limit/current_ts/channel_id and parses the view", func(t *testing.T) {
+		cl, f := newTestThreadsClient(threadsViewFixture)
+
+		resp, err := cl.SubscriptionsThreadGetView(context.Background(), "1787050000.000000", 10, "C0CHAN")
+		require.NoError(t, err)
+
+		require.NotNil(t, f.lastReq)
+		assert.Equal(t, http.MethodPost, f.lastReq.Method)
+		assert.Equal(t, "https://example.slack.com/api/subscriptions.thread.getView", f.lastReq.URL.String())
+		assert.Equal(t, "xoxc-test-token", f.lastForm.Get("token"))
+		assert.Equal(t, "10", f.lastForm.Get("limit"))
+		assert.Equal(t, "1787050000.000000", f.lastForm.Get("current_ts"))
+		assert.Equal(t, "C0CHAN", f.lastForm.Get("channel_id"))
+		assert.Equal(t, "fetch-threads-view", f.lastForm.Get("_x_reason"))
+
+		assert.True(t, resp.HasMore)
+		assert.Equal(t, 57, resp.TotalUnreadReplies)
+		assert.Equal(t, 10, resp.NewThreadsCount)
+		assert.Equal(t, "1787062266.000000", resp.MaxTs)
+		require.Len(t, resp.Threads, 2)
+
+		first := resp.Threads[0]
+		assert.Equal(t, "C0CHAN", first.RootMsg.Channel)
+		assert.Equal(t, "1786021681.497329", first.RootMsg.Timestamp)
+		assert.Equal(t, "1786021681.497329", first.RootMsg.ThreadTimestamp)
+		assert.Equal(t, 3, first.RootMsg.ReplyCount)
+		assert.Equal(t, "1787049849.098909", first.RootMsg.LatestReply)
+		assert.Equal(t, "1787048594.264689", first.RootMsg.LastRead)
+		assert.True(t, first.RootMsg.Subscribed)
+		require.Len(t, first.UnreadReplies, 1)
+		assert.Equal(t, "unread reply", first.UnreadReplies[0].Text)
+		assert.Empty(t, first.LatestReplies)
+
+		second := resp.Threads[1]
+		assert.Empty(t, second.UnreadReplies)
+		require.Len(t, second.LatestReplies, 1)
+		assert.Equal(t, "latest reply", second.LatestReplies[0].Text)
+	})
+
+	t.Run("omits empty current_ts and channel_id", func(t *testing.T) {
+		cl, f := newTestThreadsClient(`{"ok":true,"threads":[],"has_more":false}`)
+
+		resp, err := cl.SubscriptionsThreadGetView(context.Background(), "", 10, "")
+		require.NoError(t, err)
+		assert.False(t, f.lastForm.Has("current_ts"))
+		assert.False(t, f.lastForm.Has("channel_id"))
+		assert.Empty(t, resp.Threads)
+		assert.False(t, resp.HasMore)
+	})
+
+	t.Run("returns APIError on ok=false", func(t *testing.T) {
+		cl, _ := newTestThreadsClient(`{"ok":false,"error":"not_allowed_token_type"}`)
+
+		_, err := cl.SubscriptionsThreadGetView(context.Background(), "", 10, "")
+		require.Error(t, err)
+		apiErr, ok := err.(*APIError)
+		require.True(t, ok, "expected *APIError, got %T", err)
+		assert.Equal(t, "subscriptions.thread.getView", apiErr.Endpoint)
+		assert.Equal(t, "not_allowed_token_type", apiErr.Err)
+	})
+
+	t.Run("returns error for non-2xx status", func(t *testing.T) {
+		cl, f := newTestThreadsClient(`gateway error`)
+		f.status = http.StatusBadGateway
+		_, err := cl.SubscriptionsThreadGetView(context.Background(), "", 10, "")
+		require.Error(t, err)
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -541,18 +541,19 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 	if !provider.IsBotToken() && !provider.IsOAuth() && shouldAddTool(ToolConversationsThreads, enabledTools, "") {
 		threadsHandler := handler.NewThreadsHandler(provider, logger, conversationsHandler)
 		s.AddTool(mcp.NewTool(ToolConversationsThreads,
-			mcp.WithDescription("List the threads you are subscribed to (Slack's 'Threads' view), newest activity first, with each thread's unread reply count and the unread (or latest) replies. By default only threads with unread replies from the last 30 days are returned. Returns CSV; the last row's Cursor column is non-empty when more threads are available — pass it as 'cursor' to continue. To mark a listed thread as read use conversations_mark with its ChannelID and ThreadTs. Requires browser session tokens (xoxc/xoxd)."),
+			mcp.WithDescription("List the threads you are subscribed to (Slack's 'Threads' view), newest activity first, with each thread's unread reply count and the unread (or latest) replies. By default only threads with unread replies from the last 30 days are returned. Returns CSV; the last row's Cursor column is non-empty when more threads are available — pass it as 'cursor' (with the same filter/channel_id/since) to continue. Requires browser session tokens (xoxc/xoxd)."),
 			mcp.WithTitleAnnotation("List Threads"),
 			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithString("filter",
 				mcp.Description("'unread' (default): only threads with unread replies. 'all': every subscribed thread in the time window."),
 				mcp.DefaultString("unread"),
+				mcp.Enum("unread", "all"),
 			),
 			mcp.WithString("channel_id",
 				mcp.Description("Optional: only threads in this channel or DM, in format Cxxxxxxxxxx / Dxxxxxxxxxx or its name starting with #... or @..."),
 			),
 			mcp.WithString("since",
-				mcp.Description("How far back to look, by a thread's latest activity: a duration like 1d, 7d, 2w, 1m (default 30d), or 'all' for no time bound. One call scans at most 500 threads; continue with the cursor for more."),
+				mcp.Description("How far back to look, by a thread's latest activity: a duration like 1d, 7d, 2w, 1m (d=days, w=weeks, m=months; default 30d), or 'all' for no time bound. One call scans at most 500 threads; continue with the cursor for more."),
 				mcp.DefaultString("30d"),
 			),
 			mcp.WithNumber("limit",
@@ -564,7 +565,7 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.DefaultNumber(3),
 			),
 			mcp.WithString("cursor",
-				mcp.Description("Cursor for pagination: the value of the last row's Cursor column from the previous conversations_threads result."),
+				mcp.Description("Cursor for pagination: the value of the last row's Cursor column from the previous conversations_threads result. Repeat the same filter, channel_id and since when continuing."),
 			),
 		), threadsHandler.ConversationsThreadsHandler)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -47,6 +47,7 @@ const (
 	ToolSavedList                   = "saved_list"
 	ToolSavedUpdate                 = "saved_update"
 	ToolSavedClearCompleted         = "saved_clear_completed"
+	ToolConversationsThreads        = "conversations_threads"
 )
 
 var ValidToolNames = []string{
@@ -72,6 +73,7 @@ var ValidToolNames = []string{
 	ToolSavedList,
 	ToolSavedUpdate,
 	ToolSavedClearCompleted,
+	ToolConversationsThreads,
 }
 
 func ValidateEnabledTools(tools []string) error {
@@ -532,6 +534,39 @@ func NewMCPServer(provider *provider.ApiProvider, logger *zap.Logger, enabledToo
 				mcp.Description("Comma-separated user IDs that will become the COMPLETE member list (e.g., 'U0123456789,U9876543210'). All current members not in this list will be removed."),
 			),
 		), usergroupsHandler.UsergroupsUsersUpdateHandler)
+	}
+
+	// Register the "Threads" view tool — subscribed threads with per-thread unread state.
+	// Requires browser session tokens (xoxc/xoxd); not available for bot or OAuth tokens.
+	if !provider.IsBotToken() && !provider.IsOAuth() && shouldAddTool(ToolConversationsThreads, enabledTools, "") {
+		threadsHandler := handler.NewThreadsHandler(provider, logger, conversationsHandler)
+		s.AddTool(mcp.NewTool(ToolConversationsThreads,
+			mcp.WithDescription("List the threads you are subscribed to (Slack's 'Threads' view), newest activity first, with each thread's unread reply count and the unread (or latest) replies. By default only threads with unread replies from the last 30 days are returned. Returns CSV; the last row's Cursor column is non-empty when more threads are available — pass it as 'cursor' to continue. To mark a listed thread as read use conversations_mark with its ChannelID and ThreadTs. Requires browser session tokens (xoxc/xoxd)."),
+			mcp.WithTitleAnnotation("List Threads"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithString("filter",
+				mcp.Description("'unread' (default): only threads with unread replies. 'all': every subscribed thread in the time window."),
+				mcp.DefaultString("unread"),
+			),
+			mcp.WithString("channel_id",
+				mcp.Description("Optional: only threads in this channel or DM, in format Cxxxxxxxxxx / Dxxxxxxxxxx or its name starting with #... or @..."),
+			),
+			mcp.WithString("since",
+				mcp.Description("How far back to look, by a thread's latest activity: a duration like 1d, 7d, 2w, 1m (default 30d), or 'all' for no time bound. One call scans at most 500 threads; continue with the cursor for more."),
+				mcp.DefaultString("30d"),
+			),
+			mcp.WithNumber("limit",
+				mcp.Description("Maximum number of threads to return (default 20, max 200)."),
+				mcp.DefaultNumber(20),
+			),
+			mcp.WithNumber("include_replies",
+				mcp.Description("How many replies to include per thread in the Replies column: the unread ones when the thread has unread replies, otherwise the latest ones. Default 3, max 20, 0 to omit reply text."),
+				mcp.DefaultNumber(3),
+			),
+			mcp.WithString("cursor",
+				mcp.Description("Cursor for pagination: the value of the last row's Cursor column from the previous conversations_threads result."),
+			),
+		), threadsHandler.ConversationsThreadsHandler)
 	}
 
 	// Register saved items tools — "Save for Later" panel management.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -116,6 +116,7 @@ func TestValidToolNames(t *testing.T) {
 			ToolSavedList:                   true,
 			ToolSavedUpdate:                 true,
 			ToolSavedClearCompleted:         true,
+			ToolConversationsThreads:        true,
 		}
 
 		assert.Equal(t, len(expectedTools), len(ValidToolNames), "ValidToolNames should have %d tools", len(expectedTools))
@@ -148,6 +149,7 @@ func TestValidToolNames(t *testing.T) {
 		assert.Equal(t, "saved_list", ToolSavedList)
 		assert.Equal(t, "saved_update", ToolSavedUpdate)
 		assert.Equal(t, "saved_clear_completed", ToolSavedClearCompleted)
+		assert.Equal(t, "conversations_threads", ToolConversationsThreads)
 	})
 }
 


### PR DESCRIPTION
## Summary

New read-only tool **`conversations_threads`**: lists the threads you are subscribed to — Slack's **"Threads" view** — newest activity first, with each thread's unread reply count and the unread (or latest) replies. By default it returns only threads with unread replies from the last 30 days.

Until now there was no way to see *which threads have unread replies*: `conversations_unreads` covers channels/DMs only, and thread unread state lives in a separate per-thread read cursor. (Independent of #346, which adds per-thread marking; together they close the loop list → read → mark. The tool text deliberately does not reference that parameter so it is correct on `master` as-is.)

### Design

- New edge call `SubscriptionsThreadGetView` → Slack's `subscriptions.thread.getView` (the endpoint behind the Threads view; same undocumented browser-session family as `client.counts` / `saved.*`), with `current_ts` (cursor), `limit`, and the optional server-side `channel_id` filter; typed response (`threads[]` with `root_msg`, `latest_replies`, `unread_replies`; `total_unread_replies`, `new_threads_count`, `has_more`, `max_ts`).
- Observed constraints that shape the tool: Slack serves **10 threads per page whatever `limit` says**, and there is **no server-side unread-only filter**. The handler therefore pages newest-first and stops at the time bound (`since`), the end of the view, or a 50-page cap (500 threads), always returning the continuation cursor in the last row's `Cursor` column — so no scan is lossy and the LLM can keep going.
- Parameters: `filter` (`unread` default | `all`, declared as an enum), `channel_id` (`#name`/`@name` resolved like elsewhere), `since` (`1d`/`7d`/`2w`/`1m` — days/weeks/months, default `30d`, or `all`), `limit` (default 20, max 200), `include_replies` (default 3, max 20, 0 to omit), `cursor` (repeat the other filters when continuing). Slack timestamps are compared numerically; the cursor is validated as a Slack timestamp (six fractional digits). An empty result explains why the scan stopped (time window / page cap / end of view).
- Output CSV: `Channel, ChannelID, ThreadTs, RootUser, RootTime, RootText, ReplyCount, UnreadReplies, LatestReplyTime, LastRead, Replies, Cursor`. Root and replies go through the same user-resolution/text pipeline as the other conversation tools (`convertMessagesFromHistory`); `Replies` holds the unread replies when there are any, otherwise the latest ones, as `time author: text` joined by ` || `.
- Registered only for browser session tokens (`xoxc`/`xoxd`), like the other edge-API tools; `ReadOnlyHint`. Uses the Tier-3 limiter between pages.
- Kept out of `docs/03` tool lists on purpose to avoid conflicting with #345, which already edits those lines; happy to add it there once one of the two lands.

| File | Change |
|------|--------|
| `pkg/provider/edge/threads.go` | **NEW** — `SubscriptionsThreadGetView` + response types |
| `pkg/provider/edge/threads_test.go` | **NEW** — HTTP-level unit tests with a fixture mirroring the live response |
| `pkg/provider/api.go` | Added to `SlackAPI` + `MCPSlackClient` wrapper |
| `pkg/handler/threads.go` | **NEW** — `ThreadsHandler`: params, `collectThreads` (paging / filter / bound / cursor / cap), `buildThreadRows` (pure, injected renderer), `noThreadsMessage` |
| `pkg/handler/threads_test.go` | **NEW** — paging/filter/bound/cursor/page-cap tests via a fake pager, row building & CSV round trip, zero-match text, param parsing, helpers |
| `pkg/server/server.go`, `pkg/server/server_test.go` | Tool registration, `ValidToolNames` |
| `README.md` | Documented the tool |

### Token compatibility

| Token | `conversations_threads` |
|-------|-------------------------|
| `xoxc`/`xoxd` | Tested, works |
| `xoxp` | Not registered (guard) |
| `xoxb` | Not registered (guard) |

### Testing

- `make test` / `go vet` pass; unit tests as listed above.
- End-to-end through the MCP server over stdio with `xoxc`/`xoxd` on a live workspace: default call (5 unread threads in ~1 s, names/text/replies resolved), cursor continuation (strictly older threads, no overlap), `filter=all since=1d include_replies=0`, server-side `channel_id` filter, a channel without threads (friendly "no matching threads"), and validation errors for bad `filter` / `since` / unknown `#channel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
